### PR TITLE
Fix setting values for entity reference and text fields on POST

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   - curl -O https://www.drupal.org/files/issues/2086225-entity-access-check-node-create-3.patch
   - patch -p1 /home/travis/build/restful/drupal/sites/all/modules/entity/modules/callbacks.inc  < 2086225-entity-access-check-node-create-3.patch
 
-  - curl -O https://www.drupal.org/files/issues/2264079-entity-wrapper-access-single-entity-reference-1.patch
+  - curl -O https://www.drupal.org/files/issues/2264079-entity-wrapper-access-single-entity-reference-2.patch
   - patch -p1 /home/travis/build/restful/drupal/sites/all/modules/entity/includes/entity.wrapper.inc < 2264079-entity-wrapper-access-single-entity-reference-1.patch
 
   # start a web server on port 8080, run in the background; wait for initialization

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - patch -p1 /home/travis/build/restful/drupal/sites/all/modules/entity/modules/callbacks.inc  < 2086225-entity-access-check-node-create-3.patch
 
   - curl -O https://www.drupal.org/files/issues/2264079-entity-wrapper-access-single-entity-reference-2.patch
-  - patch -p1 /home/travis/build/restful/drupal/sites/all/modules/entity/includes/entity.wrapper.inc < 2264079-entity-wrapper-access-single-entity-reference-1.patch
+  - patch -p1 /home/travis/build/restful/drupal/sites/all/modules/entity/includes/entity.wrapper.inc < 2264079-entity-wrapper-access-single-entity-reference-2.patch
 
   # start a web server on port 8080, run in the background; wait for initialization
   - drush runserver 127.0.0.1:8080 &

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ with the ``field_`` prefix
 * Only JSON format is supported
 * Audience is developers and not site builders
 
+## Module dependencies
+* [Entity API](https://drupal.org/project/entity), with the following patches:
+  * [$wrapper->access() might be wrong for single entity reference field](https://www.drupal.org/node/2264079#comment-8911637)
+  * [Prevent notice in entity_metadata_no_hook_node_access() when node is not saved](https://drupal.org/node/2086225#comment-8768373)
+
 
 ## API via Drupal
 
@@ -221,11 +226,6 @@ for every resource, meaning that very volatile resources can skip cache entirely
 while other resources can have its cache in MemCached or the database. To
 configure this developers just have to specify the following keys in their
 _restful_ plugin definition.
-
-## Module dependencies
-* [Entity API](https://drupal.org/project/entity), with the following patches:
-  * [$wrapper->access() might be wrong for single entity reference field](https://www.drupal.org/node/2264079#comment-8911637)
-  * [Prevent notice in entity_metadata_no_hook_node_access() when node is not saved](https://drupal.org/node/2086225#comment-8768373)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ _restful_ plugin definition.
 
 ## Module dependencies
 * [Entity API](https://drupal.org/project/entity), with the following patches:
-  * [$wrapper->access() might be wrong for single entity reference field](https://drupal.org/node/2264079#comment-8768581)
+  * [$wrapper->access() might be wrong for single entity reference field](https://www.drupal.org/node/2264079#comment-8911637)
   * [Prevent notice in entity_metadata_no_hook_node_access() when node is not saved](https://drupal.org/node/2086225#comment-8768373)
 
 ## Credits

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -881,6 +881,13 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
     $original_request = $request;
 
     foreach ($this->getPublicFields() as $public_property => $info) {
+      if (empty($info['property'])) {
+        // We may have for example an entity with no label property, but with a
+        // label callback. In that case the $info['property'] won't exist, so
+        // we skip this field.
+        continue;
+      }
+
       $property_name = $info['property'];
       if (!isset($request[$public_property])) {
         // No property to set in the request.

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -948,24 +948,23 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
     elseif (in_array($field_info['type'], array('text', 'text_long', 'text_with_summary'))) {
       // Text field. Check if field has an input format.
       $instance = field_info_instance($this->getEntityType(), $property_name, $this->getBundle());
+      // @todo: How to get the correct format value?
+      $format = $instance['settings']['text_processing'] ? 'filtered_html' : NULL;
 
       if ($field_info['cardinality'] == 1) {
         // Single value.
-        $return = array('value' => $value);
-        if ($instance['settings']['text_processing']) {
-          // @todo: How to get the correct value?
-          $return['format'] = 'filtered_html';
-        }
-        return $return;
+        return array(
+          'value' => $value,
+          'format' => $format,
+        );
       }
 
       // Multiple values.
       foreach ($value as $delta => $single_value) {
-        $return[$delta] = array('value' => $single_value);
-        if ($instance['settings']['text_processing']) {
-          // @todo: How to get the correct value?
-          $return[$delta]['format'] = 'filtered_html';
-        }
+        $return[$delta] = array(
+          'value' => $single_value,
+          'format' => $format,
+        );
       }
       return $return;
     }

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -877,7 +877,7 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
       throw new RestfulBadRequestException('No values were sent with the request');
     }
 
-    // Removing application property from the request.
+    // Remove the application property from the request.
     static::cleanRequest($original_request);
 
     if ($original_request) {

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -583,7 +583,7 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
           throw new Exception(format_string('Process callback function: @callback does not exists.', array('@callback' => $callback_name)));
         }
 
-        $value = call_user_func($info['callback'], $wrapper);
+        $value = call_user_func($info['callback']);
       }
       else {
         // Exposing an entity field.

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -948,23 +948,31 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
     elseif (in_array($field_info['type'], array('text', 'text_long', 'text_with_summary'))) {
       // Text field. Check if field has an input format.
       $instance = field_info_instance($this->getEntityType(), $property_name, $this->getBundle());
-      // @todo: How to get the correct format value?
-      $format = $instance['settings']['text_processing'] ? 'filtered_html' : NULL;
 
       if ($field_info['cardinality'] == 1) {
         // Single value.
-        return array(
+        if (!$instance['settings']['text_processing']) {
+          return $value;
+        }
+
+        return array (
           'value' => $value,
-          'format' => $format,
+          // @todo: How to get the correct format value?
+          'format' => 'filtered_html',
         );
       }
 
       // Multiple values.
       foreach ($value as $delta => $single_value) {
-        $return[$delta] = array(
-          'value' => $single_value,
-          'format' => $format,
-        );
+        if (!$instance['settings']['text_processing']) {
+          $return[$delta] = $single_value;
+        }
+        else {
+          $return[$delta] = array(
+            'value' => $single_value,
+            'format' => 'filtered_html',
+          );
+        }
       }
       return $return;
     }

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -843,7 +843,7 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
 
     $entity = entity_create($this->entityType, $values);
 
-    if (!entity_access('create', $this->entityType, $entity, $account)) {
+    if (entity_access('create', $this->entityType, $entity, $account) === FALSE) {
       // User does not have access to create entity.
       $params = array('@resource' => $this->plugin['label']);
       throw new RestfulForbiddenException(format_string('You do not have access to create a new @resource resource.', $params));
@@ -876,8 +876,6 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
     $original_request = $request;
 
     foreach ($this->getPublicFields() as $public_property => $info) {
-      // @todo: Pass value to validators, even if it doesn't exist, so we can
-      // validate required properties.
       $property_name = $info['property'];
       if (!isset($request[$public_property])) {
         // No property to set in the request.

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -957,7 +957,6 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
 
         return array (
           'value' => $value,
-          // @todo: How to get the correct format value?
           'format' => 'filtered_html',
         );
       }

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -583,7 +583,7 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
           throw new Exception(format_string('Process callback function: @callback does not exists.', array('@callback' => $callback_name)));
         }
 
-        $value = call_user_func($info['callback']);
+        $value = call_user_func($info['callback'], $wrapper);
       }
       else {
         // Exposing an entity field.

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -948,9 +948,26 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
     elseif (in_array($field_info['type'], array('text', 'text_long', 'text_with_summary'))) {
       // Text field. Check if field has an input format.
       $instance = field_info_instance($this->getEntityType(), $property_name, $this->getBundle());
-      // @todo: Is this correct?
-      $format = $instance['settings']['text_processing'] ? 'filtered_html' : 'plain_text';
-      return array('format' => $format, 'value' => $value);
+
+      if ($field_info['cardinality'] == 1) {
+        // Single value.
+        $return = array('value' => $value);
+        if ($instance['settings']['text_processing']) {
+          // @todo: How to get the correct value?
+          $return['format'] = 'filtered_html';
+        }
+        return $return;
+      }
+
+      // Multiple values.
+      foreach ($value as $delta => $single_value) {
+        $return[$delta] = array('value' => $single_value);
+        if ($instance['settings']['text_processing']) {
+          // @todo: How to get the correct value?
+          $return[$delta]['format'] = 'filtered_html';
+        }
+      }
+      return $return;
     }
 
     // Return the value as is.

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -877,6 +877,9 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
       throw new RestfulBadRequestException('No values were sent with the request');
     }
 
+    // Removing application property from the request.
+    static::cleanRequest($original_request);
+
     if ($original_request) {
       // Request had illegal values.
       $error_message = format_plural(count($original_request), 'Property @names is invalid.', 'Property @names are invalid.', array('@names' => implode(', ', array_keys($original_request))));

--- a/tests/RestfulCreateEntityTestCase.test
+++ b/tests/RestfulCreateEntityTestCase.test
@@ -114,15 +114,19 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
   function testCreateEntity() {
     $handler = restful_get_restful_handler('main', 1, 1);
 
-    $text = $this->randomName();
-    $request = array('text_single' => $text);
+    $text1 = $this->randomName();
+    $text2 = $this->randomName();
+    $request = array(
+      'text_single' => $text1,
+      'text_multiple' => array($text1, $text2),
+    );
     $result = $handler->post('', $request);
 
     $ids = array();
 
     $entity = entity_load_single('entity_test', $result['id']);
     $ids[] = $entity->pid;
-    $this->assertEqual($result['text_single'], $text, 'Entity was created with correct text value.');
+    $this->assertEqual(strip_tags($result['text_single']), $text1, 'Entity was created with correct text value.');
 
     // Create an entity with empty request.
     try {
@@ -158,12 +162,12 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
     $request = array('entity_reference_multiple' => $ids);
     $result = $handler->post('', $request);
 
-    $this->assertEqual($result['entity_reference_multiple'], $ids);
+    $this->assertEqual($result['entity_reference_multiple'], $ids, 'Create entity with multiple reference.');
 
 
     // Create entity with comma separated multiple reference.
     $request = array('entity_reference_multiple' => implode(',', $ids));
     $result = $handler->post('', $request);
-    $this->assertEqual($result['entity_reference_multiple'], $ids);
+    $this->assertEqual($result['entity_reference_multiple'], $ids, 'Created entity with comma separated multiple reference.');
   }
 }

--- a/tests/RestfulCreateEntityTestCase.test
+++ b/tests/RestfulCreateEntityTestCase.test
@@ -33,7 +33,8 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
       'entity_type' => 'entity_test',
       'label' => t('Text single'),
       'settings' => array(
-        'text_processing' => 1,
+        // No text processing
+        'text_processing' => 0,
       ),
     );
     field_create_instance($instance);
@@ -126,7 +127,16 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
 
     $entity = entity_load_single('entity_test', $result['id']);
     $ids[] = $entity->pid;
-    $this->assertEqual(strip_tags($result['text_single']), $text1, 'Entity was created with correct text value.');
+
+    $striped_result = array(
+      'text_single' => trim(strip_tags($result['text_single'])),
+      'text_multiple' => array(
+        trim(strip_tags($result['text_multiple'][0])),
+        trim(strip_tags($result['text_multiple'][1])),
+      ),
+    );
+
+    $this->assertEqual($striped_result, $request, 'Entity was created with correct text value.');
 
     // Create an entity with empty request.
     try {

--- a/tests/RestfulCreateEntityTestCase.test
+++ b/tests/RestfulCreateEntityTestCase.test
@@ -16,7 +16,7 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
   }
 
   function setUp() {
-    parent::setUp('restful_test');
+    parent::setUp('restful_test', 'entityreference');
 
     // Text - single.
     $field = array(
@@ -36,6 +36,51 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
         'text_processing' => 1,
       ),
     );
+    field_create_instance($instance);
+
+
+    // Text - multiple.
+    $field = array(
+      'field_name' => 'text_multiple',
+      'type' => 'text_long',
+      'entity_types' => array('entity_test'),
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'field_name' => 'text_multiple',
+      'bundle' => 'main',
+      'entity_type' => 'entity_test',
+      'label' => t('Text multiple'),
+      'settings' => array(
+        'text_processing' => 1,
+      ),
+    );
+    field_create_instance($instance);
+
+    // Entity reference - single.
+    $field = array(
+      'entity_types' => array('entity_test'),
+      'settings' => array(
+        'handler' => 'base',
+        'target_type' => 'entity_test',
+        'handler_settings' => array(
+        ),
+      ),
+      'field_name' => 'entity_reference_single',
+      'type' => 'entityreference',
+      'cardinality' => 1,
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'entity_type' => 'entity_test',
+      'field_name' => 'entity_reference_single',
+      'bundle' => 'main',
+      'label' => t('Entity reference single'),
+    );
+
     field_create_instance($instance);
 
     // Entity reference - multiple.

--- a/tests/RestfulCreateEntityTestCase.test
+++ b/tests/RestfulCreateEntityTestCase.test
@@ -111,7 +111,7 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
     }
 
     // Create another test entity to be referenced.
-    $entity = entity_create('entity_test', array('type' => 'main'));
+    $entity = entity_create('entity_test', array('name' => 'main'));
     $entity->save();
     $ids[] = $entity->pid;
 

--- a/tests/RestfulCreateEntityTestCase.test
+++ b/tests/RestfulCreateEntityTestCase.test
@@ -16,22 +16,71 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
   }
 
   function setUp() {
-    parent::setUp('restful_example');
+    parent::setUp('restful_test');
+
+    // Text - single.
+    $field = array(
+      'field_name' => 'text_single',
+      'type' => 'text_long',
+      'entity_types' => array('entity_test'),
+      'cardinality' => 1,
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'field_name' => 'text_single',
+      'bundle' => 'main',
+      'entity_type' => 'entity_test',
+      'label' => t('Text single'),
+      'settings' => array(
+        'text_processing' => 1,
+      ),
+    );
+    field_create_instance($instance);
+
+    // Entity reference - multiple.
+    $field = array(
+      'entity_types' => array('entity_test'),
+      'settings' => array(
+        'handler' => 'base',
+        'target_type' => 'entity_test',
+        'handler_settings' => array(
+        ),
+      ),
+      'field_name' => 'entity_reference_multiple',
+      'type' => 'entityreference',
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'entity_type' => 'entity_test',
+      'field_name' => 'entity_reference_multiple',
+      'bundle' => 'main',
+      'label' => t('Entity reference multiple'),
+    );
+
+    field_create_instance($instance);
   }
 
   /**
    * Test creating an entity (POST method).
    */
   function testCreateEntity() {
-    $handler = restful_get_restful_handler('articles');
-    $request = array('label' => $this->randomName());
+    $handler = restful_get_restful_handler('main');
+
+    $text = $this->randomName();
+    $request = array('text_single' => $text);
     $result = $handler->post('', $request);
 
-    $node = node_load($result['id']);
+    $ids = array();
+
+    $entity = entity_load_single('entity_test', $result['id']);
+    $ids[] = $entity->pid;
     $expected_result = array(
-      'id' => $node->nid,
-      'label' => $node->title,
-      'self' => url('node/' . $node->nid, array('absolute' => TRUE)),
+      'id' => $entity->pid,
+      'text_single' => $text,
+      'entity_reference_multiple' => NULL,
     );
 
     $this->assertEqual($result, $expected_result, 'Entity was created.');
@@ -41,8 +90,11 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
       $handler->post();
       $this->fail('User can create an entity with empty request.');
     }
-    catch (Exception $e) {
+    catch (\RestfulBadRequestException $e) {
       $this->pass('User cannot create an entity with empty request.');
+    }
+    catch (\Exception $e) {
+      $this->fail('Wrong exception thrown when creating an entity with empty request.');
     }
 
     // Create an entity with invalid property name.
@@ -51,8 +103,28 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
       $handler->post('', $request);
       $this->fail('User can create an entity with invalid property name.');
     }
-    catch (Exception $e) {
+    catch (\RestfulBadRequestException $e) {
       $this->pass('User cannot create an entity with invalid property name.');
     }
+    catch (\Exception $e) {
+      $this->fail('Wrong exception thrown when creating an entity with invalid property name.');
+    }
+
+    // Create another test entity to be referenced.
+    $entity = entity_create('entity_test', array('type' => 'main'));
+    $entity->save();
+    $ids[] = $entity->pid;
+
+    // Create entity with multiple reference.
+    $request = array('entity_reference_multiple' => $ids);
+    $result = $handler->post('', $request);
+
+    $this->assertEqual($result['entity_reference_multiple'], $ids);
+
+
+    // Create entity with comma separated multiple reference.
+    $request = array('entity_reference_multiple' => implode(',', $ids));
+    $result = $handler->post('', $request);
+    $this->assertEqual($result['entity_reference_multiple'], $ids);
   }
 }

--- a/tests/RestfulCreateEntityTestCase.test
+++ b/tests/RestfulCreateEntityTestCase.test
@@ -67,7 +67,7 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
    * Test creating an entity (POST method).
    */
   function testCreateEntity() {
-    $handler = restful_get_restful_handler('main');
+    $handler = restful_get_restful_handler('main', 1, 1);
 
     $text = $this->randomName();
     $request = array('text_single' => $text);

--- a/tests/RestfulCreateEntityTestCase.test
+++ b/tests/RestfulCreateEntityTestCase.test
@@ -122,13 +122,7 @@ class RestfulCreateEntityTestCase extends DrupalWebTestCase {
 
     $entity = entity_load_single('entity_test', $result['id']);
     $ids[] = $entity->pid;
-    $expected_result = array(
-      'id' => $entity->pid,
-      'text_single' => $text,
-      'entity_reference_multiple' => NULL,
-    );
-
-    $this->assertEqual($result, $expected_result, 'Entity was created.');
+    $this->assertEqual($result['text_single'], $text, 'Entity was created with correct text value.');
 
     // Create an entity with empty request.
     try {

--- a/tests/modules/restful_test/plugins/restful/entity_test/main/1.1/RestfulTestMainResource__1_1.class.php
+++ b/tests/modules/restful_test/plugins/restful/entity_test/main/1.1/RestfulTestMainResource__1_1.class.php
@@ -13,14 +13,18 @@ class RestfulTestMainResource__1_1 extends RestfulTestMainResource {
   public function getPublicFields() {
     $public_fields = parent::getPublicFields();
 
+    // Determine if the wrapper should use a "sub property" on a text field
+    // by checking if the "text_processing" is enabled.
+    $instance = field_info_instance($this->getEntityType(), 'text_single', $this->getBundle());
     $public_fields['text_single'] = array(
       'property' => 'text_single',
-      'sub_property' => 'value',
+      'sub_property' => $instance['settings']['text_processing'] ? 'value' : FALSE,
     );
 
+    $instance = field_info_instance($this->getEntityType(), 'text_multiple', $this->getBundle());
     $public_fields['text_multiple'] = array(
       'property' => 'text_multiple',
-      'sub_property' => 'value',
+      'sub_property' => $instance['settings']['text_processing'] ? 'value' : FALSE,
     );
 
     $public_fields['entity_reference_single'] = array(


### PR DESCRIPTION
When creating a new entity via POST request, now the fields of entity reference type with multiple values is supported.
