### PR TITLE
Fix access token, and checking access for correct account

### DIFF
--- a/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
+++ b/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
@@ -21,11 +21,14 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
    */
   public function authenticate($request = NULL, $method = 'get') {
     $key_name = !empty($this->plugin['options']['param_name']) ? $this->plugin['options']['param_name'] : 'access_token';
+    $token = !empty($request['__application'][$key_name]) ? $request['__application'][$key_name] : $request[$key_name];
+
     // Check if there is a token that did not expire yet.
+
     $query = new EntityFieldQuery();
     $result = $query
       ->entityCondition('entity_type', 'restful_token_auth')
-      ->propertyCondition('token', $request[$key_name])
+      ->propertyCondition('token', $token)
       ->range(0, 1)
       ->execute();
 

--- a/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
+++ b/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
@@ -13,7 +13,7 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
     $key_name = !empty($this->plugin['options']['param_name']) ? $this->plugin['options']['param_name'] : 'access_token';
 
     // Access token may be on the request, or in the headers.
-    return $request['__application'][$key_name] || !empty($request[$key_name]);
+    return !empty($request['__application'][$key_name]) || !empty($request[$key_name]);
   }
 
   /**

--- a/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
+++ b/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
@@ -11,7 +11,9 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
    */
   public function applies($request = NULL, $method = 'get') {
     $key_name = !empty($this->plugin['options']['param_name']) ? $this->plugin['options']['param_name'] : 'access_token';
-    return !empty($request[$key_name]);
+
+    // Access token may be on the request, or in the headers.
+    return $request['__application'][$key_name] || !empty($request[$key_name]);
   }
 
   /**
@@ -19,7 +21,6 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
    */
   public function authenticate($request = NULL, $method = 'get') {
     $key_name = !empty($this->plugin['options']['param_name']) ? $this->plugin['options']['param_name'] : 'access_token';
-
     // Check if there is a token that did not expire yet.
     $query = new EntityFieldQuery();
     $result = $query
@@ -27,6 +28,7 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
       ->propertyCondition('token', $request[$key_name])
       ->range(0, 1)
       ->execute();
+
 
     if (empty($result['restful_token_auth'])) {
       // No token exists.

--- a/modules/restful_token_auth/restful_token_auth.module
+++ b/modules/restful_token_auth/restful_token_auth.module
@@ -28,6 +28,21 @@ function restful_token_auth_menu() {
   return $items;
 }
 
+/**
+ * Implements hook_restful_parse_request_alter()
+ */
+function restful_token_auth_restful_parse_request_alter(&$request) {
+  $plugin = restful_get_authentication_plugin('token');
+  $param_name = $plugin['options']['param_name'];
+
+  $capital_name = strtoupper('HTTP_X_' . $param_name);
+
+  $request['__application'] += array(
+    $param_name => !empty($_SERVER[$capital_name]) ? $_SERVER[$capital_name] : NULL,
+  );
+
+}
+
 
 /**
  * Implements hook_ctools_plugin_directory().

--- a/modules/restful_token_auth/restful_token_auth.module
+++ b/modules/restful_token_auth/restful_token_auth.module
@@ -40,7 +40,6 @@ function restful_token_auth_restful_parse_request_alter(&$request) {
   $request['__application'] += array(
     $param_name => !empty($_SERVER[$capital_name]) ? $_SERVER[$capital_name] : NULL,
   );
-
 }
 
 

--- a/plugins/restful/user/login_cookie/1.0/RestfulUserLoginCookie.class.php
+++ b/plugins/restful/user/login_cookie/1.0/RestfulUserLoginCookie.class.php
@@ -36,7 +36,9 @@ class RestfulUserLoginCookie extends \RestfulEntityBase {
     $version = $this->getVersion();
     $handler = restful_get_restful_handler('users', $version['major'], $version['minor']);
 
-    return $handler->viewEntity($account->uid, $request, $account);
+    $output = $handler->viewEntity($account->uid, $request, $account);
+    $output += restful_csrf_session_token();
+    return $output;
   }
 
   /**

--- a/restful.api.php
+++ b/restful.api.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the RESTful module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+
+/**
+ * Allow altering the request before it is processed.
+ *
+ * @param $request
+ *   The request array.
+ */
+function hook_restful_parse_request_alter(&$request) {
+  $request['__application'] += array(
+    'some_header' => !empty($_SERVER['X_HTTP_SOME_HEADER']) ? $_SERVER['X_HTTP_SOME_HEADER'] : NULL,
+  );
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/restful.module
+++ b/restful.module
@@ -411,7 +411,7 @@ function restful_menu_access_callback($major_version, $resource_name) {
     return;
   }
 
-  if (!in_array($_SERVER['REQUEST_METHOD'], array('GET', 'POST', 'PUT', 'PATCH', 'DELETE'))) {
+  if (!in_array($_SERVER['REQUEST_METHOD'], array('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'))) {
     return;
   }
 
@@ -441,6 +441,15 @@ function restful_menu_process_callback($major_version, $resource_name) {
   $path = implode('/', $path);
 
   $method = strtolower($_SERVER['REQUEST_METHOD']);
+
+  if ($method == 'options') {
+    // OPTIONS method is a special case that might be sent by the browser
+    // before the actual method.
+    drupal_add_http_header('Status', 204);
+    drupal_add_http_header('Content-Type', 'application/hal+json; charset=utf-8');
+    return;
+  }
+
   $request = restful_parse_request();
 
   try {

--- a/restful.module
+++ b/restful.module
@@ -444,7 +444,7 @@ function restful_menu_process_callback($major_version, $resource_name) {
 
   if ($method == 'options') {
     // OPTIONS method is a special case that might be sent by the browser
-    // before the actual method.
+    // before the actual method to check for CORS (known as preflight OPTIONS).
     drupal_add_http_header('Status', 204);
     drupal_add_http_header('Content-Type', 'application/hal+json; charset=utf-8');
     return;

--- a/restful.module
+++ b/restful.module
@@ -411,7 +411,7 @@ function restful_menu_access_callback($major_version, $resource_name) {
     return;
   }
 
-  if (!in_array($_SERVER['REQUEST_METHOD'], array('GET', 'POST', 'PUT', 'PATCH', 'DELETE'))) {
+  if (!in_array($_SERVER['REQUEST_METHOD'], array('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'))) {
     return;
   }
 
@@ -441,6 +441,15 @@ function restful_menu_process_callback($major_version, $resource_name) {
   $path = implode('/', $path);
 
   $method = strtolower($_SERVER['REQUEST_METHOD']);
+
+  if ($method == 'options') {
+    // OPTIONS method is a special case that might be sent by the browser
+    // before the actual method.
+    drupal_add_http_header('Status', 204);
+    drupal_add_http_header('Content-Type', 'application/hal+json; charset=utf-8');
+    return;
+  }
+
   $request = restful_parse_request();
 
   try {
@@ -505,6 +514,7 @@ function restful_parse_request() {
     // $_POST, so we try to re-grab it here.
     parse_str($query_string, $request);
   }
+
 
   // This flag is used to identify if the request is done "via Drupal" or "via
   // CURL";

--- a/restful.module
+++ b/restful.module
@@ -513,6 +513,10 @@ function restful_parse_request() {
     'rest_call' => TRUE,
     'csrf_token' => !empty($_SERVER['HTTP_X_CSRF_TOKEN']) ? $_SERVER['HTTP_X_CSRF_TOKEN'] : NULL,
   );
+
+  // Allow implemeting modules to alter the request.
+  drupal_alter('restful_parse_request', $request);
+
   return $request;
 }
 

--- a/restful.module
+++ b/restful.module
@@ -696,6 +696,5 @@ function restful_file_upload_access() {
  * Page callback: returns a session token for the currently active user.
  */
 function restful_csrf_session_token() {
-  drupal_add_http_header('Content-Type', 'text/plain');
   return array('X-CSRF-Token' => drupal_get_token(\RestfulInterface::TOKEN_VALUE));
 }

--- a/restful.module
+++ b/restful.module
@@ -411,7 +411,7 @@ function restful_menu_access_callback($major_version, $resource_name) {
     return;
   }
 
-  if (!in_array($_SERVER['REQUEST_METHOD'], array('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'))) {
+  if (!in_array($_SERVER['REQUEST_METHOD'], array('GET', 'POST', 'PUT', 'PATCH', 'DELETE'))) {
     return;
   }
 
@@ -441,15 +441,6 @@ function restful_menu_process_callback($major_version, $resource_name) {
   $path = implode('/', $path);
 
   $method = strtolower($_SERVER['REQUEST_METHOD']);
-
-  if ($method == 'options') {
-    // OPTIONS method is a special case that might be sent by the browser
-    // before the actual method.
-    drupal_add_http_header('Status', 204);
-    drupal_add_http_header('Content-Type', 'application/hal+json; charset=utf-8');
-    return;
-  }
-
   $request = restful_parse_request();
 
   try {
@@ -514,7 +505,6 @@ function restful_parse_request() {
     // $_POST, so we try to re-grab it here.
     parse_str($query_string, $request);
   }
-
 
   // This flag is used to identify if the request is done "via Drupal" or "via
   // CURL";

--- a/tests/RestfulEntityUserAccessTestCase.test
+++ b/tests/RestfulEntityUserAccessTestCase.test
@@ -54,15 +54,15 @@ class RestfulEntityUserAccessTestCase extends DrupalWebTestCase {
     }
 
     // View own user account.
-    $handler->get($user1->uid);
+    $result = $handler->get($user1->uid);
+    $this->assertEqual($result['mail'], $user1->mail, 'User can see own mail.');
 
-    // Privileged user.
+    // Privileged user, watching another user's profile.
     $handler->setAccount($user2);
     $result = $handler->get($user1->uid);
     $expected_result = array(
       'id' => $user1->uid,
       'label' => $user1->name,
-      'mail' => $user1->mail,
       'self' => url('user/' . $user1->uid, array('absolute' => TRUE)),
     );
 


### PR DESCRIPTION
- We need to check access for the passed $account not the active user
- We need to allow POSTing using access-token, thus moving it to the http header (otherwise it will be part of the request, and then it will throw an exception)
- Allow browser to send preflight OPTIONS before POST
