### PR TITLE
Add exception handling

### DIFF
--- a/exceptions/RestfulBadRequestException.php
+++ b/exceptions/RestfulBadRequestException.php
@@ -5,4 +5,19 @@
  * Contains RestfulBadRequestException
  */
 
-class RestfulBadRequestException extends Exception {}
+class RestfulBadRequestException extends RestfulException {
+
+  /**
+   * Defines the HTTP error code.
+   *
+   * @var int
+   */
+  protected $code = 400;
+
+  /**
+   * Defines the description.
+   *
+   * @var string
+   */
+  protected $description = 'Bad Request.';
+}

--- a/exceptions/RestfulException.php
+++ b/exceptions/RestfulException.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulException
+ */
+
+class RestfulException extends Exception {
+
+  final public function getDescription() {
+    return $this->description;
+  }
+}

--- a/exceptions/RestfulGoneException.php
+++ b/exceptions/RestfulGoneException.php
@@ -5,4 +5,20 @@
  * Contains RestfulGoneException
  */
 
-class RestfulGoneException extends Exception {}
+class RestfulGoneException extends Exception {
+
+  /**
+   * Defines the HTTP error code.
+   *
+   * @var int
+   */
+  protected $code = 410;
+
+  /**
+   * Defines the description.
+   *
+   * @var string
+   */
+  protected $description = 'The resource at this end point is no longer available.';
+
+}

--- a/exceptions/RestfulUnprocessableEntityException.php
+++ b/exceptions/RestfulUnprocessableEntityException.php
@@ -5,4 +5,20 @@
  * Contains RestfulUnprocessableEntityException
  */
 
-class RestfulUnprocessableEntityException extends Exception {}
+class RestfulUnprocessableEntityException extends Exception {
+
+  /**
+   * Defines the HTTP error code.
+   *
+   * @var int
+   */
+  protected $code = 422;
+
+  /**
+   * Defines the description.
+   *
+   * @var string
+   */
+  protected $description = 'Unprocessable Entity; Validation errors.';
+
+}

--- a/exceptions/RestfulUnsupportedMediaTypeException.php
+++ b/exceptions/RestfulUnsupportedMediaTypeException.php
@@ -5,4 +5,20 @@
  * Contains RestfulUnsupportedMediaTypeException
  */
 
-class RestfulUnsupportedMediaTypeException extends Exception {}
+class RestfulUnsupportedMediaTypeException extends Exception {
+
+  /**
+   * Defines the HTTP error code.
+   *
+   * @var int
+   */
+  protected $code = 415;
+
+  /**
+   * Defines the description.
+   *
+   * @var string
+   */
+  protected $description = 'Unsupported Media Type.';
+
+}

--- a/restful.info
+++ b/restful.info
@@ -11,6 +11,7 @@ files[] = plugins/restful/RestfulEntityInterface.php
 files[] = plugins/restful/RestfulInterface.php
 
 ; Exceptions
+files[] = exceptions/RestfulException.php
 files[] = exceptions/RestfulBadRequestException.php
 files[] = exceptions/RestfulGoneException.php
 files[] = exceptions/RestfulUnsupportedMediaTypeException.php
@@ -18,6 +19,7 @@ files[] = exceptions/RestfulUnprocessableEntityException.php
 
 ; Tests
 files[] = tests/RestfulCRUDTestCase.test
+files[] = tests/RestfulExceptionHandleTestCase.test
 files[] = tests/RestfulGetHandlersTestCase.test
 files[] = tests/RestfulHookMenuTestCase.test
 files[] = tests/RestfulListTestCase.test

--- a/restful.module
+++ b/restful.module
@@ -217,5 +217,22 @@ function restful_menu_process_callback($major_version, $resource_name) {
       $request = $_POST;
   }
 
-  return drupal_json_output($handler->{$method}($path, $request));
+  try {
+    $result = $handler->{$method}($path, $request);
+  }
+  catch (RestfulException $e) {
+    $result = array(
+      'code' => $e->getCode(),
+      'message' => $e->getMessage(),
+      'description' => $e->getDescription(),
+    );
+  }
+  catch (Exception $e) {
+    $result = array(
+      'code' => 500,
+      'message' => $e->getMessage(),
+    );
+  }
+
+  return drupal_json_output($result);
 }

--- a/tests/RestfulExceptionHandleTestCase.test
+++ b/tests/RestfulExceptionHandleTestCase.test
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulExceptionHandleTestCase
+ */
+
+class RestfulExceptionHandleTestCase extends DrupalWebTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Exception handling',
+      'description' => 'Test converting exceptions into JSON with code, message and description.',
+      'group' => 'Restful',
+    );
+  }
+
+  function setUp() {
+    parent::setUp('restful_example');
+  }
+
+  /**
+   * Test converting exceptions into JSON with code, message and description.
+   *
+   * When calling the API via hook_menu(), exceptions should be converted to a
+   * valid JSON.
+   */
+  function testExceptionHandle() {
+    $options['query'] = array('sort' => 'wrong_key');
+    $this->drupalGet('api/v1/articles', $options);
+    $expected_result = array(
+      'code' => 400,
+      'message' => 'The sort wrong_key is not allowed for this path.',
+      'description' => 'Bad Request.',
+    );
+    $this->assertText(drupal_json_encode($expected_result), 'Exception was converted to JSON.');
+  }
+}


### PR DESCRIPTION
When calling the API via hook_menu(), exceptions should be converted to a JSON with HTTP error code, message and description.
