### PR TITLE
move declaration of publicFieldsInfo and getFieldInfo into RestFulEntityInterface

### DIFF
--- a/plugins/restful/RestfulEntityInterface.php
+++ b/plugins/restful/RestfulEntityInterface.php
@@ -7,4 +7,21 @@
  */
 
 interface RestfulEntityInterface extends RestfulInterface {
+
+  /**
+   * Return the properties that should be public.
+   *
+   * @return array
+   */
+  public function publicFieldsInfo();
+
+  /**
+   * Return the properties that should be public after processing.
+   *
+   * Default values would be assigned to the properties declared in
+   * \RestfulInterface::publicFieldsInfo().
+   *
+   * @return array
+   */
+  public function getPublicFields();
 }

--- a/plugins/restful/RestfulEntityInterface.php
+++ b/plugins/restful/RestfulEntityInterface.php
@@ -24,4 +24,5 @@ interface RestfulEntityInterface extends RestfulInterface {
    * @return array
    */
   public function getPublicFields();
+
 }

--- a/plugins/restful/RestfulInterface.php
+++ b/plugins/restful/RestfulInterface.php
@@ -58,22 +58,7 @@ interface RestfulInterface {
   public function process($path = '', array $request = array(), $method = \RestfulInterface::GET, $check_rate_limit = TRUE);
 
 
-  /**
-   * Return the properties that should be public.
-   *
-   * @return array
-   */
-  public function publicFieldsInfo();
 
-  /**
-   * Return the properties that should be public after processing.
-   *
-   * Default values would be assigned to the properties declared in
-   * \RestfulInterface::publicFieldsInfo().
-   *
-   * @return array
-   */
-  public function getPublicFields();
 
   /**
    * Return array keyed by the header property, and the value.


### PR DESCRIPTION
Hi, 

I am trying to use restful to implement non-entity-based rest-handlers. I think the interface-declaration is a bit misleading, as publicFields and getFieldInfo look like an implementation-detail of RestFulEntityInterfaces.

Hope, you'll find this pull request valuable.

cheers,

Stephan
