### PR TITLE
added few more plugin configurations entity_id, entity_count, entity_lis...

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -524,12 +524,11 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
       // Return autocomplete list.
       return $this->getListForAutocomplete();
     }
-
+    
     $entity_type = $this->entityType;
     $result = $this
       ->getQueryForList()
       ->execute();
-
 
     if (empty($result[$entity_type])) {
       return array();
@@ -551,9 +550,11 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
       $return[$this->entityListName][] = $this->viewEntity($id);
     }
     
-    // add count if requested in plugin config
+    // add count if requested in plugin config.
     if ($this->entityCount) {
-        $return['count'] = count($ids);
+        $count_query = $this->getQueryForList()->count();
+        unset($count_query->range);
+        $return['count'] = $count_query->execute();
     }
     return $return;
   }
@@ -629,7 +630,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
     $query->addMetaData('account', $this->getAccount());
 
     $query->range($offset, $range);
-
+    
     return $query;
   }
 
@@ -802,13 +803,12 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
     $values = array();
 
     $limit_fields = !empty($request['fields']) ? explode(',', $request['fields']) : array();
-
+    
     foreach ($this->getPublicFields() as $public_property => $info) {
       if ($limit_fields && !in_array($public_property, $limit_fields)) {
         // Limit fields doesn't include this property.
         continue;
       }
-
       // Set default values.
       $info += array(
         'property' => FALSE,

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -344,9 +344,9 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
     $this->authenticationManager = $auth_manager ? $auth_manager : new \RestfulAuthenticationManager();
     $this->cacheController = $cache_controller ? $cache_controller : $this->newCacheObject();
     
-    $this->entityId = $plugin['entity_id'] ? $plugin['entity_id'] : 'id';
-    $this->entityCount = $plugin['entity_count'] ? $plugin['entity_count'] : FALSE;
-    $this->entityListName = $plugin['entity_list_name'] ? $plugin['entity_list_name'] : 'list';    
+    $this->entityId = !empty($plugin['entity_id']) ? $plugin['entity_id'] : 'id';
+    $this->entityCount = !empty($plugin['entity_count']) ? $plugin['entity_count'] : FALSE;
+    $this->entityListName = !empty($plugin['entity_list_name']) ? $plugin['entity_list_name'] : 'list';    
     
     if (!empty($plugin['rate_limit'])) {
       $this->setRateLimitManager(new \RestfulRateLimitManager($plugin['resource'], $plugin['rate_limit']));


### PR DESCRIPTION
In my project I needed a way to easily set entity ID and list name to a custom name.
For example:

``` javascript
{
    "products": [
        {
            "pid": 310,
            "tnid": "309",
            "title": "product name",
            "status": "1",
            "description": "product descr"
                }
        ]
}
```

I think this could be done from plugin configuration without the needs to extend RestfulEntityBaseNode class.

These are the new parameters added to plugin config

``` php
'entity_id' => 'pid',
'entity_list_name' => 'products',
'entity_count' => TRUE,
```

This also adds a count of the returned items.
