### PR TITLE
Move non entity related stuff to RestfulBase.

### DIFF
--- a/plugins/authentication/RestfulAuthenticationManager.php
+++ b/plugins/authentication/RestfulAuthenticationManager.php
@@ -62,12 +62,14 @@ class RestfulAuthenticationManager extends \ArrayObject {
    *   The request.
    * @param string $method
    *   The HTTP method.
+   * @param boolean $cache
+   *   Boolean indicating if the resolved user should be cached for next calls.
    *
    * @throws RestfulUnauthorizedException
    * @return \stdClass
    *   The user object.
    */
-  public function getAccount(array $request = array(), $method = \RestfulInterface::GET) {
+  public function getAccount(array $request = array(), $method = \RestfulInterface::GET, $cache = TRUE) {
     global $user;
     // Return the previously resolved user, if any.
     if (!empty($this->account)) {
@@ -100,7 +102,9 @@ class RestfulAuthenticationManager extends \ArrayObject {
         $account = $user->uid ? user_load($user->uid) : $account;
       }
     }
-    $this->setAccount($account);
+    if ($cache) {
+      $this->setAccount($account);
+    }
     return $account;
   }
 

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -15,6 +15,198 @@ abstract class RestfulBase implements RestfulInterface {
   protected $plugin;
 
   /**
+   * Array keyed by the header property, and the value.
+   *
+   * This can be used for example to change the "Status" code of the HTTP
+   * response, or to add a "Location" property.
+   *
+   * @var array $httpHeaders
+   */
+  protected $httpHeaders = array();
+
+  /**
+   * Cache controller object.
+   *
+   * @var \DrupalCacheInterface
+   */
+  protected $cacheController;
+
+  /**
+   * Authentication manager.
+   *
+   * @var \RestfulAuthenticationManager
+   */
+  protected $authenticationManager;
+
+  /**
+   * Rate limit manager.
+   *
+   * @var \RestfulRateLimitManager
+   */
+  protected $rateLimitManager = NULL;
+
+  /**
+   * The HTTP method used for the request.
+   *
+   * @var string
+   */
+  protected $method = \RestfulInterface::GET;
+
+  /**
+   * Get the HTTP method used for the request.
+   * @return string
+   */
+  public function getMethod() {
+    return $this->method;
+  }
+
+  /**
+   * Set the HTTP method used for the request.
+   *
+   * @param string $method
+   *   The method name.
+   */
+  public function setMethod($method) {
+    $this->method = $method;
+  }
+
+  /**
+   * The path of the request.
+   *
+   * @var string
+   */
+  protected $path = '';
+
+  /**
+   * The request array.
+   *
+   * @var array
+   */
+  protected $request = array();
+
+  /**
+   * Return the path of the request.
+   *
+   * @return string
+   *   String with the path.
+   */
+  public function getPath() {
+    return $this->path;
+  }
+
+  /**
+   * Set the path of the request.
+   *
+   * @param string $path
+   */
+  public function setPath($path = '') {
+    $this->path = implode(',', array_unique(array_filter(explode(',', $path))));
+  }
+
+  /**
+   * Get the request array.
+   *
+   * @return array
+   */
+  public function getRequest() {
+    return $this->request;
+  }
+
+  /**
+   * Set the request array.
+   *
+   * @param array $request
+   *   Array with the request.
+   */
+  public function setRequest(array $request = array()) {
+    $this->request = $request;
+  }
+
+  /**
+   * Helper function to remove the application generated request data.
+   *
+   * @param &array $request
+   *   The request array to be modified.
+   */
+  public static function cleanRequest(&$request) {
+    unset($request['__application']);
+  }
+
+  /**
+   * Get the defined controllers
+   *
+   * @return array
+   *   The defined controllers.
+   */
+  public function getControllers() {
+    return $this->controllers;
+  }
+
+  /**
+   * Set the HTTP headers.
+   *
+   * @param string $key
+   *   The HTTP header key.
+   * @param string $value
+   *   The HTTP header value.
+   */
+  public function setHttpHeaders($key, $value) {
+    $this->httpHeaders[$key] = $value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getHttpHeaders() {
+    return $this->httpHeaders;
+  }
+
+  /**
+   * Setter for $authenticationManager.
+   *
+   * @param \RestfulAuthenticationManager $authenticationManager
+   */
+  public function setAuthenticationManager($authenticationManager) {
+    $this->authenticationManager = $authenticationManager;
+  }
+
+  /**
+   * Getter for $authenticationManager.
+   *
+   * @return \RestfulAuthenticationManager
+   */
+  public function getAuthenticationManager() {
+    return $this->authenticationManager;
+  }
+
+  /**
+   * Getter for $cacheController.
+   *
+   * @return \DrupalCacheInterface
+   */
+  public function getCacheController() {
+    return $this->cacheController;
+  }
+
+  /**
+   * Setter for rateLimitManager.
+   *
+   * @param \RestfulRateLimitManager $rateLimitManager
+   */
+  public function setRateLimitManager($rateLimitManager) {
+    $this->rateLimitManager = $rateLimitManager;
+  }
+
+  /**
+   * Getter for rateLimitManager.
+
+   * @return \RestfulRateLimitManager
+   */
+  public function getRateLimitManager() {
+    return $this->rateLimitManager;
+  }
+
+  /**
    * Constructs a RestfulEntityBase object.
    *
    * @param array $plugin
@@ -26,6 +218,11 @@ abstract class RestfulBase implements RestfulInterface {
    */
   public function __construct($plugin, \RestfulAuthenticationManager $auth_manager = NULL, \DrupalCacheInterface $cache_controller = NULL) {
     $this->plugin = $plugin;
+    $this->authenticationManager = $auth_manager ? $auth_manager : new \RestfulAuthenticationManager();
+    $this->cacheController = $cache_controller ? $cache_controller : $this->newCacheObject();
+    if (!empty($plugin['rate_limit'])) {
+      $this->setRateLimitManager(new \RestfulRateLimitManager($plugin['resource'], $plugin['rate_limit']));
+    }
   }
 
   /**
@@ -116,4 +313,396 @@ abstract class RestfulBase implements RestfulInterface {
     $formatter_handler = restful_get_formatter_handler($this->getPluginInfo('formatter'), $this);
     return $formatter_handler->format($data);
   }
+
+  /**
+   * Return the resource name.
+   *
+   * @return string
+   *   Gets the name of the resource.
+   */
+  public function getResourceName() {
+    return $this->getPluginInfo('resource');
+  }
+
+  /**
+   * Return array keyed with the major and minor version of the resource.
+   *
+   * @return array
+   *   Keyed array with the major and minor version as provided in the plugin
+   *   definition.
+   */
+  public function getVersion() {
+    return array(
+      'major' => $this->plugin['major_version'],
+      'minor' => $this->plugin['minor_version'],
+    );
+  }
+
+  /**
+   * Call resource using the GET http method.
+   *
+   * @param string $path
+   *   (optional) The path.
+   * @param array $request
+   *   (optional) The request.
+   *
+   * @return mixed
+   *   The return value can depend on the controller for the get method.
+   */
+  public function get($path = '', array $request = array()) {
+    return $this->process($path, $request, \RestfulInterface::GET);
+  }
+
+  /**
+   * Call resource using the POST http method.
+   *
+   * @param string $path
+   *   (optional) The path.
+   * @param array $request
+   *   (optional) The request.
+   *
+   * @return mixed
+   *   The return value can depend on the controller for the post method.
+   */
+  public function post($path = '', array $request = array()) {
+    return $this->process($path, $request, \RestfulInterface::POST);
+  }
+
+  /**
+   * Call resource using the PUT http method.
+   *
+   * @param string $path
+   *   (optional) The path.
+   * @param array $request
+   *   (optional) The request.
+   *
+   * @return mixed
+   *   The return value can depend on the controller for the put method.
+   */
+  public function put($path = '', array $request = array()) {
+    return $this->process($path, $request, \RestfulInterface::PUT);
+  }
+
+  /**
+   * Call resource using the PATCH http method.
+   *
+   * @param string $path
+   *   (optional) The path.
+   * @param array $request
+   *   (optional) The request.
+   * @return mixed
+   *   The return value can depend on the controller for the patch method.
+   */
+  public function patch($path = '', array $request = array()) {
+    return $this->process($path, $request, \RestfulInterface::PATCH);
+  }
+
+  /**
+   * Call resource using the DELETE http method.
+   *
+   * @param string $path
+   *   (optional) The path.
+   * @param array $request
+   *   (optional) The request.
+   *
+   * @return mixed
+   *   The return value can depend on the controller for the delete method.
+   */
+  public function delete($path = '', array $request = array()) {
+    return $this->process($path, $request, \RestfulInterface::DELETE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process($path = '', array $request = array(), $method = \RestfulInterface::GET, $check_rate_limit = TRUE) {
+    $this->setMethod($method);
+    $this->setPath($path);
+    $this->setRequest($request);
+
+    if (!$method_name = $this->getControllerFromPath()) {
+      throw new RestfulBadRequestException('Path does not exist');
+    }
+
+    if ($check_rate_limit && $this->getRateLimitManager()) {
+      // This will throw the appropriate exception if needed.
+      $this->getRateLimitManager()->checkRateLimit($request);
+    }
+
+    return $this->{$method_name}($path);
+  }
+
+  /**
+   * Return the controller from a given path.
+   *
+   * @return string
+   *   The appropriate method to call.
+   *
+   * @throws RestfulBadRequestException
+   * @throws RestfulGoneException
+   */
+  public function getControllerFromPath() {
+    $path = $this->getPath();
+    $method = $this->getMethod();
+
+    $selected_controller = NULL;
+    foreach ($this->getControllers() as $pattern => $controllers) {
+      if ($pattern != $path && !($pattern && preg_match('/' . $pattern . '/', $path))) {
+        continue;
+      }
+
+      if ($controllers === FALSE) {
+        // Method isn't valid anymore, due to a deprecated API endpoint.
+        $params = array('@path' => $path);
+        throw new RestfulGoneException(format_string('The path @path endpoint is not valid.', $params));
+      }
+
+      if (!isset($controllers[$method])) {
+        $params = array('@method' => strtoupper($method));
+        throw new RestfulBadRequestException(format_string('The http method @method is not allowed for this path.', $params));
+      }
+
+      // We found the controller, so we can break.
+      $selected_controller = $controllers[$method];
+      break;
+    }
+
+    return $selected_controller;
+  }
+
+  /**
+   * Adds query tags and metadata to the EntityFieldQuery.
+   *
+   * @param \EntityFieldQuery $query
+   *   The query to enhance.
+   */
+  protected function addExtraInfoToQuery(\EntityFieldQuery $query) {
+    // Add a generic tags to the query.
+    $query->addTag('restful');
+    $query->addMetaData('account', $this->getAccount());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access() {
+    return TRUE;
+  }
+
+  /**
+   * Proxy method to get the account from the authenticationManager.
+   *
+   * @return \stdClass
+   *   The user object.
+   */
+  public function getAccount() {
+    // The request.
+    $request = $this->getRequest();
+    // The HTTP method. Defaults to "get".
+    $method = $this->getMethod();
+
+    $account = $this->getAuthenticationManager()->getAccount($request, $method);
+
+    // If the limit rate is enabled for the current plugin then set the account.
+    if ($this->getRateLimitManager()) {
+      $this->getRateLimitManager()->setAccount($account);
+    }
+    return $account;
+  }
+
+  /**
+   * Proxy method to set the account from the authenticationManager.
+   *
+   * @param \stdClass $account
+   *   The account to set.
+   */
+  public function setAccount(\stdClass $account) {
+    // If the limit rate is enabled for the current plugin then set the account.
+    if ($this->getRateLimitManager()) {
+      $this->getRateLimitManager()->setAccount($account);
+    }
+    $this->getAuthenticationManager()->setAccount($account);
+  }
+
+  /**
+   * Helper method; Get the URL of the resource and query strings.
+   *
+   * By default the URL is absolute.
+   *
+   * @param $request
+   *   The request array.
+   * @param $options
+   *   Array with options passed to url().
+   * @param $keep_query
+   *   If TRUE the $request will be appended to the $options['query']. This is
+   *   the typical behavior for $_GET method, however it is not for $_POST.
+   *   Defaults to TRUE.
+   *
+   * @return string
+   *   The URL address.
+   */
+  public function getUrl($request = NULL, $options = array(), $keep_query = TRUE) {
+    // By default set URL to be absolute.
+    $options += array(
+      'absolute' => TRUE,
+      'query' => array(),
+    );
+
+    if ($keep_query) {
+      // Remove special params.
+      unset($request['q']);
+      static::cleanRequest($request);
+
+      // Add the request as query strings.
+      $options['query'] += $request;
+    }
+
+    return url($this->getPluginInfo('menu_item'), $options);
+  }
+
+  /**
+   * Get the default cache object based on the plugin configuration.
+   *
+   * By default, this returns an instance of the DrupalDatabaseCache class.
+   * Classes implementing DrupalCacheInterface can register themselves both as a
+   * default implementation and for specific bins.
+   *
+   * @return \DrupalCacheInterface
+   *   The cache object associated with the specified bin.
+   *
+   * @see \DrupalCacheInterface
+   * @see _cache_get_object().
+   */
+  protected function newCacheObject() {
+    // We do not use drupal_static() here because we do not want to change the
+    // storage of a cache bin mid-request.
+    static $cache_object;
+    if (isset($cache_object)) {
+      // Return cached object.
+      return $cache_object;
+    }
+
+    $cache_info = $this->getPluginInfo('cache');
+    $class = $cache_info['class'];
+    if (empty($class)) {
+      $class = variable_get('cache_class_' . $cache_info['bin']);
+      if (empty($class)) {
+        $class = variable_get('cache_default_class', 'DrupalDatabaseCache');
+      }
+    }
+    $cache_object = new $class($cache_info['bin']);
+    return $cache_object;
+  }
+
+  /**
+   * Get a rendered entity from cache.
+   *
+   * @param array $context
+   *   An associative array with additional information to build the cache ID.
+   *
+   * @return \stdClass
+   *   The cache with rendered entity as returned by
+   *   \RestfulEntityInterface::viewEntity().
+   *
+   * @see \RestfulEntityInterface::viewEntity().
+   */
+  protected function getRenderedCache(array $context = array()) {
+    $cache_info = $this->getPluginInfo('cache');
+    if (!$cache_info['render']) {
+      return;
+    }
+
+    $cid = $this->generateCacheId($context);
+    return $this->getCacheController()->get($cid);
+  }
+
+  /**
+   * Store a rendered entity into the cache.
+   *
+   * @param mixed $data
+   *   The data to be stored into the cache generated by
+   *   \RestfulEntityInterface::viewEntity().
+   * @param array $context
+   *   An associative array with additional information to build the cache ID.
+   *
+   * @return array
+   *   The rendered entity as returned by \RestfulEntityInterface::viewEntity().
+   *
+   * @see \RestfulEntityInterface::viewEntity().
+   */
+  protected function setRenderedCache($data, array $context = array()) {
+    $cache_info = $this->getPluginInfo('cache');
+    if (!$cache_info['render']) {
+      return;
+    }
+
+    $cid = $this->generateCacheId($context);
+    $this->getCacheController()->set($cid, $data, $cache_info['expire']);
+  }
+
+  /**
+   * Generate a cache identifier for the request and the current entity.
+   *
+   * @param array $context
+   *   An associative array with additional information to build the cache ID.
+   *
+   * @return string
+   *   The cache identifier.
+   */
+  protected function generateCacheId(array $context = array()) {
+    // Get the cache ID from the selected params. We will use a complex cache ID
+    // for smarter invalidation. The cache id will be like:
+    // v<major version>.<minor version>::uu<user uid>::pa<params array>
+    // The code before every bit is a 2 letter representation of the label. For
+    // instance, the params array will be something like:
+    // fi:id,title::re:admin
+    // When the request has ?fields=id,title&restrict=admin
+    $version = $this->getVersion();
+    $cid = 'v' . $version['major'] . '.' . $version['minor'] . '::uu' . $this->getAccount()->uid . '::pa';
+    $cid_params = array();
+    $request = $this->getRequest();
+    static::cleanRequest($request);
+    $options = $context + $request;
+    foreach ($options as $param => $value) {
+      // Some request parameters don't affect how the resource is rendered, this
+      // means that we should skip them for the cache ID generation.
+      if (in_array($param, array('page', 'sort', 'q', '__application', 'filter'))) {
+        continue;
+      }
+      // Make sure that ?fields=title,id and ?fields=id,title hit the same cache
+      // identifier.
+      $values = explode(',', $value);
+      sort($values);
+      $value = implode(',', $values);
+
+      $cid_params[] = substr($param, 0, 2) . ':' . $value;
+    }
+    $cid .= implode('::', $cid_params);
+    return $cid;
+  }
+
+  /**
+   * Invalidates cache for a certain entity.
+   *
+   * @param string $cid
+   *   The wildcard cache id to invalidate.
+   */
+  public function cacheInvalidate($cid) {
+    $cache_info = $this->getPluginInfo('cache');
+    if (!$cache_info['simple_invalidate']) {
+      // Simple invalidation is disabled. This means it is up to the
+      // implementing module to take care of the invalidation.
+      return;
+    }
+    // If the $cid is not '*' then remove the asterisk since it can mess with
+    // dynamically built wildcards.
+    if ($cid != '*') {
+      $pos = strpos($cid, '*');
+      if ($pos !== FALSE) {
+        $cid = substr($cid, 0, $pos);
+      }
+    }
+    $this->getCacheController()->clear($cid, TRUE);
+  }
+
 }

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -492,16 +492,19 @@ abstract class RestfulBase implements RestfulInterface {
   /**
    * Proxy method to get the account from the authenticationManager.
    *
+   * @param boolean $cache
+   *   Boolean indicating if the resolved user should be cached for next calls.
+   *
    * @return \stdClass
    *   The user object.
    */
-  public function getAccount() {
+  public function getAccount($cache = TRUE) {
     // The request.
     $request = $this->getRequest();
     // The HTTP method. Defaults to "get".
     $method = $this->getMethod();
 
-    $account = $this->getAuthenticationManager()->getAccount($request, $method);
+    $account = $this->getAuthenticationManager()->getAccount($request, $method, $cache);
 
     // If the limit rate is enabled for the current plugin then set the account.
     if ($this->getRateLimitManager()) {

--- a/restful.module
+++ b/restful.module
@@ -825,7 +825,7 @@ function _restful_invalidate_entity_cache($cid) {
       $version = $handler->getVersion();
       // Get the uid for the invalidation.
       try {
-        $uid = $handler->getAccount()->uid;
+        $uid = $handler->getAccount(FALSE)->uid;
       }
       catch (\RestfulUnauthorizedException $e) {
         // If no user could be found using the handler default to the logged in

--- a/restful.module
+++ b/restful.module
@@ -778,7 +778,7 @@ function restful_cron() {
  */
 function restful_entity_update($entity, $type) {
   list($entity_id) = entity_extract_ids($type, $entity);
-  $cid = 'et' . $type . '::ei' . $entity_id . '::uu';
+  $cid = 'paet:' . $type . '::ei:' . $entity_id;
   _restful_invalidate_entity_cache($cid);
 }
 
@@ -787,7 +787,7 @@ function restful_entity_update($entity, $type) {
  */
 function restful_entity_delete($entity, $type) {
   list($entity_id) = entity_extract_ids($type, $entity);
-  $cid = 'et' . $type . '::ei' . $entity_id . '::uu';
+  $cid = 'paet:' . $type . '::ei:' . $entity_id;
   _restful_invalidate_entity_cache($cid);
 }
 
@@ -823,7 +823,16 @@ function _restful_invalidate_entity_cache($cid) {
     $reflector = new \ReflectionClass($handler);
     if ($reflector->hasMethod('cacheInvalidate')) {
       $version = $handler->getVersion();
-      $version_cid = 'v' . $version['major'] . '.' . $version['minor'];
+      // Get the uid for the invalidation.
+      try {
+        $uid = $handler->getAccount()->uid;
+      }
+      catch (\RestfulUnauthorizedException $e) {
+        // If no user could be found using the handler default to the logged in
+        // user.
+        $uid = $GLOBALS['user']->uid;
+      }
+      $version_cid = 'v' . $version['major'] . '.' . $version['minor'] . '::uu' . $uid;
       $handler->cacheInvalidate($version_cid . '::' . $cid);
     }
   }

--- a/tests/RestfulAuthenticationTestCase.test
+++ b/tests/RestfulAuthenticationTestCase.test
@@ -2,10 +2,10 @@
 
 /**
  * @file
- * Contains RestfulAuthorizationEntityTestCase.
+ * Contains RestfulAuthenticationTestCase.
  */
 
-class RestfulAuthorizationTestCase extends RestfulCurlBaseTestCase {
+class RestfulAuthenticationTestCase extends RestfulCurlBaseTestCase {
 
   /**
    * Holds the generated account.

--- a/tests/RestfulRenderCacheTestCase.test
+++ b/tests/RestfulRenderCacheTestCase.test
@@ -56,7 +56,7 @@ class RestfulRenderCacheTestCase extends DrupalWebTestCase {
     $this->assertEqual($pre_cache_results[0], $post_cache_results[0], 'Cached data is consistent.');
     // Get a cached result directly from the cache backend.
     $node = reset($nodes);
-    $cid = 'v1.1::etnode::ei' . $node->nid . '::uu' . $account->uid . '::pa';
+    $cid = 'v1.1' . '::uu' . $account->uid . '::pa' . 'et:node::ei:' . $node->nid;
     $record = $cache->get($cid);
     $this->assertEqual($pre_cache_results[0], $record->data, 'Data in cache bins is correct.');
 
@@ -87,7 +87,7 @@ class RestfulRenderCacheTestCase extends DrupalWebTestCase {
     // Check that the cached results for the entity without request array are
     // different than with the request array.
     $cid_wo_request = $cid;
-    $cid_w_request = $cid_wo_request . 'fi:id,label';
+    $cid_w_request = $cid_wo_request . '::fi:id,label';
     $record = $cache->get($cid_w_request);
     // Check that the stored data for both cache ids exists and is different.
     $this->assertNotEqual($record->data, $cache->get($cid_wo_request)->data, 'Cache with request params is different.');


### PR DESCRIPTION
Issue #132

With this PR code is better structured and it opens the door to non-entity based endpoints (manual queries, views, …).

All that is not directly related to an entity has been moved to the `RestfulBase` class.

@amitaibu it should be pretty easy to review since I only did cut & paste and fixed the coupling with the render cache (and its tests).
