### PR TITLE
Allow handler to set HTTP headers

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -74,10 +74,41 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
   );
 
   /**
+   * Array keyed by the header property, and the value.
+   *
+   * This can be used for example to change the "Status" code of the HTTP
+   * response, or to add a "Location" property.
+   *
+   * @var array
+   */
+  protected $httpHeaders = array();
+
+  /**
    * Return the defined controllers.
    */
   public function getControllers () {
     return $this->controllers;
+  }
+
+  /**
+   * Set the HTTP headers.
+   *
+   * @param string $key
+   *   The HTTP header key.
+   * @param string
+   *   The HTTP header value.
+   */
+  public function setHttpHeaders($key, $value) {
+    $this->httpHeaders[$key] = $value;
+  }
+
+  /**
+   * Return the HTTP header values.
+   *
+   * @return array
+   */
+  public function getHttpHeaders() {
+    return $this->httpHeaders;
   }
 
   public function __construct($plugin) {

--- a/plugins/restful/RestfulInterface.php
+++ b/plugins/restful/RestfulInterface.php
@@ -32,6 +32,15 @@ interface RestfulInterface {
    */
   public function getPublicFields();
 
+  /**
+   * Return array keyed by the header property, and the value.
+   *
+   * This can be used for example to change the "Status" code of the HTTP
+   * response, or to add a "Location" property.
+   *
+   * @return array
+   */
+  public function getHttpHeaders();
 
   /**
    * Determine if user can access notifier.

--- a/restful.module
+++ b/restful.module
@@ -217,8 +217,12 @@ function restful_menu_process_callback($major_version, $resource_name) {
       $request = $_POST;
   }
 
+  // Determine if request was successful.
+  $success = FALSE;
+
   try {
     $result = $handler->{$method}($path, $request);
+    $success = TRUE;
   }
   catch (RestfulException $e) {
     drupal_add_http_header('Status', $e->getCode());
@@ -233,6 +237,13 @@ function restful_menu_process_callback($major_version, $resource_name) {
       'code' => 500,
       'message' => $e->getMessage(),
     );
+  }
+
+  if ($success) {
+    // Allow the handler to change the HTTP headers.
+    foreach ($handler->getHttpHeaders() as $key => $value) {
+      drupal_add_http_header($key, $value);
+    }
   }
 
   return drupal_json_output($result);


### PR DESCRIPTION
For example: `$this->updateEntity()` will `$this->setHttpHeaders('Status', 201);`
