### PR TITLE
Use Vary header for minor versions 

### DIFF
--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -143,12 +143,7 @@ abstract class RestfulBase implements RestfulInterface {
   }
 
   /**
-   * Set the HTTP headers.
-   *
-   * @param string $key
-   *   The HTTP header key.
-   * @param string $value
-   *   The HTTP header value.
+   * {@inheritdoc}
    */
   public function setHttpHeaders($key, $value) {
     $this->httpHeaders[$key] = $value;

--- a/plugins/restful/RestfulInterface.php
+++ b/plugins/restful/RestfulInterface.php
@@ -86,6 +86,16 @@ interface RestfulInterface {
   public function getHttpHeaders();
 
   /**
+   * Set the HTTP headers.
+   *
+   * @param string $key
+   *   The HTTP header key.
+   * @param string $value
+   *   The HTTP header value.
+   */
+  public function setHttpHeaders($key, $value);
+
+  /**
    * Determine if user can access the handler.
    *
    * @return bool

--- a/restful.module
+++ b/restful.module
@@ -540,6 +540,12 @@ function restful_menu_process_callback($major_version, $resource_name) {
   $major_version = intval(str_replace('v', '', $major_version));
   $minor_version = !empty($_SERVER['HTTP_X_RESTFUL_MINOR_VERSION']) && is_numeric($_SERVER['HTTP_X_RESTFUL_MINOR_VERSION']) ? $_SERVER['HTTP_X_RESTFUL_MINOR_VERSION'] : 0;
   $handler = restful_get_restful_handler($resource_name, $major_version, $minor_version);
+  // If there is a minor version we need to Vary the response.
+  if ($minor_version) {
+    $headers = $handler->getHttpHeaders();
+    $vary = empty($headers['Vary']) ? '' : $headers['Vary'];
+    $handler->setHttpHeaders('Vary', $vary . ',X-Restful-Minor-Version');
+  }
 
   $path = func_get_args();
   unset($path[0], $path[1]);

--- a/tests/RestfulViewEntityTestCase.test
+++ b/tests/RestfulViewEntityTestCase.test
@@ -214,4 +214,16 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
     $this->assertEqual(array_keys($result[0]['image']['styles']) == array('thumbnail', 'medium', 'large'), 'The selected image styles are present.');
     $this->assertEqual(count(array_filter(array_values($result[0]['image']['styles']))) == 3, 'The image styles are populated.');
   }
+
+  /**
+   * Test the generation of the Vary headers.
+   */
+  public function testVaryHeader() {
+    // When there is no minor version passed in there is no need of Vary.
+    $response = $this->httpRequest('api/v1/articles');
+    $this->assertFalse(preg_match('/X-Restful-Minor-Version/', $response['headers']), 'The Vary header was not added.');
+
+    $response = $this->httpRequest('api/v1/articles', \RestfulInterface::GET, NULL, array('X-Restful-Minor-Version' => 1));
+    $this->assertTrue(preg_match('/X-Restful-Minor-Version/', $response['headers']), 'The Vary header was added.');
+  }
 }


### PR DESCRIPTION
**Edit**: If a header changes the output, then we need to list that header name in the `Vary` so proxy caches and cdns can do a decent work.

Also, the mobi version of github sucks. 
