### PR TITLE
Allow changing the entity just before it's saved via POST

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -876,7 +876,7 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
    *
    * @throws RestfulBadRequestException
    */
-  protected function setPropertyValues(EntityMetadataWrapper $wrapper, $request, $account, $null_missing_fields = FALSE) {
+  protected function setPropertyValues(EntityMetadataWrapper $wrapper, $request, stdClass $account, $null_missing_fields = FALSE) {
     $save = FALSE;
     $original_request = $request;
 
@@ -919,6 +919,10 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
       $error_message = format_plural(count($original_request), 'Property @names is invalid.', 'Property @names are invalid.', array('@names' => implode(', ', array_keys($original_request))));
       throw new RestfulBadRequestException($error_message);
     }
+
+    // Allow changing the entity just before it's saved. For example, setting
+    // the author of the node entity.
+    $this->createEntityPreInsert($wrapper->value(), $request, $account);
 
     $wrapper->save();
   }
@@ -979,6 +983,18 @@ abstract class RestfulEntityBase implements RestfulEntityInterface {
     // Return the value as is.
     return $value;
   }
+
+  /**
+   * Allow manipulating the entity before it is saved for the first time.
+   *
+   * @param $entity
+   *   The unsaved entity object, passed by reference.
+   * @param array $request
+   *   The request array.
+   * @param stdClass $account
+   *   The user object.
+   */
+  public function createEntityPreInsert($entity, $request, stdClass $account) {}
 
   /**
    * Helper method to check access on a property.

--- a/plugins/restful/RestfulEntityBaseNode.php
+++ b/plugins/restful/RestfulEntityBaseNode.php
@@ -22,4 +22,14 @@ class RestfulEntityBaseNode extends RestfulEntityBase {
     return $query;
   }
 
+  /**
+   * Overrides RestfulEntityBase::createEntityPreInsert().
+   *
+   * Set the node author and other defaults.
+   */
+  public function createEntityPreInsert($entity, $request, stdClass $account) {
+    node_object_prepare($entity);
+    $entity->uid = $account->uid;
+  }
+
 }

--- a/restful.info
+++ b/restful.info
@@ -33,6 +33,7 @@ files[] = exceptions/RestfulUnprocessableEntityException.php
 ; Tests
 files[] = tests/RestfulAuthenticationTestCase.test
 files[] = tests/RestfulCreateEntityTestCase.test
+files[] = tests/RestfulCreateNodeTestCase.test
 files[] = tests/RestfulCurlBaseTestCase.test
 files[] = tests/RestfulEntityAndPropertyAccessTestCase.test
 files[] = tests/RestfulEntityUserAccessTestCase.test

--- a/tests/RestfulCreateNodeTestCase.test
+++ b/tests/RestfulCreateNodeTestCase.test
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulCreateNodeTestCase
+ */
+
+class RestfulCreateNodeTestCase extends DrupalWebTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Create node',
+      'description' => 'Test the creation of a node entity type.',
+      'group' => 'Restful',
+    );
+  }
+
+  function setUp() {
+    parent::setUp('restful_example');
+  }
+
+  /**
+   * Test creating a node (POST method).
+   */
+  function testCreateNode() {
+    $user1 = $this->drupalCreateUser();
+    $this->drupalLogin($user1);
+
+    $handler = restful_get_restful_handler('articles');
+
+    // Set a different user from the logged in user, to assert the node's author
+    // is set correctly.
+    $user2 = $this->drupalCreateUser(array('create article content'));
+    $handler->setAccount($user2);
+
+    $text1 = $this->randomName();
+    $request = array('label' => $text1);
+    $result = $handler->post('', $request);
+
+    $node = node_load($result['id']);
+    $this->assertEqual($node->uid, $user2->uid, 'Correct user was set to be the author of the node.');
+  }
+}


### PR DESCRIPTION
For example, setting the author of the node entity.
