### PR TITLE
Add \RestfulInterface::publicFieldsInfo() for users to declare their fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ term) with a ``tags`` resource, we would define the relation via the
 ``RestfulEntityBase::getPublicFields()``
 
 ```php
-public function getPublicFields() {
+public function publicFieldsInfo() {
   // ...
   $public_fields['tags'] = array(
     'property' => 'field_tags',

--- a/modules/restful_example/plugins/restful/node/articles/1.1/RestfulExampleArticlesResource__1_1.class.php
+++ b/modules/restful_example/plugins/restful/node/articles/1.1/RestfulExampleArticlesResource__1_1.class.php
@@ -8,10 +8,10 @@
 class RestfulExampleArticlesResource__1_1 extends RestfulExampleArticlesResource {
 
   /**
-   * Overrides RestfulExampleArticlesResource::getPublicFields().
+   * Overrides RestfulExampleArticlesResource::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
     unset($public_fields['self']);
     return $public_fields;
   }

--- a/modules/restful_example/plugins/restful/node/articles/1.5/RestfulExampleArticlesResource__1_5.class.php
+++ b/modules/restful_example/plugins/restful/node/articles/1.5/RestfulExampleArticlesResource__1_5.class.php
@@ -8,10 +8,10 @@
 class RestfulExampleArticlesResource__1_5 extends RestfulEntityBaseNode {
 
   /**
-   * Overrides RestfulExampleArticlesResource::getPublicFields().
+   * Overrides RestfulExampleArticlesResource::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
 
     $public_fields['body'] = array(
       'property' => 'body',
@@ -27,7 +27,9 @@ class RestfulExampleArticlesResource__1_5 extends RestfulEntityBaseNode {
 
     $public_fields['image'] = array(
       'property' => 'field_image',
-      'process_callback' => array($this, 'imageProcess'),
+      'process_callbacks' => array(
+        array($this, 'imageProcess'),
+      ),
     );
 
     return $public_fields;

--- a/modules/restful_example/plugins/restful/node/per_role_content/1.0/RestfulExampleRoleResource.class.php
+++ b/modules/restful_example/plugins/restful/node/per_role_content/1.0/RestfulExampleRoleResource.class.php
@@ -18,8 +18,8 @@ class RestfulExampleRoleResource extends \RestfulEntityBase implements \RestfulE
   /**
    * Overrides \RestfulEntityBase::publicFields().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
     $public_fields['type'] = array(
       'property' => 'type',
       'wrapper_method' => 'getBundle',

--- a/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/1.0/RestfulTokenAuthentication.class.php
+++ b/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/1.0/RestfulTokenAuthentication.class.php
@@ -8,11 +8,11 @@
 class RestfulTokenAuthentication extends \RestfulEntityBase {
 
   /**
-   * Overrides RestfulEntityBase::getPublicFields().
+   * Overrides RestfulEntityBase::publicFieldsInfo().
    *
    * Keep only the "token" property.
    */
-  public function getPublicFields() {
+  public function publicFieldsInfo() {
     $public_fields['access_token'] = array(
       'property' => 'token',
     );

--- a/plugins/restful/RestfulInterface.php
+++ b/plugins/restful/RestfulInterface.php
@@ -57,8 +57,19 @@ interface RestfulInterface {
    */
   public function process($path = '', array $request = array(), $method = \RestfulInterface::GET, $check_rate_limit = TRUE);
 
+
   /**
    * Return the properties that should be public.
+   *
+   * @return array
+   */
+  public function publicFieldsInfo();
+
+  /**
+   * Return the properties that should be public after processing.
+   *
+   * Default values would be assigned to the properties declared in
+   * \RestfulInterface::publicFieldsInfo().
    *
    * @return array
    */

--- a/plugins/restful/user/user/1.0/RestfulEntityBaseUser.class.php
+++ b/plugins/restful/user/user/1.0/RestfulEntityBaseUser.class.php
@@ -8,10 +8,10 @@
 class RestfulEntityBaseUser extends \RestfulEntityBase {
 
   /**
-   * Overrides \RestfulEntityBase::getPublicFields().
+   * Overrides \RestfulEntityBase::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
     $public_fields['id'] = array(
       'property' => 'uid',
     );

--- a/tests/modules/restful_test/plugins/restful/entity_test/main/1.1/RestfulTestMainResource__1_1.class.php
+++ b/tests/modules/restful_test/plugins/restful/entity_test/main/1.1/RestfulTestMainResource__1_1.class.php
@@ -8,10 +8,10 @@
 class RestfulTestMainResource__1_1 extends RestfulTestMainResource {
 
   /**
-   * Overrides RestfulTestEntityTestsResource::getPublicFields().
+   * Overrides RestfulTestEntityTestsResource::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
 
     $public_fields['text_single'] = array(
       'property' => 'text_single',
@@ -69,23 +69,31 @@ class RestfulTestMainResource__1_1 extends RestfulTestMainResource {
 
     $public_fields['file_single'] = array(
       'property' => 'file_single',
-      'process_callback' => array($this, 'getFileId'),
-
+      'process_callbacks' =>
+        array(
+          array($this, 'getFileId'),
+        )
     );
 
     $public_fields['file_multiple'] = array(
       'property' => 'file_multiple',
-      'process_callback' => array($this, 'getFilesId'),
+      'process_callbacks' => array(
+        array($this, 'getFilesId'),
+      ),
     );
 
     $public_fields['image_single'] = array(
       'property' => 'image_single',
-      'process_callback' => array($this, 'getFileId'),
+      'process_callbacks' => array(
+        array($this, 'getFileId'),
+      ),
     );
 
     $public_fields['image_multiple'] = array(
       'property' => 'image_multiple',
-      'process_callback' => array($this, 'getFilesId'),
+      'process_callbacks' => array(
+        array($this, 'getFilesId'),
+      ),
     );
 
 

--- a/tests/modules/restful_test/plugins/restful/entity_test/main/1.2/RestfulTestMainResource__1_2.class.php
+++ b/tests/modules/restful_test/plugins/restful/entity_test/main/1.2/RestfulTestMainResource__1_2.class.php
@@ -8,10 +8,10 @@
 class RestfulTestMainResource__1_2 extends RestfulTestMainResource {
 
   /**
-   * Overrides RestfulTestEntityTestsResource::getPublicFields().
+   * Overrides RestfulTestEntityTestsResource::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
 
     $public_fields['callback'] = array(
       'callback' => array($this, 'callback'),
@@ -19,13 +19,17 @@ class RestfulTestMainResource__1_2 extends RestfulTestMainResource {
 
     $public_fields['process_callback_from_callback'] = array(
       'callback' => array($this, 'callback'),
-      'process_callback' => array($this, 'processCallbackFromCallback'),
+      'process_callbacks' => array(
+        array($this, 'processCallbackFromCallback'),
+      ),
     );
 
     $public_fields['process_callback_from_value'] = array(
       'wrapper_method' => 'getIdentifier',
       'wrapper_method_on_entity' => TRUE,
-      'process_callback' => array($this, 'processCallbackFromValue'),
+      'process_callbacks' => array(
+        array($this, 'processCallbackFromValue'),
+      ),
     );
 
     return $public_fields;

--- a/tests/modules/restful_test/plugins/restful/entity_test/main/1.3/RestfulTestMainResource__1_3.class.php
+++ b/tests/modules/restful_test/plugins/restful/entity_test/main/1.3/RestfulTestMainResource__1_3.class.php
@@ -8,10 +8,10 @@
 class RestfulTestMainResource__1_3 extends RestfulTestMainResource {
 
   /**
-   * Overrides RestfulTestEntityTestsResource::getPublicFields().
+   * Overrides RestfulTestEntityTestsResource::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
 
     $public_fields['callback'] = array(
       'callback' => array($this, 'invalidCallback'),

--- a/tests/modules/restful_test/plugins/restful/entity_test/main/1.4/RestfulTestMainResource__1_4.class.php
+++ b/tests/modules/restful_test/plugins/restful/entity_test/main/1.4/RestfulTestMainResource__1_4.class.php
@@ -8,15 +8,17 @@
 class RestfulTestMainResource__1_4 extends RestfulTestMainResource {
 
   /**
-   * Overrides RestfulTestEntityTestsResource::getPublicFields().
+   * Overrides RestfulTestEntityTestsResource::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
 
-    $public_fields['process_callback'] = array(
+    $public_fields['process_callbacks'] = array(
       'wrapper_method' => 'label',
       'wrapper_method_on_entity' => TRUE,
-      'process_callback' => array($this, 'invalidProcessCallback'),
+      'process_callbacks' => array(
+        array($this, 'invalidProcessCallback'),
+      ),
     );
 
     return $public_fields;

--- a/tests/modules/restful_test/plugins/restful/entity_test/tests/1.0/RestfulTestTestsResource.class.php
+++ b/tests/modules/restful_test/plugins/restful/entity_test/tests/1.0/RestfulTestTestsResource.class.php
@@ -8,10 +8,10 @@
 class RestfulTestTestsResource extends RestfulEntityBase {
 
   /**
-   * Overrides RestfulEntityBase::getPublicFields().
+   * Overrides RestfulEntityBase::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
     $public_fields['type'] = array(
       'property' => 'name',
       'wrapper_method' => 'getBundle',

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.0/RestfulTestArticlesResource__1_0.class.php
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.0/RestfulTestArticlesResource__1_0.class.php
@@ -8,10 +8,10 @@
 class RestfulTestArticlesResource__1_0 extends RestfulExampleArticlesResource {
 
   /**
-   * Overrides RestfulExampleArticlesResource::getPublicFields().
+   * Overrides RestfulExampleArticlesResource::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
 
     $public_fields['body'] = array(
       'property' => 'body',

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
@@ -8,10 +8,10 @@
 class RestfulTestArticlesResource__1_2 extends RestfulEntityBaseNode {
 
   /**
-   * Overrides \RestfulEntityBase::getPublicFields().
+   * Overrides \RestfulEntityBase::publicFieldsInfo().
    */
-  public function getPublicFields() {
-    $public_fields = parent::getPublicFields();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
 
     $public_fields['body'] = array(
       'property' => 'body',


### PR DESCRIPTION
It's much cleaner that getPublicFields() returns with all the values populated. This also helps with #124, when we need the `$public_field['column']` outside of `entityView()`
