### PR TITLE
Allow "X-HTTP-Method-Override" in request.

### DIFF
--- a/restful.module
+++ b/restful.module
@@ -449,6 +449,16 @@ function restful_menu_access_callback($major_version, $resource_name) {
     return;
   }
 
+  $method = strtoupper($_SERVER['REQUEST_METHOD']);
+  if ($method == \RestfulInterface::POST && !empty($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'])) {
+    $method = strtoupper($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']);
+  }
+
+  if (!\RestfulBase::isValidMethod($method, FALSE)) {
+    // HTTP method is invalid.
+    return;
+  }
+
   return $handler->access();
 }
 
@@ -474,9 +484,13 @@ function restful_menu_process_callback($major_version, $resource_name) {
   unset($path[0], $path[1]);
   $path = implode('/', $path);
 
-  $method = strtolower($_SERVER['REQUEST_METHOD']);
+  $method = strtoupper($_SERVER['REQUEST_METHOD']);
 
-  if ($method == 'options') {
+  if ($method == \RestfulInterface::POST && !empty($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'])) {
+    $method = strtoupper($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']);
+  }
+
+  if ($method == \RestfulInterface::OPTIONS) {
     // OPTIONS method is a special case that might be sent by the browser
     // before the actual method to check for CORS (known as preflight OPTIONS).
     drupal_add_http_header('Status', 204);
@@ -484,6 +498,7 @@ function restful_menu_process_callback($major_version, $resource_name) {
     return;
   }
 
+  $method = strtolower($method);
   $request = restful_parse_request();
 
   try {

--- a/tests/RestfulHookMenuTestCase.test
+++ b/tests/RestfulHookMenuTestCase.test
@@ -17,6 +17,9 @@ class RestfulHookMenuTestCase extends RestfulCurlBaseTestCase {
 
   function setUp() {
     parent::setUp('restful_example');
+
+    // Allow anonymous users to edit articles.
+    user_role_change_permissions(DRUPAL_ANONYMOUS_RID, array('edit any article content' => TRUE));
   }
 
   /**
@@ -51,6 +54,18 @@ class RestfulHookMenuTestCase extends RestfulCurlBaseTestCase {
     $result = $this->httpRequest('api/v1/articles/' . $node1->nid, \RestfulInterface::GET, NULL, $headers);
     unset($expected_result['data']['self']);
     $this->assertEqual($result['body'], json_encode($expected_result));
+
+    // Test method override.
+    $headers = array('X-HTTP-Method-Override' => \RestfulInterface::PATCH);
+    $body = array(
+      'label' => 'new title',
+    );
+    $this->httpRequest('api/v1/articles/' . $node1->nid, \RestfulInterface::POST, $body, $headers);
+
+    $node1 = node_load($node1->nid);
+    $this->assertEqual($node1->title, 'new title', 'HTTP method was overriden.');
+
+
   }
 
   /**


### PR DESCRIPTION
#137

Client may send a POST request, but override the method to newer methods (e.g. PATCH, PUT).
