### PR TITLE
Allow creating referenced sub-resources in a single request

### DIFF
--- a/modules/restful_angular_example/restful_angular_example.module
+++ b/modules/restful_angular_example/restful_angular_example.module
@@ -74,3 +74,4 @@ function restful_angular_example_form_page() {
   $url = url($app_path . '/views/main.html', array('absolute' => TRUE));
   return theme('restful_angular_example_angular_form', array('url' => $url));
 }
+

--- a/modules/restful_example/plugins/restful/node/per_role_content/1.0/RestfulExampleRoleResource.class.php
+++ b/modules/restful_example/plugins/restful/node/per_role_content/1.0/RestfulExampleRoleResource.class.php
@@ -36,8 +36,8 @@ class RestfulExampleRoleResource extends \RestfulEntityBase implements \RestfulE
   /**
    * Overrides \RestfulEntityBase::getQueryForList().
    */
-  public function getQueryForList($request, stdClass $account = NULL) {
-    $query = parent::getQueryForList($request, $account);
+  public function getQueryForList() {
+    $query = parent::getQueryForList();
     // Get the configured roles.
     $options = $this->getPluginInfo('options');
 

--- a/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
+++ b/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
@@ -9,7 +9,7 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
   /**
    * {@inheritdoc}
    */
-  public function applies($request = NULL, $method = 'get') {
+  public function applies(array $request = array(), $method = \RestfulBase::GET) {
     $key_name = !empty($this->plugin['options']['param_name']) ? $this->plugin['options']['param_name'] : 'access_token';
     return !empty($request[$key_name]);
   }
@@ -17,7 +17,7 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
   /**
    * {@inheritdoc}
    */
-  public function authenticate($request = NULL, $method = 'get') {
+  public function authenticate(array $request = array(), $method = \RestfulBase::GET) {
     $key_name = !empty($this->plugin['options']['param_name']) ? $this->plugin['options']['param_name'] : 'access_token';
 
     // Check if there is a token that did not expire yet.

--- a/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
+++ b/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
@@ -9,7 +9,7 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
   /**
    * {@inheritdoc}
    */
-  public function applies(array $request = array(), $method = \RestfulBase::GET) {
+  public function applies(array $request = array(), $method = \RestfulInterface::GET) {
     $key_name = !empty($this->plugin['options']['param_name']) ? $this->plugin['options']['param_name'] : 'access_token';
     return !empty($request[$key_name]);
   }
@@ -17,7 +17,7 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
   /**
    * {@inheritdoc}
    */
-  public function authenticate(array $request = array(), $method = \RestfulBase::GET) {
+  public function authenticate(array $request = array(), $method = \RestfulInterface::GET) {
     $key_name = !empty($this->plugin['options']['param_name']) ? $this->plugin['options']['param_name'] : 'access_token';
 
     // Check if there is a token that did not expire yet.

--- a/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/1.0/RestfulTokenAuthentication.class.php
+++ b/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/1.0/RestfulTokenAuthentication.class.php
@@ -35,6 +35,7 @@ class RestfulTokenAuthentication extends \RestfulEntityBase {
    * Create a token for a user, and return its value.
    */
   public function getOrCreateToken() {
+    $account = $this->getAccount();
     // Check if there is a token that did not expire yet.
     $query = new EntityFieldQuery();
     $result = $query

--- a/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/1.0/RestfulTokenAuthentication.class.php
+++ b/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/1.0/RestfulTokenAuthentication.class.php
@@ -34,7 +34,7 @@ class RestfulTokenAuthentication extends \RestfulEntityBase {
   /**
    * Create a token for a user, and return its value.
    */
-  public function getOrCreateToken($request = NULL, stdClass $account = NULL) {
+  public function getOrCreateToken() {
     // Check if there is a token that did not expire yet.
     $query = new EntityFieldQuery();
     $result = $query
@@ -76,6 +76,6 @@ class RestfulTokenAuthentication extends \RestfulEntityBase {
       $id = $auth_token->id;
     }
 
-    return $this->viewEntity($id, $request, $account);
+    return $this->viewEntity($id);
   }
 }

--- a/plugins/authentication/RestfulAuthenticationBase.php
+++ b/plugins/authentication/RestfulAuthenticationBase.php
@@ -32,7 +32,7 @@ abstract class RestfulAuthenticationBase implements RestfulAuthenticationInterfa
   /**
    * {@inheritdoc}
    */
-  public function applies($request = NULL, $method = 'get') {
+  public function applies(array $request = array(), $method = \RestfulBase::GET) {
     // By default assume that the request can be checked for authentication.
     return TRUE;
   }

--- a/plugins/authentication/RestfulAuthenticationBase.php
+++ b/plugins/authentication/RestfulAuthenticationBase.php
@@ -32,7 +32,7 @@ abstract class RestfulAuthenticationBase implements RestfulAuthenticationInterfa
   /**
    * {@inheritdoc}
    */
-  public function applies(array $request = array(), $method = \RestfulBase::GET) {
+  public function applies(array $request = array(), $method = \RestfulInterface::GET) {
     // By default assume that the request can be checked for authentication.
     return TRUE;
   }

--- a/plugins/authentication/RestfulAuthenticationBasic.class.php
+++ b/plugins/authentication/RestfulAuthenticationBasic.class.php
@@ -10,7 +10,7 @@ class RestfulAuthenticationBasic extends RestfulAuthenticationBase implements Re
   /**
    * {@inheritdoc}
    */
-  public function applies(array $request = array(), $method = \RestfulBase::GET) {
+  public function applies(array $request = array(), $method = \RestfulInterface::GET) {
     list($username, $password) = $this->getCredentials();
     return isset($username) && isset($password);
   }
@@ -20,7 +20,7 @@ class RestfulAuthenticationBasic extends RestfulAuthenticationBase implements Re
    *
    * @see user_login_authenticate_validate().
    */
-  public function authenticate(array $request = array(), $method = \RestfulBase::GET) {
+  public function authenticate(array $request = array(), $method = \RestfulInterface::GET) {
     list($username, $password) = $this->getCredentials();
 
     // Do not allow any login from the current user's IP if the limit has been

--- a/plugins/authentication/RestfulAuthenticationBasic.class.php
+++ b/plugins/authentication/RestfulAuthenticationBasic.class.php
@@ -10,7 +10,7 @@ class RestfulAuthenticationBasic extends RestfulAuthenticationBase implements Re
   /**
    * {@inheritdoc}
    */
-  public function applies($request = NULL, $method = 'get') {
+  public function applies(array $request = array(), $method = \RestfulBase::GET) {
     list($username, $password) = $this->getCredentials();
     return isset($username) && isset($password);
   }
@@ -20,7 +20,7 @@ class RestfulAuthenticationBasic extends RestfulAuthenticationBase implements Re
    *
    * @see user_login_authenticate_validate().
    */
-  public function authenticate($request = NULL, $method = 'get') {
+  public function authenticate(array $request = array(), $method = \RestfulBase::GET) {
     list($username, $password) = $this->getCredentials();
 
     // Do not allow any login from the current user's IP if the limit has been

--- a/plugins/authentication/RestfulAuthenticationCookie.class.php
+++ b/plugins/authentication/RestfulAuthenticationCookie.class.php
@@ -9,7 +9,7 @@ class RestfulAuthenticationCookie extends RestfulAuthenticationBase implements R
   /**
    * Implements RestfulAuthenticationInterface::authenticate().
    */
-  public function authenticate($request = NULL, $method = 'get') {
+  public function authenticate(array $request = array(), $method = \RestfulBase::GET) {
     if (!drupal_session_started() && !$this->isCli()) {
       return;
     }

--- a/plugins/authentication/RestfulAuthenticationCookie.class.php
+++ b/plugins/authentication/RestfulAuthenticationCookie.class.php
@@ -9,7 +9,7 @@ class RestfulAuthenticationCookie extends RestfulAuthenticationBase implements R
   /**
    * Implements RestfulAuthenticationInterface::authenticate().
    */
-  public function authenticate(array $request = array(), $method = \RestfulBase::GET) {
+  public function authenticate(array $request = array(), $method = \RestfulInterface::GET) {
     if (!drupal_session_started() && !$this->isCli()) {
       return;
     }

--- a/plugins/authentication/RestfulAuthenticationInterface.php
+++ b/plugins/authentication/RestfulAuthenticationInterface.php
@@ -18,14 +18,14 @@ interface RestfulAuthenticationInterface {
    * @return \stdClass|null
    *   The user object.
    */
-  public function authenticate($request = NULL, $method = 'get');
+  public function authenticate(array $request = array(), $method = \RestfulBase::GET);
 
   /**
    * Determines if the request can be checked for authentication. For example,
    * when authenticating with HTTP header, return FALSE if the header values do
    * not exist.
    *
-   * @param $request
+   * @param array $request
    *   The request.
    * @param string $method
    *   The HTTP method. Defaults to "get".
@@ -33,7 +33,7 @@ interface RestfulAuthenticationInterface {
    * @return bool
    *   TRUE if the request can be checked for authentication, FALSE otherwise.
    */
-  public function applies($request = NULL, $method = 'get');
+  public function applies(array $request = array(), $method = 'get');
 
   /**
    * Get the name of the authentication plugin.

--- a/plugins/authentication/RestfulAuthenticationInterface.php
+++ b/plugins/authentication/RestfulAuthenticationInterface.php
@@ -18,7 +18,7 @@ interface RestfulAuthenticationInterface {
    * @return \stdClass|null
    *   The user object.
    */
-  public function authenticate(array $request = array(), $method = \RestfulBase::GET);
+  public function authenticate(array $request = array(), $method = \RestfulInterface::GET);
 
   /**
    * Determines if the request can be checked for authentication. For example,

--- a/plugins/authentication/RestfulAuthenticationInterface.php
+++ b/plugins/authentication/RestfulAuthenticationInterface.php
@@ -33,7 +33,7 @@ interface RestfulAuthenticationInterface {
    * @return bool
    *   TRUE if the request can be checked for authentication, FALSE otherwise.
    */
-  public function applies(array $request = array(), $method = 'get');
+  public function applies(array $request = array(), $method = \RestfulInterface::GET);
 
   /**
    * Get the name of the authentication plugin.

--- a/plugins/authentication/RestfulAuthenticationManager.php
+++ b/plugins/authentication/RestfulAuthenticationManager.php
@@ -66,7 +66,7 @@ class RestfulAuthenticationManager extends \ArrayObject {
    * @return \stdClass
    *   The user object.
    */
-  public function getAccount(array $request = array(), $method = \RestfulBase::GET) {
+  public function getAccount(array $request = array(), $method = \RestfulInterface::GET) {
     global $user;
     // Return the previously resolved user, if any.
     if (!empty($this->account)) {

--- a/plugins/authentication/RestfulAuthenticationManager.php
+++ b/plugins/authentication/RestfulAuthenticationManager.php
@@ -66,7 +66,7 @@ class RestfulAuthenticationManager extends \ArrayObject {
    * @return \stdClass
    *   The user object.
    */
-  public function getAccount($request = NULL, $method = 'get') {
+  public function getAccount($request = NULL, $method = \RestfulBase::GET) {
     global $user;
     // Return the previously resolved user, if any.
     if (!empty($this->account)) {

--- a/plugins/authentication/RestfulAuthenticationManager.php
+++ b/plugins/authentication/RestfulAuthenticationManager.php
@@ -58,7 +58,7 @@ class RestfulAuthenticationManager extends \ArrayObject {
   /**
    * Get the user account for the request.
    *
-   * @param $request
+   * @param array $request
    *   The request.
    * @param string $method
    *   The HTTP method.
@@ -66,7 +66,7 @@ class RestfulAuthenticationManager extends \ArrayObject {
    * @return \stdClass
    *   The user object.
    */
-  public function getAccount($request = NULL, $method = \RestfulBase::GET) {
+  public function getAccount(array $request = array(), $method = \RestfulBase::GET) {
     global $user;
     // Return the previously resolved user, if any.
     if (!empty($this->account)) {

--- a/plugins/rate_limit/RestfulRateLimitInterface.php
+++ b/plugins/rate_limit/RestfulRateLimitInterface.php
@@ -16,5 +16,5 @@ interface RestfulRateLimitInterface {
    *   TRUE if the event is met and the rate limit hits counter should be
    *   incremented.
    */
-  public function isRequestedEvent($request = NULL);
+  public function isRequestedEvent(array $request = array());
 }

--- a/plugins/rate_limit/RestfulRateLimitRequest.class.php
+++ b/plugins/rate_limit/RestfulRateLimitRequest.class.php
@@ -10,7 +10,7 @@ class RestfulRateLimitRequest implements RestfulRateLimitInterface {
   /**
    * {@inheritdoc}
    */
-  public function isRequestedEvent($request = NULL) {
+  public function isRequestedEvent(array $request = array()) {
     return TRUE;
   }
 }

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1280,7 +1280,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
 
     if (empty($params['@fields'])) {
       // There was a validation error, but on non-public fields, so we need to
-      // throw an exception, but can say on which fields it coccured.
+      // throw an exception, but can't say on which fields it occurred.
       throw new \RestfulBadRequestException('Invalid value(s) sent with the request.');
     }
 

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -471,7 +471,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
       $this->getRateLimitManager()->checkRateLimit($request);
     }
 
-    return $this->{$method_name}();
+    return $this->{$method_name}($path);
   }
 
   /**

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -385,13 +385,13 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
    *
    * @param string $path
    *   (optional) The path.
-   * @param null $request
+   * @param array $request
    *   (optional) The request.
    *
    * @return mixed
    *   The return value can depend on the controller for the get method.
    */
-  public function get($path = '', $request = NULL) {
+  public function get($path = '', array $request = array()) {
     return $this->process($path, $request, \RestfulInterface::GET);
   }
 
@@ -400,13 +400,13 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
    *
    * @param string $path
    *   (optional) The path.
-   * @param null $request
+   * @param array $request
    *   (optional) The request.
    *
    * @return mixed
    *   The return value can depend on the controller for the post method.
    */
-  public function post($path = '', $request = NULL) {
+  public function post($path = '', array $request = array()) {
     return $this->process($path, $request, \RestfulInterface::POST);
   }
 
@@ -415,13 +415,13 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
    *
    * @param string $path
    *   (optional) The path.
-   * @param null $request
+   * @param array $request
    *   (optional) The request.
    *
    * @return mixed
    *   The return value can depend on the controller for the put method.
    */
-  public function put($path = '', $request = NULL) {
+  public function put($path = '', array $request = array()) {
     return $this->process($path, $request, \RestfulInterface::PUT);
   }
 
@@ -430,12 +430,12 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
    *
    * @param string $path
    *   (optional) The path.
-   * @param null $request
+   * @param array $request
    *   (optional) The request.
    * @return mixed
    *   The return value can depend on the controller for the patch method.
    */
-  public function patch($path = '', $request = NULL) {
+  public function patch($path = '', array $request = array()) {
     return $this->process($path, $request, \RestfulInterface::PATCH);
   }
 
@@ -444,20 +444,20 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
    *
    * @param string $path
    *   (optional) The path.
-   * @param null $request
+   * @param array $request
    *   (optional) The request.
    *
    * @return mixed
    *   The return value can depend on the controller for the delete method.
    */
-  public function delete($path = '', $request = NULL) {
+  public function delete($path = '', array $request = array()) {
     return $this->process($path, $request, \RestfulInterface::DELETE);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function process($path = '', $request = NULL, $method = \RestfulInterface::GET, $check_rate_limit = TRUE) {
+  public function process($path = '', array $request = array(), $method = \RestfulInterface::GET, $check_rate_limit = TRUE) {
     $this->setMethod($method);
     $this->setPath($path);
     $this->setRequest($request);

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -526,7 +526,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
 
     $entity_type = $this->entityType;
     $result = $this
-      ->getQueryForList($request, $account)
+      ->getQueryForList()
       ->execute();
 
 

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1133,21 +1133,26 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
       return $value;
     }
 
+    // Value is actually a sub request, so for clarity we will name it $request.
+    $request = $value;
+
     // Figure the method that should be used.
-    if (empty($value['id'])) {
+    if (empty($request['id'])) {
       $method_name = \RestfulInterface::POST;
       $path = '';
     }
     else {
       // Use PATCH by default, unless client has explicitly set the method in
       // the sub-resource.
-      $method_name = !empty($value['__application']['method']) ? strtoupper($value['__application']['method']) : \RestfulInterface::PATCH;
-      $path = $value['id'];
+      // As any request, under the the "__application" we may pass additional
+      // metadata.
+      $method_name = !empty($request['__application']['method']) ? strtoupper($request['__application']['method']) : \RestfulInterface::PATCH;
+      $path = $request['id'];
       // Unset the ID from the sub-request.
-      unset($value['id']);
+      unset($request['id']);
     }
 
-    $result = $handler->process($path, $value, $method_name, FALSE);
+    $result = $handler->process($path, $request, $method_name, FALSE);
     return $result['id'];
   }
 

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1143,6 +1143,8 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
       // the sub-resource.
       $method_name = !empty($value['__application']['method']) ? strtoupper($value['__application']['method']) : \RestfulInterface::PATCH;
       $path = $value['id'];
+      // Unset the ID from the sub-request.
+      unset($value['id']);
     }
 
     $result = $handler->process($path, $value, $method_name, FALSE);

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1113,9 +1113,11 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
 
     // Return the entity ID that was created.
     if ($field_info['cardinality'] == 1) {
+      // Single value.
       return $result['id'];
     }
 
+    // Multiple values.
     $return = array();
     foreach ($result as $row) {
       $return[] = $row['id'];

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -947,6 +947,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
    * @throws RestfulBadRequestException
    */
   protected function setPropertyValues(EntityMetadataWrapper $wrapper, $null_missing_fields = FALSE) {
+    $account = $this->getAccount();
     $request = $this->getRequest();
 
     static::cleanRequest($request);
@@ -972,7 +973,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
       }
 
       if (!$this->checkPropertyAccess($wrapper->{$property_name}, 'edit', $account)) {
-        throw new RestfulBadRequestException(format_string('Property @name cannot be set.', array('@name' => $public_property)));
+        throw new RestfulBadRequestException(format_string('Property @name cannot be set.', array('@name' => $public_field_name)));
       }
 
       $field_value = $this->propertyValuesPreprocess($property_name, $request[$public_field_name], $public_field_name);

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -656,6 +656,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
    * @throws Exception
    */
   public function viewEntity($entity_id) {
+    $account = $this->getAccount();
     $request = $this->getRequest();
 
     $cached_data = $this->getRenderedEntityCache($entity_id);

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1101,18 +1101,18 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
     $version = $this->getVersion();
     $handler = restful_get_restful_handler($resource_name, $version['major'], $version['minor']);
 
-    $result = $handler->process($this->getPath(), $value, $this->getMethod(), FALSE);
-
     // Return the entity ID that was created.
     if ($field_info['cardinality'] == 1) {
+      $result = $handler->process($this->getPath(), $value, $this->getMethod(), FALSE);
       // Single value.
       return $result['id'];
     }
 
     // Multiple values.
     $return = array();
-    foreach ($result as $row) {
-      $return[] = $row['id'];
+    foreach ($value as $value_item) {
+      $result = $handler->process($this->getPath(), $value_item, $this->getMethod(), FALSE);
+      $return[] = $result['id'];
     }
 
     return $return;
@@ -1243,6 +1243,12 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
 
       $map[$value['property']] = $field_name;
       $params['@fields'][] = $field_name;
+    }
+
+    if (empty($params['@fields'])) {
+      // There was a validation error, but on non-public fields, so we need to
+      // throw an exception, but can say on which fields it coccured.
+      throw new \RestfulBadRequestException('Invalid value(s) sent with the request.');
     }
 
     $params['@fields'] = implode(',', $params['@fields']);

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -206,14 +206,6 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
   }
 
   /**
-   * Clear the request and path.
-   */
-  public function clearRequestAndPath() {
-    $this->setRequest();
-    $this->setPath();
-  }
-
-  /**
    * Helper function to remove the application generated request data.
    *
    * @param &array $request

--- a/plugins/restful/RestfulEntityBaseMultipleBundles.php
+++ b/plugins/restful/RestfulEntityBaseMultipleBundles.php
@@ -56,6 +56,9 @@ class RestfulEntityBaseMultipleBundles extends RestfulEntityBase {
       return;
     }
 
+    $account = $this->getAccount();
+    $request = $this->getRequest();
+
     $ids = array_keys($result[$entity_type]);
 
     // Pre-load all entities.

--- a/plugins/restful/RestfulEntityBaseMultipleBundles.php
+++ b/plugins/restful/RestfulEntityBaseMultipleBundles.php
@@ -45,7 +45,7 @@ class RestfulEntityBaseMultipleBundles extends RestfulEntityBase {
   /**
    * Overrides RestfulEntityBase::getList().
    */
-  public function getList($request = NULL, stdClass $account = NULL) {
+  public function getList() {
     $entity_type = $this->entityType;
     $result = $this
       ->getQueryForList()

--- a/plugins/restful/RestfulEntityBaseMultipleBundles.php
+++ b/plugins/restful/RestfulEntityBaseMultipleBundles.php
@@ -48,7 +48,7 @@ class RestfulEntityBaseMultipleBundles extends RestfulEntityBase {
   public function getList($request = NULL, stdClass $account = NULL) {
     $entity_type = $this->entityType;
     $result = $this
-      ->getQueryForList($request, $account)
+      ->getQueryForList()
       ->execute();
 
 
@@ -84,8 +84,8 @@ class RestfulEntityBaseMultipleBundles extends RestfulEntityBase {
   /**
    * Overrides RestfulEntityBase::getQueryForList().
    */
-  public function getQueryForList($request, stdClass $account = NULL) {
-    $query = parent::getQueryForList($request, $account);
+  public function getQueryForList() {
+    $query = parent::getQueryForList();
     $query->entityCondition('bundle', array_keys($this->getBundles()), 'IN');
     return $query;
   }

--- a/plugins/restful/RestfulEntityBaseNode.php
+++ b/plugins/restful/RestfulEntityBaseNode.php
@@ -16,8 +16,8 @@ class RestfulEntityBaseNode extends RestfulEntityBase {
    *
    * Expose only published nodes.
    */
-  public function getQueryForList($request, stdClass $account = NULL) {
-    $query = parent::getQueryForList($request, $account);
+  public function getQueryForList() {
+    $query = parent::getQueryForList();
     $query->propertyCondition('status', NODE_PUBLISHED);
     return $query;
   }
@@ -27,13 +27,14 @@ class RestfulEntityBaseNode extends RestfulEntityBase {
    *
    * Set the node author and other defaults.
    */
-  public function entityPreSave($entity, $request, stdClass $account) {
-    if (!empty($entity->nid)) {
+  public function entityPreSave(\EntityMetadataWrapper $wrapper) {
+    $node = $wrapper->value();
+    if (!empty($node->nid)) {
       // Node is already saved.
       return;
     }
-    node_object_prepare($entity);
-    $entity->uid = $account->uid;
+    node_object_prepare($node);
+    $node->uid = $account->uid;
   }
 
 }

--- a/plugins/restful/RestfulEntityBaseNode.php
+++ b/plugins/restful/RestfulEntityBaseNode.php
@@ -34,7 +34,7 @@ class RestfulEntityBaseNode extends RestfulEntityBase {
       return;
     }
     node_object_prepare($node);
-    $node->uid = $account->uid;
+    $node->uid = $this->getAccount()->uid;
   }
 
 }

--- a/plugins/restful/RestfulInterface.php
+++ b/plugins/restful/RestfulInterface.php
@@ -44,7 +44,7 @@ interface RestfulInterface {
    * @param string $path
    *   The requested path.
    * @param array $request
-   *   The request array
+   *   The request array.
    * @param string $method
    *   The HTTP method.
    * @param bool $check_rate_limit
@@ -55,7 +55,7 @@ interface RestfulInterface {
    * @return mixed
    *   The return value can depend on the controller for the current $method.
    */
-  public function process($path = '', $request = NULL, $method = \RestfulInterface::GET, $check_rate_limit = TRUE);
+  public function process($path = '', array $request = array(), $method = \RestfulInterface::GET, $check_rate_limit = TRUE);
 
   /**
    * Return the properties that should be public.

--- a/plugins/restful/RestfulInterface.php
+++ b/plugins/restful/RestfulInterface.php
@@ -47,11 +47,15 @@ interface RestfulInterface {
    *   The request array
    * @param string $method
    *   The HTTP method.
+   * @param bool $check_rate_limit
+   *   Determines if rate limit should be checked. This could be set to FALSE
+   *   for example when inside a recursion, and we don't want to cout multiple
+   *   times the same request. Defautls to TRUE.
    *
    * @return mixed
    *   The return value can depend on the controller for the current $method.
    */
-  public function process($path = '', $request = NULL, $method = \RestfulInterface::GET);
+  public function process($path = '', $request = NULL, $method = \RestfulInterface::GET, $check_rate_limit = TRUE);
 
   /**
    * Return the properties that should be public.

--- a/plugins/restful/file/files_upload/1.0/RestfulFilesUpload.class.php
+++ b/plugins/restful/file/files_upload/1.0/RestfulFilesUpload.class.php
@@ -54,7 +54,7 @@ class RestfulFilesUpload extends \RestfulEntityBase {
    *
    * @throws \Exception
    */
-  public function createEntity($request = NULL, stdClass $account = NULL) {
+  public function createEntity() {
     if (!$_FILES) {
       throw new \RestfulBadRequestException('No files sent with the request.');
     }

--- a/plugins/restful/file/files_upload/1.0/RestfulFilesUpload.class.php
+++ b/plugins/restful/file/files_upload/1.0/RestfulFilesUpload.class.php
@@ -85,7 +85,7 @@ class RestfulFilesUpload extends \RestfulEntityBase {
     }
 
     foreach ($ids as $id) {
-      $return['list'][] = $this->viewEntity($id, $request, $account);
+      $return['list'][] = $this->viewEntity($id);
     }
 
     return $return;

--- a/plugins/restful/user/login_cookie/1.0/RestfulUserLoginCookie.class.php
+++ b/plugins/restful/user/login_cookie/1.0/RestfulUserLoginCookie.class.php
@@ -36,7 +36,7 @@ class RestfulUserLoginCookie extends \RestfulEntityBase {
     $version = $this->getVersion();
     $handler = restful_get_restful_handler('users', $version['major'], $version['minor']);
 
-    return $handler->viewEntity($account->uid, $request, $account);
+    return $handler->viewEntity($account->uid);
   }
 
   /**

--- a/plugins/restful/user/login_cookie/1.0/RestfulUserLoginCookie.class.php
+++ b/plugins/restful/user/login_cookie/1.0/RestfulUserLoginCookie.class.php
@@ -21,16 +21,12 @@ class RestfulUserLoginCookie extends \RestfulEntityBase {
   /**
    * Login a user and return a JSON along with the authentication cookie.
    *
-   * @param array $request
-   *   (optional) The request.
-   * @param stdClass $account
-   *   (optional) The user object.
-   *
    * @return array
    *   Array with the public fields populated.
    */
-  public function loginAndRespondWithCookie($request = NULL, stdClass $account = NULL) {
+  public function loginAndRespondWithCookie() {
     // Login the user.
+    $account = $this->getAccount();
     $this->loginUser($account);
 
     $version = $this->getVersion();

--- a/plugins/restful/user/user/1.0/RestfulEntityBaseUser.class.php
+++ b/plugins/restful/user/user/1.0/RestfulEntityBaseUser.class.php
@@ -28,11 +28,12 @@ class RestfulEntityBaseUser extends \RestfulEntityBase {
    *
    * Make sure only privileged users may see a list of users.
    */
-  public function getList($request = NULL, stdClass $account = NULL) {
+  public function getList() {
+    $account = $this->getAccount();
     if (!user_access('administer users', $account) && !user_access('access user profiles', $account)) {
       throw new \RestfulForbiddenException('You do not have access to listing of users.');
     }
-    return parent::getList($request, $account);
+    return parent::getList();
   }
 
   /**
@@ -40,8 +41,8 @@ class RestfulEntityBaseUser extends \RestfulEntityBase {
    *
    * Skip the anonymous user in listing.
    */
-  public function getQueryForList($request, stdClass $account = NULL) {
-    $query = parent::getQueryForList($request, $account);
+  public function getQueryForList() {
+    $query = parent::getQueryForList();
     $query->entityCondition('entity_id', 0, '>');
     return $query;
   }

--- a/restful.info
+++ b/restful.info
@@ -48,6 +48,7 @@ files[] = tests/RestfulListTestCase.test
 files[] = tests/RestfulRateLimitTestCase.test
 files[] = tests/RestfulRenderCacheTestCase.test
 files[] = tests/RestfulUpdateEntityTestCase.test
+files[] = tests/RestfulSubResourcesCreateEntityTestCase.test
 files[] = tests/RestfulUpdateEntityCurlTestCase.test
 files[] = tests/RestfulUserLoginCookieTestCase.test
 files[] = tests/RestfulViewEntityTestCase.test

--- a/tests/RestfulEntityAndPropertyAccessTestCase.test
+++ b/tests/RestfulEntityAndPropertyAccessTestCase.test
@@ -17,26 +17,6 @@ class RestfulEntityAndPropertyAccessTestCase extends DrupalWebTestCase {
 
   function setUp() {
     parent::setUp('restful_test');
-
-    // Text - single.
-    $field = array(
-      'field_name' => 'text_single',
-      'type' => 'text_long',
-      'entity_types' => array('node'),
-      'cardinality' => 1,
-    );
-    field_create_field($field);
-
-    $instance = array(
-      'field_name' => 'text_single',
-      'bundle' => 'article',
-      'entity_type' => 'node',
-      'label' => t('Text single'),
-      'settings' => array(
-        'text_processing' => 1,
-      ),
-    );
-    field_create_instance($instance);
   }
 
   /**
@@ -72,7 +52,7 @@ class RestfulEntityAndPropertyAccessTestCase extends DrupalWebTestCase {
     // Privileged user, with limited access to property, and that property
     // passed in the request.
     $text1 = $this->randomName();
-    $request['text_single'] = $text1;
+    $request['body'] = $text1;
 
     try {
       $handler->setAccount($user1);
@@ -131,7 +111,7 @@ class RestfulEntityAndPropertyAccessTestCase extends DrupalWebTestCase {
     // Privileged user, with limited access to property, and that property
     // passed in the request.
     $text1 = $this->randomName();
-    $request['text_single'] = $text1;
+    $request['body'] = $text1;
 
     try {
       $handler->setAccount($user1);
@@ -159,7 +139,7 @@ class RestfulEntityAndPropertyAccessTestCase extends DrupalWebTestCase {
     $wrapper = entity_metadata_wrapper('node' ,$node1);
 
     $text1 = $this->randomName();
-    $wrapper->text_single->set(array('value' => $text1));
+    $wrapper->body->set(array('value' => $text1));
     $wrapper->save();
 
     $handler = restful_get_restful_handler('test_articles');
@@ -167,13 +147,13 @@ class RestfulEntityAndPropertyAccessTestCase extends DrupalWebTestCase {
     // Privileged user.
     $handler->setAccount($user1);
     $result = $handler->get($node1->nid, array());
-    $this->assertTrue($result['text_single'], 'Privileged user can view entity.');
+    $this->assertTrue($result['body'], 'Privileged user can view entity.');
 
     // Privileged user, with limited access to property.
     restful_test_deny_access_field();
     $handler->setAccount($user1);
     $result = $handler->get($node1->nid, array());
-    $this->assertTrue(!isset($result['text_single']), 'Privileged user can view entity but without unaccessible properties.');
+    $this->assertTrue(!isset($result['body']), 'Privileged user can view entity but without unaccessible properties.');
     restful_test_clear_access();
 
     // Non-privileged user (Revoke "access content" permission).

--- a/tests/RestfulEntityValidatorTestCase.test
+++ b/tests/RestfulEntityValidatorTestCase.test
@@ -16,7 +16,7 @@ class RestfulEntityValidatorTestCase extends RestfulCurlBaseTestCase {
   }
 
   function setUp() {
-    parent::setUp('restful_example', 'entity_validator_example');
+    parent::setUp('restful_test', 'entity_validator_example');
   }
 
   /**
@@ -26,8 +26,8 @@ class RestfulEntityValidatorTestCase extends RestfulCurlBaseTestCase {
     // Allow anonymous user to create article content.
     user_role_change_permissions(DRUPAL_ANONYMOUS_RID, array('create article content' => TRUE));
 
-    $request = array('label' => 'no');
-    $result = $this->httpRequest('api/v1/articles', \RestfulInterface::POST, $request);
+    $request = array('label' => 'no', 'body' => 'Text with Drupal');
+    $result = $this->httpRequest('api/v1/test_articles', \RestfulInterface::POST, $request);
 
     $expected_result = array(
       'label' => array(
@@ -37,10 +37,10 @@ class RestfulEntityValidatorTestCase extends RestfulCurlBaseTestCase {
 
     $body = drupal_json_decode($result['body']);
     $this->assertEqual($result['code'], 400, 'Too short title caused a "Bad request" error.');
-    $this->assertEqual($body['fields'], $expected_result, 'Correct error message passed in the JSON');
+    $this->assertEqual($body['errors'], $expected_result, 'Correct error message passed in the JSON');
 
-    $request = array('label' => 'yes');
-    $result = $this->httpRequest('api/v1/articles', \RestfulInterface::POST, $request);
+    $request['label'] = 'yes';
+    $result = $this->httpRequest('api/v1/test_articles', \RestfulInterface::POST, $request);
     $this->assertEqual($result['code'], 200, 'Entity with proper title length passed validation.');
   }
 }

--- a/tests/RestfulEntityValidatorTestCase.test
+++ b/tests/RestfulEntityValidatorTestCase.test
@@ -23,11 +23,22 @@ class RestfulEntityValidatorTestCase extends RestfulCurlBaseTestCase {
    * Test entity validator.
    */
   function testEntityValidator() {
-    // Allow anonymous user to create article content.
-    user_role_change_permissions(DRUPAL_ANONYMOUS_RID, array('create article content' => TRUE));
+    $user1 = $this->drupalCreateUser(array('create article content'));
+    $this->drupalLogin($user1);
+
+    $handler = restful_get_restful_handler('test_articles');
+    $handler->setAccount($user1);
 
     $request = array('label' => 'no', 'body' => 'Text with Drupal');
-    $result = $this->httpRequest('api/v1/test_articles', \RestfulInterface::POST, $request);
+
+    try {
+      $handler->post('', $request);
+      $this->fail('Too short title did not cause a "Bad request" error.');
+    }
+    catch (\RestfulBadRequestException $e) {
+      $field_errors = $e->getFieldErrors();
+      $this->pass('Too short title did not caused a "Bad request" error.');
+    }
 
     $expected_result = array(
       'label' => array(
@@ -35,12 +46,10 @@ class RestfulEntityValidatorTestCase extends RestfulCurlBaseTestCase {
       ),
     );
 
-    $body = drupal_json_decode($result['body']);
-    $this->assertEqual($result['code'], 400, 'Too short title caused a "Bad request" error.');
-    $this->assertEqual($body['errors'], $expected_result, 'Correct error message passed in the JSON');
+    $this->assertEqual($field_errors, $expected_result, 'Correct error message passed in the JSON');
 
     $request['label'] = 'yes';
-    $result = $this->httpRequest('api/v1/test_articles', \RestfulInterface::POST, $request);
-    $this->assertEqual($result['code'], 200, 'Entity with proper title length passed validation.');
+    $result = $handler->post('', $request);
+    $this->assertTrue($result['id'], 'Entity with proper title length passed validation and was created.');
   }
 }

--- a/tests/RestfulEntityValidatorTestCase.test
+++ b/tests/RestfulEntityValidatorTestCase.test
@@ -12,7 +12,6 @@ class RestfulEntityValidatorTestCase extends RestfulCurlBaseTestCase {
       'name' => 'Entity validator',
       'description' => 'Test integration with entity validator module.',
       'group' => 'Restful',
-      'dependencies' => array('entity_validator'),
     );
   }
 

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -171,8 +171,8 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
     $handler = $this->handler;
     $result = $handler->{$method}($path, $request);
     $this->assertTrue($result['id'], 'Parent entity created.');
-    $this->assertTrue($result['entity_reference_single']['id'], 'Single sub-resource created.');
-    $this->assertTrue($result['entity_reference_multiple'][0]['id'] && $result['entity_reference_multiple'][1]['id'], 'Multiple sub-resource created.');
+    $this->assertTrue($result['entity_reference_single']['id'], 'Single sub-resource created or updated.');
+    $this->assertTrue($result['entity_reference_multiple'][0]['id'] && $result['entity_reference_multiple'][1]['id'], 'Multiple sub-resource created or updated.');
 
     // Validation fail on the parent.
     $request['label'] = 'no';

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -82,19 +82,19 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
     $handler = $this->handler;
     $request = array(
       'label' => 'parent',
-      'body' => 'Gizra',
+      'body' => 'Drupal',
       'entity_reference_single' => array(
         'label' => 'child1',
-        'body' => 'Gizra1',
+        'body' => 'Drupal1',
       ),
       'entity_reference_multiple' => array(
         array(
           'label' => 'child2',
-          'body' => 'Gizra2',
+          'body' => 'Drupal2',
         ),
         array(
           'label' => 'child3',
-          'body' => 'Gizra3',
+          'body' => 'Drupal3',
         ),
       ),
     );

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -19,7 +19,6 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
       'name' => 'Sub requests',
       'description' => 'Test the creation of sub-resources (referenced entities) via sub requests.',
       'group' => 'Restful',
-      'dependencies' => array('entity_validator'),
     );
   }
 

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -79,8 +79,7 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
    * Test creating an entity with sub-resources.
    */
   function testCreateEntity() {
-    $handler = $this->handler;
-    $request = array(
+    $base_request = $request = array(
       'label' => 'parent',
       'body' => 'Drupal',
       'entity_reference_single' => array(
@@ -98,7 +97,76 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
         ),
       ),
     );
-    $result = $handler->post('', $request);
+
+    // POST parent
+    $this->processRequests('post', '', $request);
+
+    // PUT/ PATCH parent.
+    $settings = array(
+      'type' => 'article',
+      'title' => 'title1',
+    );
+    $node1 = $this->drupalCreateNode();
+    $request = $base_request;
+
+    foreach (array('put', 'patch') as $method) {
+      $this->processRequests($method, $node1->nid, $request);
+    }
+
+
+    // POST parent, reference existing on single reference, multiple reference
+    // empty.
+    $request = $base_request;
+    $request['entity_reference_single'] = $node1->nid;
+    unset($request['entity_reference_multiple']);
+    $this->processRequests($method, $node1->nid, $request);
+
+    // POST parent, reference existing on multiple reference, POST a new one,
+    // PATCH existing one, and PUT existing one.
+    $node2 = $this->drupalCreateNode();
+    $node3 = $this->drupalCreateNode();
+    $node4 = $this->drupalCreateNode();
+
+    $request = $base_request;
+    $request['entity_reference_multiple'] = array(
+      $node2->nid,
+      array(
+        'label' => 'post new one',
+        'body' => 'Drupal',
+      ),
+      array(
+        'id' => $node3->nid,
+        'label' => 'Patch existing one',
+        'body' => 'Drupal',
+      ),
+      array(
+        // Explicetly set the method.
+        '__application' => array(
+          'method' => 'put',
+        ),
+        'id' => $node3->nid,
+        'label' => 'Patch existing one',
+        'body' => 'Drupal',
+      ),
+    );
+
+    unset($request['entity_reference_single']);
+    $this->processRequests($method, $node1->nid, $request);
+  }
+
+  /**
+   * Assert valid and invalid requests.
+   *
+   * @param string $method
+   *   The method name.
+   * @param string $path
+   *   The path.
+   * @param array $request
+   *   The request array.
+   */
+  protected function processRequests($method = 'post', $path = '', array $request = array()) {
+    $handler = $this->handler;
+    $result = $handler->{$method}($path, $request);
     $this->assertTrue($result['id'], 'Parent entity created.');
     $this->assertTrue($result['entity_reference_single']['id'], 'Single sub-resource created.');
     $this->assertTrue($result['entity_reference_multiple'][0]['id'] && $result['entity_reference_multiple'][1]['id'], 'Multiple sub-resource created.');
@@ -120,15 +188,20 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Validate an invalid request fails.
+   * Assert an invalid request fails.
    *
+   * @param string $method
+   *   The method name.
+   * @param string $path
+   *   The path.
    * @param array $request
    *   The request array.
    */
-  protected function assertInvalidRequest(array $request = array()) {
+  protected function assertInvalidRequest($method = 'post', $path = '', array $request = array()) {
+
     $handler = $this->handler;
     try {
-      $handler->post('', $request);
+      $handler->{$method}($path, $request);
       $this->fail('No exception thrown on validation fail on the parent.');
     }
     catch (\RestfulBadRequestException $e) {

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -75,9 +75,9 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Test creating an entity with sub-resources.
+   * Test creating and updating an entity with sub-resources.
    */
-  function testCreateEntity() {
+  function testCreateAndUpdateEntity() {
     $base_request = $request = array(
       'label' => 'parent',
       'body' => 'Drupal',

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -110,7 +110,7 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
     $request = $base_request;
 
     foreach (array('put', 'patch') as $method) {
-      $this->processRequests($method, $node1->nid, $request);
+       $this->processRequests($method, $node1->nid, $request);
     }
 
     // POST parent, reference existing on single reference, multiple reference
@@ -123,10 +123,11 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
 
     $request = $base_request;
     $request['entity_reference_single'] = $node1->nid;
-    $this->processRequests('post', '', $request);
     $request['entity_reference_multiple'] = array(
       $node2->nid,
+      $node3->nid,
     );
+    $this->processRequests('post', '', $request);
 
     // POST parent, reference existing on multiple reference, POST a new one,
     // PATCH existing one, and PUT existing one.
@@ -135,12 +136,12 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
     $request['entity_reference_multiple'] = array(
       $node3->nid,
       array(
-        'label' => 'post new one',
+        'label' => 'POST new one',
         'body' => 'Drupal',
       ),
       array(
         'id' => $node4->nid,
-        'label' => 'Patch existing one',
+        'label' => 'PATCH existing one',
         'body' => 'Drupal',
       ),
       array(
@@ -149,7 +150,7 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
           'method' => 'put',
         ),
         'id' => $node5->nid,
-        'label' => 'Patch existing one',
+        'label' => 'PUT existing one',
         'body' => 'Drupal',
       ),
     );
@@ -181,13 +182,19 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
 
     // Validation fail on the single resource.
     $request['label'] = 'parent';
-    $request['entity_reference_single']['label'] = 'no';
-    $this->assertInvalidRequest($method, $path, $request);
+
+    if (is_array($request['entity_reference_single'])) {
+      $request['entity_reference_single']['label'] = 'no';
+      $this->assertInvalidRequest($method, $path, $request);
+      $request['entity_reference_single']['label'] = 'child1';
+    }
+
 
     // Validation fail on the multiple resource.
-    $request['entity_reference_single']['label'] = 'child1';
-    $request['entity_reference_multiple'][0]['label'] = 'no';
-    $this->assertInvalidRequest($method, $path, $request);
+    if (is_array($request['entity_reference_multiple'][0]['label'])) {
+      $request['entity_reference_multiple'][0]['label'] = 'no';
+      $this->assertInvalidRequest($method, $path, $request);
+    }
   }
 
   /**

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulSubResourcesCreateEntityTestCase.
+ */
+
+class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
+
+  /**
+   * Hold the RESTful handler.
+   *
+   * @var RestfulInterface | NULL
+   */
+  protected $handler = NULL;
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Create Sub resources',
+      'description' => 'Test the creation of sub-resources (referenced entities).',
+      'group' => 'Restful',
+      'dependencies' => array('entity_validator_example'),
+    );
+  }
+
+  function setUp() {
+    parent::setUp('restful_example', 'entityreference', 'entity_validator_example');
+
+    // Entity reference - single.
+    $field = array(
+      'entity_types' => array('node'),
+      'settings' => array(
+        'handler' => 'base',
+        'target_type' => 'node',
+        'handler_settings' => array(),
+      ),
+      'field_name' => 'entity_reference_single',
+      'type' => 'entityreference',
+      'cardinality' => 1,
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'entity_type' => 'node',
+      'field_name' => 'entity_reference_single',
+      'bundle' => 'article',
+      'label' => t('Entity reference single'),
+    );
+
+    field_create_instance($instance);
+
+    // Entity reference - multiple.
+    $field = array(
+      'entity_types' => array('node'),
+      'settings' => array(
+        'handler' => 'base',
+        'target_type' => 'node',
+        'handler_settings' => array(),
+      ),
+      'field_name' => 'entity_reference_multiple',
+      'type' => 'entityreference',
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'entity_type' => 'node',
+      'field_name' => 'entity_reference_multiple',
+      'bundle' => 'article',
+      'label' => t('Entity reference multiple'),
+    );
+
+    field_create_instance($instance);
+
+    $this->handler = restful_get_restful_handler('test_articles', 1, 2);
+  }
+
+  /**
+   * Test creating an entity with sub-resources.
+   */
+  function testCreateEntity() {
+    $handler = $this->handler;
+    $request = array(
+      'label' => 'parent',
+      'body' => 'Gizra',
+      'entity_reference_single' => array(
+        'label' => 'child1',
+        'body' => 'Gizra1',
+      ),
+      'entity_reference_multiple' => array(
+        array(
+          'label' => 'child2',
+          'body' => 'Gizra2',
+        ),
+        array(
+          'label' => 'child3',
+          'body' => 'Gizra3',
+        ),
+      ),
+    );
+    $result = $handler->post('', $request);
+    $this->assertTrue($result['id'], 'Parent entity created.');
+    $this->assertTrue($result['entity_reference_single']['id'], 'Single sub-resource created.');
+    $this->assertTrue($result['entity_reference_multiple'][0]['id'] && $result['entity_reference_multiple'][1]['id'], 'Multiple sub-resource created.');
+
+    // Validation fail on the parent.
+    $request['label'] = 'no';
+    $this->assertInvalidRequest($request);
+
+
+    // Validation fail on the single resource.
+    $request['label'] = 'parent';
+    $request['entity_reference_single']['label'] = 'no';
+    $this->assertInvalidRequest($request);
+
+    // Validation fail on the multiple resource.
+    $request['entity_reference_single']['label'] = 'child1';
+    $request['entity_reference_multiple'][0]['label'] = 'no';
+    $this->assertInvalidRequest($request);
+  }
+
+  /**
+   * Validate an invalid request fails.
+   *
+   * @param array $request
+   *   The request array.
+   */
+  protected function assertInvalidRequest(array $request = array()) {
+    $handler = $this->handler;
+    try {
+      $handler->post('', $request);
+      $this->fail('No exception thrown on validation fail on the parent.');
+    }
+    catch (\RestfulBadRequestException $e) {
+      $this->fail('Correct exception thrown on validation fail on the parent.');
+    }
+    catch (\Exception $e) {
+      $this->fail('Wrong exception thrown on validation fail on the parent.');
+    }
+  }
+}

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -19,7 +19,7 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
       'name' => 'Create Sub resources',
       'description' => 'Test the creation of sub-resources (referenced entities).',
       'group' => 'Restful',
-      'dependencies' => array('entity_validator_example'),
+      'dependencies' => array('entity_validator'),
     );
   }
 

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -113,43 +113,47 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
       $this->processRequests($method, $node1->nid, $request);
     }
 
-
     // POST parent, reference existing on single reference, multiple reference
     // empty.
+
+    $node2 = $this->drupalCreateNode($settings);
+    $node3 = $this->drupalCreateNode($settings);
+    $node4 = $this->drupalCreateNode($settings);
+    $node5 = $this->drupalCreateNode($settings);
+
     $request = $base_request;
     $request['entity_reference_single'] = $node1->nid;
-    unset($request['entity_reference_multiple']);
-    $this->processRequests($method, $node1->nid, $request);
+    $this->processRequests('post', '', $request);
+    $request['entity_reference_multiple'] = array(
+      $node2->nid,
+    );
 
     // POST parent, reference existing on multiple reference, POST a new one,
     // PATCH existing one, and PUT existing one.
-    $node2 = $this->drupalCreateNode($settings);
-    $node3 = $this->drupalCreateNode($settings);
-
     $request = $base_request;
+    $request['entity_reference_single'] = $node2->nid;
     $request['entity_reference_multiple'] = array(
-      $node2->nid,
+      $node3->nid,
       array(
         'label' => 'post new one',
         'body' => 'Drupal',
       ),
       array(
-        'id' => $node3->nid,
+        'id' => $node4->nid,
         'label' => 'Patch existing one',
         'body' => 'Drupal',
       ),
       array(
-        // Explicetly set the method.
+        // Explicitly set the method.
         '__application' => array(
           'method' => 'put',
         ),
-        'id' => $node3->nid,
+        'id' => $node5->nid,
         'label' => 'Patch existing one',
         'body' => 'Drupal',
       ),
     );
 
-    unset($request['entity_reference_single']);
     $this->processRequests($method, $node1->nid, $request);
   }
 

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -132,7 +132,7 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
       $this->fail('No exception thrown on validation fail on the parent.');
     }
     catch (\RestfulBadRequestException $e) {
-      $this->fail('Correct exception thrown on validation fail on the parent.');
+      $this->pass('Correct exception thrown on validation fail on the parent.');
     }
     catch (\Exception $e) {
       $this->fail('Wrong exception thrown on validation fail on the parent.');

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -24,7 +24,7 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
   }
 
   function setUp() {
-    parent::setUp('restful_example', 'entityreference', 'entity_validator_example');
+    parent::setUp('restful_test', 'entity_validator_example');
 
     // Entity reference - single.
     $field = array(

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -106,7 +106,7 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
       'type' => 'article',
       'title' => 'title1',
     );
-    $node1 = $this->drupalCreateNode();
+    $node1 = $this->drupalCreateNode($settings);
     $request = $base_request;
 
     foreach (array('put', 'patch') as $method) {
@@ -123,9 +123,8 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
 
     // POST parent, reference existing on multiple reference, POST a new one,
     // PATCH existing one, and PUT existing one.
-    $node2 = $this->drupalCreateNode();
-    $node3 = $this->drupalCreateNode();
-    $node4 = $this->drupalCreateNode();
+    $node2 = $this->drupalCreateNode($settings);
+    $node3 = $this->drupalCreateNode($settings);
 
     $request = $base_request;
     $request['entity_reference_multiple'] = array(

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -10,7 +10,7 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
   /**
    * Hold the RESTful handler.
    *
-   * @var RestfulInterface | NULL
+   * @var RestfulInterface
    */
   protected $handler = NULL;
 

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -16,8 +16,8 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
 
   public static function getInfo() {
     return array(
-      'name' => 'Create Sub resources',
-      'description' => 'Test the creation of sub-resources (referenced entities).',
+      'name' => 'Sub requests',
+      'description' => 'Test the creation of sub-resources (referenced entities) via sub requests.',
       'group' => 'Restful',
       'dependencies' => array('entity_validator'),
     );
@@ -173,18 +173,18 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
 
     // Validation fail on the parent.
     $request['label'] = 'no';
-    $this->assertInvalidRequest($request);
+    $this->assertInvalidRequest($method, $path, $request);
 
 
     // Validation fail on the single resource.
     $request['label'] = 'parent';
     $request['entity_reference_single']['label'] = 'no';
-    $this->assertInvalidRequest($request);
+    $this->assertInvalidRequest($method, $path, $request);
 
     // Validation fail on the multiple resource.
     $request['entity_reference_single']['label'] = 'child1';
     $request['entity_reference_multiple'][0]['label'] = 'no';
-    $this->assertInvalidRequest($request);
+    $this->assertInvalidRequest($method, $path, $request);
   }
 
   /**

--- a/tests/RestfulUpdateEntityCurlTestCase.test
+++ b/tests/RestfulUpdateEntityCurlTestCase.test
@@ -25,26 +25,6 @@ class RestfulUpdateEntityCurlTestCase extends RestfulCurlBaseTestCase {
   function setUp() {
     parent::setUp('restful_test');
 
-    // Text - single.
-    $field = array(
-      'field_name' => 'text_single',
-      'type' => 'text_long',
-      'entity_types' => array('node'),
-      'cardinality' => 1,
-    );
-    field_create_field($field);
-
-    $instance = array(
-      'field_name' => 'text_single',
-      'bundle' => 'article',
-      'entity_type' => 'node',
-      'label' => t('Text single'),
-      'settings' => array(
-        'text_processing' => 0,
-      ),
-    );
-    field_create_instance($instance);
-
     $this->account = $this->drupalCreateUser(array(
       'administer site configuration',
       'administer nodes',
@@ -69,7 +49,7 @@ class RestfulUpdateEntityCurlTestCase extends RestfulCurlBaseTestCase {
       'type' => 'article',
       'title' => $label,
     );
-    $settings['text_single'][LANGUAGE_NONE][0]['value'] = $text;
+    $settings['body'][LANGUAGE_NONE][0]['value'] = $text;
 
     $node = $this->drupalCreateNode($settings);
     $id = $node->nid;
@@ -82,7 +62,7 @@ class RestfulUpdateEntityCurlTestCase extends RestfulCurlBaseTestCase {
       'id' => $id,
       'label' => $new_label,
       'self' => url('node/' . $id, array('absolute' => TRUE)),
-      'text_single' => NULL,
+      'body' => NULL,
     );
 
     $this->assertEqual($result['body'], drupal_json_encode($expected_result));
@@ -106,7 +86,7 @@ class RestfulUpdateEntityCurlTestCase extends RestfulCurlBaseTestCase {
       'type' => 'article',
       'title' => $label,
     );
-    $settings['text_single'][LANGUAGE_NONE][0]['value'] = $text;
+    $settings['body'][LANGUAGE_NONE][0]['value'] = $text;
 
     $node = $this->drupalCreateNode($settings);
     $id = $node->nid;
@@ -117,7 +97,7 @@ class RestfulUpdateEntityCurlTestCase extends RestfulCurlBaseTestCase {
       'id' => $id,
       'label' => $new_label,
       'self' => url('node/' . $id, array('absolute' => TRUE)),
-      'text_single' => $text,
+      'body' => $text,
     );
 
     $this->assertEqual($result['body'], drupal_json_encode($expected_result));

--- a/tests/RestfulUpdateEntityCurlTestCase.test
+++ b/tests/RestfulUpdateEntityCurlTestCase.test
@@ -97,7 +97,7 @@ class RestfulUpdateEntityCurlTestCase extends RestfulCurlBaseTestCase {
       'id' => $id,
       'label' => $new_label,
       'self' => url('node/' . $id, array('absolute' => TRUE)),
-      'body' => $text,
+      'body' => '<p>' . $text . '</p>',
     );
 
     $this->assertEqual($result['body'], drupal_json_encode($expected_result));

--- a/tests/RestfulUpdateEntityCurlTestCase.test
+++ b/tests/RestfulUpdateEntityCurlTestCase.test
@@ -99,9 +99,11 @@ class RestfulUpdateEntityCurlTestCase extends RestfulCurlBaseTestCase {
       'self' => url('node/' . $id, array('absolute' => TRUE)),
       'body' => $text,
     );
-    $result['body']['body'] = trim(strip_tags($result['body']['body']));
 
-    $this->assertEqual($result['body'], drupal_json_encode($expected_result));
+    $result = drupal_json_decode($result['body']);
+    $result['body'] = trim(strip_tags($result['body']));
+
+    $this->assertEqual($result, $expected_result);
 
     // Update an entity with invalid property name.
     $request['invalid'] = 'wrong';

--- a/tests/RestfulUpdateEntityCurlTestCase.test
+++ b/tests/RestfulUpdateEntityCurlTestCase.test
@@ -97,8 +97,9 @@ class RestfulUpdateEntityCurlTestCase extends RestfulCurlBaseTestCase {
       'id' => $id,
       'label' => $new_label,
       'self' => url('node/' . $id, array('absolute' => TRUE)),
-      'body' => '<p>' . $text . '</p>',
+      'body' => $text,
     );
+    $result['body']['body'] = trim(strip_tags($result['body']['body']));
 
     $this->assertEqual($result['body'], drupal_json_encode($expected_result));
 

--- a/tests/RestfulUpdateEntityTestCase.test
+++ b/tests/RestfulUpdateEntityTestCase.test
@@ -17,26 +17,6 @@ class RestfulUpdateEntityTestCase extends DrupalWebTestCase {
 
   function setUp() {
     parent::setUp('restful_test');
-
-    // Text - single.
-    $field = array(
-      'field_name' => 'text_single',
-      'type' => 'text_long',
-      'entity_types' => array('node'),
-      'cardinality' => 1,
-    );
-    field_create_field($field);
-
-    $instance = array(
-      'field_name' => 'text_single',
-      'bundle' => 'article',
-      'entity_type' => 'node',
-      'label' => t('Text single'),
-      'settings' => array(
-        'text_processing' => 0,
-      ),
-    );
-    field_create_instance($instance);
   }
 
   /**
@@ -52,7 +32,7 @@ class RestfulUpdateEntityTestCase extends DrupalWebTestCase {
       'type' => 'article',
       'title' => $label,
     );
-    $settings['text_single'][LANGUAGE_NONE][0]['value'] = $text;
+    $settings['body'][LANGUAGE_NONE][0]['value'] = $text;
 
     $node = $this->drupalCreateNode($settings);
     $id = $node->nid;
@@ -65,7 +45,7 @@ class RestfulUpdateEntityTestCase extends DrupalWebTestCase {
       'id' => $id,
       'label' => $new_label,
       'self' => url('node/' . $id, array('absolute' => TRUE)),
-      'text_single' => NULL,
+      'body' => NULL,
     );
 
     $this->assertEqual($result, $expected_result);
@@ -94,7 +74,7 @@ class RestfulUpdateEntityTestCase extends DrupalWebTestCase {
       'type' => 'article',
       'title' => $label,
     );
-    $settings['text_single'][LANGUAGE_NONE][0]['value'] = $text;
+    $settings['body'][LANGUAGE_NONE][0]['value'] = $text;
 
     $node = $this->drupalCreateNode($settings);
     $id = $node->nid;
@@ -107,7 +87,7 @@ class RestfulUpdateEntityTestCase extends DrupalWebTestCase {
       'id' => $id,
       'label' => $new_label,
       'self' => url('node/' . $id, array('absolute' => TRUE)),
-      'text_single' => $text,
+      'body' => $text,
     );
 
     $this->assertEqual($result, $expected_result);

--- a/tests/RestfulUpdateEntityTestCase.test
+++ b/tests/RestfulUpdateEntityTestCase.test
@@ -87,9 +87,10 @@ class RestfulUpdateEntityTestCase extends DrupalWebTestCase {
       'id' => $id,
       'label' => $new_label,
       'self' => url('node/' . $id, array('absolute' => TRUE)),
-      'body' => '<p>' . $text . '</p>',
+      'body' => $text,
     );
 
+    $result['body']['body'] = trim(strip_tags($result['body']['body']));
     $this->assertEqual($result, $expected_result);
 
     // Update an entity with invalid property name.

--- a/tests/RestfulUpdateEntityTestCase.test
+++ b/tests/RestfulUpdateEntityTestCase.test
@@ -90,7 +90,7 @@ class RestfulUpdateEntityTestCase extends DrupalWebTestCase {
       'body' => $text,
     );
 
-    $result['body']['body'] = trim(strip_tags($result['body']['body']));
+    $result['body'] = trim(strip_tags($result['body']));
     $this->assertEqual($result, $expected_result);
 
     // Update an entity with invalid property name.

--- a/tests/RestfulUpdateEntityTestCase.test
+++ b/tests/RestfulUpdateEntityTestCase.test
@@ -87,7 +87,7 @@ class RestfulUpdateEntityTestCase extends DrupalWebTestCase {
       'id' => $id,
       'label' => $new_label,
       'self' => url('node/' . $id, array('absolute' => TRUE)),
-      'body' => $text,
+      'body' => '<p>' . $text . '</p>',
     );
 
     $this->assertEqual($result, $expected_result);

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.0/RestfulTestArticlesResource__1_0.class.php
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.0/RestfulTestArticlesResource__1_0.class.php
@@ -13,8 +13,9 @@ class RestfulTestArticlesResource__1_0 extends RestfulExampleArticlesResource {
   public function getPublicFields() {
     $public_fields = parent::getPublicFields();
 
-    $public_fields['text_single'] = array(
-      'property' => 'text_single',
+    $public_fields['body'] = array(
+      'property' => 'body',
+      'sub_property' => 'value',
     );
 
     return $public_fields;

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulTestArticlesResource__1_2.
+ */
+
+class RestfulTestArticlesResource__1_2 extends RestfulEntityBaseNode {
+
+  /**
+   * Overrides \RestfulEntityBase::getPublicFields().
+   */
+  public function getPublicFields() {
+    $public_fields = parent::getPublicFields();
+
+    $public_fields['entity_reference_single'] = array(
+      'property' => 'entity_reference_single',
+      'resource' => array(
+        'article' => 'test_articles',
+      ),
+    );
+
+    $public_fields['entity_reference_multiple'] = array(
+      'property' => 'entity_reference_multiple',
+      'resource' => array(
+        'article' => 'test_articles',
+      ),
+    );
+
+
+    return $public_fields;
+  }
+
+}

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
@@ -13,6 +13,11 @@ class RestfulTestArticlesResource__1_2 extends RestfulEntityBaseNode {
   public function getPublicFields() {
     $public_fields = parent::getPublicFields();
 
+    $public_fields['body'] = array(
+      'property' => 'body',
+      'sub_property' => 'value',
+    );
+
     $public_fields['entity_reference_single'] = array(
       'property' => 'entity_reference_single',
       'resource' => array(

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/test_articles__1_2.inc
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/test_articles__1_2.inc
@@ -1,0 +1,12 @@
+<?php
+
+$plugin = array(
+  'label' => t('Articles'),
+  'resource' => 'test_articles',
+  'name' => 'test_articles__1_2',
+  'entity_type' => 'node',
+  'bundle' => 'article',
+  'description' => t('Export the article content type.'),
+  'class' => 'RestfulTestArticlesResource__1_2',
+  'minor_version' => 2,
+);

--- a/tests/modules/restful_test/restful_test.module
+++ b/tests/modules/restful_test/restful_test.module
@@ -18,9 +18,9 @@ function restful_test_ctools_plugin_directory($module, $plugin) {
  * Flag a field to not be accessible.
  *
  * @param $field_name
- *   The field name. Defaults to "text_single".
+ *   The field name. Defaults to "body".
  */
-function restful_test_deny_access_field($field_name = 'text_single') {
+function restful_test_deny_access_field($field_name = 'body') {
   variable_set('restful_test_deny_access_field', $field_name);
 }
 


### PR DESCRIPTION
#109

``` php
  $request = array(
    'label' => 'parent',
    'body' => 'Gizra1',
    'er' => array(
      'label' => 'child',
      'body' => 'Gizra2',
    ),
  );
  $result = $handler->post('', $request);
```

![site-install](https://cloud.githubusercontent.com/assets/125707/3604454/8c8aba5c-0d20-11e4-91af-63316fc0b6dd.jpg)

Validation is also working, since we are recursing into the referenced sub-resources, so nothing is saved if one of entities is invalid!

Note that the PR also moved request, account, path and method to properties of the handler, to stop passing so many arguments around from function to function.
