### PR TITLE
Authorization handlers structure.

### DIFF
--- a/plugins/authorization/RestfulAuthenticationGetString.class.php
+++ b/plugins/authorization/RestfulAuthenticationGetString.class.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @file
+ * Authorization plugin class.
+ */
+
+class RestfulAuthenticationGetString extends RestfulAuthorizationBase {
+  /**
+   * Overrides RestfulAuthenticationBase::authorize().
+   */
+  public function authorize() {
+    // Get the name of the get parameter.
+    if ($param_name = $this->{$this->settings['parameter name method']}()) {
+      if (!empty($_GET[$param_name])) {
+        return $this->{$this->settings['parameter value method']}() == $_GET[$param_name];
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Get the parameter name to check.
+   */
+  protected function getParamName() {
+    return variable_get('restful_authentication_get_string_name', 'token');
+  }
+
+  /**
+   * Get the parameter value to check.
+   */
+  protected function getParamValue() {
+    $default = drupal_hmac_base64('restful_authentication_get_string_value', drupal_get_hash_salt());
+    return variable_get('restful_authentication_get_string_value', $default);
+  }
+
+}

--- a/plugins/authorization/RestfulAuthorizationBase.php
+++ b/plugins/authorization/RestfulAuthorizationBase.php
@@ -15,7 +15,7 @@ class RestfulAuthorizationBase implements RestfulAuthorizationInterface {
   protected $settings;
 
   /**
-   * Indicates if the request needs to be authenticated befor it can be
+   * Indicates if the request needs to be authenticated before it can be
    * authorized.
    *
    * @var bool

--- a/plugins/authorization/RestfulAuthorizationBase.php
+++ b/plugins/authorization/RestfulAuthorizationBase.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @file
+ * Authentication base class
+ */
+
+class RestfulAuthorizationBase implements RestfulAuthorizationInterface {
+
+  /**
+   * Settings from the plugin definition.
+   *
+   * @var array
+   */
+  protected $settings;
+
+  /**
+   * Indicates if the request needs to be authenticated befor it can be
+   * authorized.
+   *
+   * @var bool
+   */
+  protected $needsAuthentication;
+
+  /**
+   * The plugin definition.
+   *
+   * @var array
+   */
+  protected $plugin;
+
+  /**
+   * Constructor.
+   */
+  public function __construct($plugin) {
+    $this->settings = $plugin['settings'];
+    $this->needsAuthentication = !empty($plugin['authentication']);
+    $this->plugin = $plugin;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function authorize() {
+    // This implementation is rather shallow. It will authorize all requests if
+    // they don't need authentication. If they do the request will be authorized
+    // if the user can be authenticated.
+    if ($this->needsAuthentication) {
+      $account = $this->authenticate();
+      return !empty($account);
+    }
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function authenticate() {
+    // Since not all authorization types require authentication, give a sensible
+    // default.
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return $this->plugin['name'];
+  }
+
+}

--- a/plugins/authorization/RestfulAuthorizationInterface.php
+++ b/plugins/authorization/RestfulAuthorizationInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Interface RestfulAuthorizationInterface
+ */
+
+interface RestfulAuthorizationInterface {
+  /**
+   * Check authorization for the request.
+   *
+   * @return bool
+   *   TRUE if the request has granted access. FALSE otherwise.
+   */
+  public function authorize();
+
+  /**
+   * Authenticate the request by trying to match a user.
+   *
+   * @return stdClass
+   *   The user object.
+   */
+  public function authenticate();
+
+  /**
+   * Get the name of the authorization plugin.
+   *
+   * @return string
+   *   The name.
+   */
+  public function getName();
+
+}

--- a/plugins/authorization/get_string.inc
+++ b/plugins/authorization/get_string.inc
@@ -1,0 +1,13 @@
+<?php
+
+$plugin = array(
+  'label' => t('Get String authentication'),
+  'description' => t('Authenticate requests based on a secret get parameter.'),
+  'name' => 'get_string',
+  'authentication' => FALSE,
+  'settings' => array(
+    'parameter name method' => 'getParamName',
+    'parameter value method' => 'getParamValue',
+  ),
+  'class' => 'RestfulAuthenticationGetString',
+);

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -84,6 +84,11 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
   protected $httpHeaders = array();
 
   /**
+   * Array containing all the authorization classes that apply to this request.
+   */
+  protected $authorizers = array();
+
+  /**
    * Return the defined controllers.
    */
   public function getControllers () {
@@ -213,6 +218,22 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
   }
 
   public function process($path = '', $request = NULL, $account = NULL, $method = 'get') {
+    if (!empty($this->authorizers)) {
+      // If there are not authorizers then the request is granted access.
+      $access = FALSE;
+      foreach ($this->authorizers as $authorizer) {
+        if ($authorizer->authorize()) {
+          // Grant access to the first authorizer that says so.
+          $access = TRUE;
+          break;
+        }
+      }
+      if (!$access) {
+        throw new \RestfulForbiddenException('The request could not be authorized');
+      }
+    }
+
+    // @TODO: The user should come from the $authorizer->authenticate();
     global $user;
     if (!$method_name = $this->getControllerFromPath($path, $method)) {
       throw new RestfulBadRequestException('Path does not exist');
@@ -736,5 +757,15 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
 
   public function access() {
     return TRUE;
+  }
+
+  /**
+   * Adds the authorizer to the list.
+   *
+   * @param \RestfulAuthorizationInterface $authorizer
+   *   The authorization plugin object.
+   */
+  public function setAuthorizer(\RestfulAuthorizationInterface $authorizer) {
+    $this->authorizers[$authorizer->getName()] = $authorizer;
   }
 }

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -768,4 +768,27 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
   public function setAuthorizer(\RestfulAuthorizationInterface $authorizer) {
     $this->authorizers[$authorizer->getName()] = $authorizer;
   }
+
+  /**
+   * Return the array of authorizers.
+   *
+   * @return array
+   *   The authorizers.
+   */
+  public function getAuthorizers() {
+    return $this->authorizers;
+  }
+
+  /**
+   * Gets information about the restful plugin.
+   *
+   * @param string
+   *   (optional) The name of the key to return.
+   *
+   * @return mixed
+   *   Depends on the requested value.
+   */
+  public function getPluginInfo($key = NULL) {
+    return isset($key) ? $this->plugin[$key] : $this->plugin;
+  }
 }

--- a/plugins/restful/RestfulEntityBaseMultipleBundles.php
+++ b/plugins/restful/RestfulEntityBaseMultipleBundles.php
@@ -25,7 +25,9 @@ class RestfulEntityBaseMultipleBundles extends RestfulEntityBase {
   public function __construct($plugin) {
     parent::__construct($plugin);
 
-    $this->bundles = $plugin['bundles'];
+    if (!empty($plugin['bundles'])) {
+      $this->bundles = $plugin['bundles'];
+    }
   }
 
   /**

--- a/restful.info
+++ b/restful.info
@@ -22,6 +22,7 @@ files[] = exceptions/RestfulUnsupportedMediaTypeException.php
 files[] = exceptions/RestfulUnprocessableEntityException.php
 
 ; Tests
+files[] = tests/RestfulAuthorizationEntityTestCase.test
 files[] = tests/RestfulCreateEntityTestCase.test
 files[] = tests/RestfulEntityAndPropertyAccessTestCase.test
 files[] = tests/RestfulExceptionHandleTestCase.test

--- a/restful.info
+++ b/restful.info
@@ -10,6 +10,8 @@ files[] = plugins/restful/RestfulEntityBaseNode.php
 files[] = plugins/restful/RestfulEntityBaseMultipleBundles.php
 files[] = plugins/restful/RestfulEntityInterface.php
 files[] = plugins/restful/RestfulInterface.php
+files[] = plugins/authorization/RestfulAuthorizationInterface.php
+files[] = plugins/authorization/RestfulAuthorizationBase.php
 
 ; Exceptions
 files[] = exceptions/RestfulException.php

--- a/restful.module
+++ b/restful.module
@@ -33,24 +33,35 @@ function restful_ctools_plugin_directory($module, $plugin) {
  *     the fly token replacement, or even editing the message type.
  */
 function restful_plugin_process(&$plugin, $info) {
-  $plugin += array(
-    'description' => '',
-    'options' => array(),
-    'major_version' => 1,
-    'minor_version' => 0,
-    'entity_type' => FALSE,
-    'bundle' => FALSE,
-  );
+  if ($info['type'] == 'restful') {
+    $plugin += array(
+      'description' => '',
+      'options' => array(),
+      'major_version' => 1,
+      'minor_version' => 0,
+      'entity_type' => FALSE,
+      'bundle' => FALSE,
+    );
 
-  $plugin['options'] += array(
-  );
+    $plugin['options'] += array(
+    );
+  }
+  else if ($info['type'] == 'authorization') {
+    $plugin += array(
+      'description' => '',
+      'settings' => array(),
+    );
+
+    $plugin['settings'] += array(
+    );
+  }
 }
 
 /**
  * Implements hook_ctools_plugin_type().
  */
 function restful_ctools_plugin_type() {
-  $plugins['restful'] = array(
+  $plugins['authorization'] = $plugins['restful'] = array(
     'classes' => array('class'),
     'process' => 'restful_plugin_process',
   );
@@ -64,6 +75,20 @@ function restful_ctools_plugin_type() {
 function restful_get_restful_plugins() {
   ctools_include('plugins');
   return ctools_get_plugins('restful', 'restful');
+}
+
+/**
+ * Helper function to include CTools plugins and get all authorization plugins.
+ *
+ * @param string $plugin_name
+ *   (optional) If provided this function only returns the selected plugin.
+ *
+ * @return array
+ *   The selected plugin or all plugins for restful authorization.
+ */
+function restful_get_authorization_plugins($plugin_name = NULL) {
+  ctools_include('plugins');
+  return ctools_get_plugins('restful', 'authorization', $plugin_name);
 }
 
 /**
@@ -146,7 +171,21 @@ function restful_get_restful_handler($resource_name, $major_version = 1, $minor_
   $plugin = end($valid_plugins);
 
   $class = ctools_plugin_load_class('restful', 'restful', $plugin['name'], 'class');
-  $cache[$identifier] = new $class($plugin);
+  $handler = new $class($plugin);
+  // If the restful plugin needs authorization load the corresponding
+  // authorization plugin.
+  if (!empty($plugin['authorization types'])) {
+    // Since we can have multiple authorization plugins
+    foreach ($plugin['authorization types'] as $auth_plugin_name) {
+      $auth_plugin = restful_get_authorization_plugins($auth_plugin_name);
+      $auth_class = ctools_plugin_get_class($auth_plugin, 'class');
+      if (!empty($auth_class)) {
+        $handler->setAuthorizer(new $auth_class($auth_plugin));
+      }
+    }
+  }
+  $cache[$identifier] = $handler;
+
   return $cache[$identifier];
 }
 

--- a/tests/RestfulAuthorizationEntityTestCase.test
+++ b/tests/RestfulAuthorizationEntityTestCase.test
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulAuthorizationEntityTestCase
+ */
+
+class RestfulAuthorizationEntityTestCase extends DrupalWebTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Authorize entity',
+      'description' => 'Test the authorization of an entity.',
+      'group' => 'Restful',
+    );
+  }
+
+  /**
+   * Get string credentials.
+   *
+   * @var array
+   */
+  protected $credentials = array();
+
+  function setUp() {
+    parent::setUp('restful_example', 'restful_test');
+
+    // Text - single.
+    $field = array(
+      'field_name' => 'text_single',
+      'type' => 'text_long',
+      'entity_types' => array('entity_test'),
+      'cardinality' => 1,
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'field_name' => 'text_single',
+      'bundle' => 'main',
+      'entity_type' => 'entity_test',
+      'label' => t('Text single'),
+      'settings' => array(
+        'text_processing' => 1,
+      ),
+    );
+    field_create_instance($instance);
+
+    // Get the correct credentials.
+    $default_value = drupal_hmac_base64('restful_authentication_get_string_value', drupal_get_hash_salt());
+    $this->credentials = array(
+      'key' => variable_get('restful_authentication_get_string_name', 'token'),
+      'value' => variable_get('restful_authentication_get_string_value', $default_value),
+    );
+  }
+
+  /**
+   * Test authorizing an entity.
+   *
+   * v1.1 - Authorize GET request.
+   */
+  function testAuthorizeEntity() {
+    $author = $this->drupalCreateUser();
+    $entity = entity_create('entity_test', array('name' => 'main', 'uid' => $author->uid));
+    $wrapper = entity_metadata_wrapper('entity_test', $entity);
+
+    $wrapper->text_single->set(array('value' => $this->randomName()));
+    $wrapper->save();
+
+    $id = $entity->pid;
+
+    // v1.1 - GET string authorization.
+    $handler = restful_get_restful_handler('entity_tests', 1, 1);
+    // Case 1. Check that the handler has the expected authorizers.
+    $authorizers = array_keys($handler->getAuthorizers());
+    foreach ($handler->getPluginInfo('authorization types') as $authorizer_name) {
+      $this->assertTrue(in_array($authorizer_name, $authorizers), format_string('The %name authorization type was found.', array(
+        '%name' => $authorizer_name,
+      )));
+    }
+
+    // Case 2. Test unauthorized request w/ empty GET string.
+    try {
+      $handler->get($id);
+      $this->fail("Authorized a request that shouldn't be authorized.");
+    }
+    catch (\RestfulForbiddenException $e) {
+      $this->pass('The request was successfully unauthorized.');
+    }
+    catch (\Exception $e) {
+      $this->fail(format_string('Unhandled @type: @message', array(
+        '@type' => get_class($e),
+        '@message' => $e->getMessage(),
+      )));
+    }
+
+    // Case 3. Test unauthorized request w/ incorrect value.
+    $_GET[$this->credentials['key']] = $this->credentials['value'] . '_invalid';
+    try {
+      $handler->get($id);
+      $this->fail("Authorized a request that shouldn't be authorized.");
+    }
+    catch (\RestfulForbiddenException $e) {
+      $this->pass('The request was successfully unauthorized.');
+    }
+    catch (\Exception $e) {
+      // Fail on unhandled exceptions so other cases can be evaluated.
+      $this->fail(format_string('Unhandled @type: @message', array(
+        '@type' => get_class($e),
+        '@message' => $e->getMessage(),
+      )));
+    }
+
+    // Case 4. Test authorized request.
+    $_GET[$this->credentials['key']] = $this->credentials['value'];
+    try {
+      $handler->get($id);
+      $this->pass("Request successfully authorized.");
+    }
+    catch (\RestfulForbiddenException $e) {
+      $this->fail("Unauthorized valid request.");
+    }
+    catch (\Exception $e) {
+      $this->fail(format_string('Unhandled @type: @message', array(
+        '@type' => get_class($e),
+        '@message' => $e->getMessage(),
+      )));
+    }
+
+  }
+}

--- a/tests/modules/restful_test/plugins/restful/entity_test/entity_tests/1.1/RestfulTestEntityTestsResource__1_1.class.php
+++ b/tests/modules/restful_test/plugins/restful/entity_test/entity_tests/1.1/RestfulTestEntityTestsResource__1_1.class.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulTestEntityTestsResource.
+ */
+
+class RestfulTestEntityTestsResource__1_1 extends RestfulEntityBase {
+}

--- a/tests/modules/restful_test/plugins/restful/entity_test/entity_tests/1.1/entity_tests__1_1.inc
+++ b/tests/modules/restful_test/plugins/restful/entity_test/entity_tests/1.1/entity_tests__1_1.inc
@@ -1,0 +1,15 @@
+<?php
+
+$plugin = array(
+  'label' => t('Entity Test'),
+  'description' => t('Export the entity test with multiple bundle.'),
+  'resource' => 'entity_tests',
+  'name' => 'entity_tests__1_1',
+  'entity_type' => 'entity_test',
+  'bundle' => 'main',
+  'authorization types' => array(
+    'get_string',
+  ),
+  'class' => 'RestfulTestEntityTestsResource__1_1',
+  'minor_version' => 1,
+);


### PR DESCRIPTION
This PR adds the necessary structure to start supporting Authentication/Authorization.

This has to be seen as the base to build on top of it, since there are some gray areas that need more work. Namely:
- Make the authentication required and its flow more like D8, where we default to cookie auth and if that fails the anonymous user is returned. Right now if you don't use `authentication required` in your plugin definition, no authentication happens.
- Make the `RestfulAuthenticationBase` class to have a `canAuthenticate` method (similar to D8 Authentication Manager).
- Add authentication for Basic Auth. This shouldn't be that hard.

What this has:
- The business logic to add the authorization plugins into the restful handler.
- The business logic to return a 403 if the authorization fails.
- A new `authorization` plugin type to define authorization types. We may need an `authentication` type in the future, I'm not quite sure yet.
- A **dummy** auth-z plugin that will check the presence of a key/value as a GET param. The key and value are stored in a variable. This base class may be leveraged to check the presence of any negotiated token in the future (thinking about OAuth, Facebook, …).
- Some extra helper methods in `RestfulEntityBase`.
- Tests for the GET param authentication type.

Maybe @juampy72 is curious about this PR.

:boom:
