### PR TITLE
Fix entityvalidate property condition

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1426,7 +1426,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
 
     $map = array();
     foreach ($this->getPublicFields() as $field_name => $value) {
-      if (!$value['property']) {
+      if (!isset($value['property'])) {
         continue;
       }
 

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1426,7 +1426,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
 
     $map = array();
     foreach ($this->getPublicFields() as $field_name => $value) {
-      if (!isset($value['property'])) {
+      if (empty($value['property'])) {
         continue;
       }
 


### PR DESCRIPTION
This fix the PHP Notice of:
`Notice: Undefined index: property in RestfulEntityBase->entityValidate() (line 1400 of /path/to/project/modules/contrib/restful/plugins/restful/RestfulEntityBase.php).`

When you define a field with just a callback without a field property,
For example:

``` php
$public_fields['phpVersion'] = array(
      'callback' => 'phpversion',
);
```
