### PR TITLE
Accept header negotiation for the output format.

### DIFF
--- a/modules/restful_example/plugins/formatter/RestfulFormatterHalXml.class.php
+++ b/modules/restful_example/plugins/formatter/RestfulFormatterHalXml.class.php
@@ -8,6 +8,13 @@
 class RestfulFormatterHalXml extends \RestfulFormatterHalJson implements \RestfulFormatterInterface {
 
   /**
+   * Content Type
+   *
+   * @var string
+   */
+  protected $contentType = 'application/xml; charset=utf-8';
+
+  /**
    * {@inheritdoc}
    */
   public function render(array $structured_data) {

--- a/plugins/formatter/RestfulFormatterBase.php
+++ b/plugins/formatter/RestfulFormatterBase.php
@@ -9,7 +9,7 @@ abstract class RestfulFormatterBase implements \RestfulFormatterInterface {
   /**
    * The entity handler containing more info about the request.
    *
-   * @var \RestfulEntityBase
+   * @var \RestfulBase
    */
   protected $handler;
 

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -305,7 +305,7 @@ abstract class RestfulBase implements RestfulInterface {
    *   The formatted output.
    */
   public function format(array $data) {
-    $formatter_handler = restful_get_formatter_handler($this->getPluginInfo('formatter'), $this);
+    $formatter_handler = restful_output_format($this);
     return $formatter_handler->format($data);
   }
 

--- a/restful.module
+++ b/restful.module
@@ -765,7 +765,9 @@ function restful_output_format(\RestfulBase $restful_handler = NULL) {
       return restful_get_formatter_handler($formatter_name, $restful_handler);
     }
   }
-  if (!empty($GLOBALS['_SERVER']['HTTP_ACCEPT'])) {
+  // Sometimes we will get a default Accept: */* in that case we want to return
+  // the default content type and not just any.
+  if (!empty($GLOBALS['_SERVER']['HTTP_ACCEPT']) && $GLOBALS['_SERVER']['HTTP_ACCEPT'] != '*/*') {
     foreach (explode(',', $GLOBALS['_SERVER']['HTTP_ACCEPT']) as $accepted_content_type) {
       // Loop through all the formatters and find the first one that matches the
       // Content-Type header.

--- a/restful.module
+++ b/restful.module
@@ -247,11 +247,22 @@ function restful_get_authentication_plugins() {
  * Include CTools plugins and get all rate_limit plugins.
  *
  * @return array
- *   All plugins for restful authentication.
+ *   All the restful rate_limit plugins.
  */
 function restful_get_rate_limit_plugins() {
   ctools_include('plugins');
   return ctools_get_plugins('restful', 'rate_limit');
+}
+
+/**
+ * Include CTools plugins and get all formatter plugins.
+ *
+ * @return array
+ *   All the restful formatter plugins.
+ */
+function restful_get_formatter_plugins() {
+  ctools_include('plugins');
+  return ctools_get_plugins('restful', 'formatter');
 }
 
 /**
@@ -501,7 +512,11 @@ function restful_get_formatter_handler($formatter_plugin_name, $restful_handler)
  *   The restful handler or NULL.
  */
 function restful_get_restful_handler_for_path($path = NULL) {
+  $handlers = &drupal_static(__FUNCTION__);
   $path = is_null($path) ? $_GET['q'] : $path;
+  if (isset($handlers[$path])) {
+    return $handlers[$path];
+  }
   $router_item = menu_get_item($path);
   // We can only get the information if the current path was processed by
   // restful_menu_process_callback.
@@ -511,7 +526,8 @@ function restful_get_restful_handler_for_path($path = NULL) {
   list($major_version, $resource) = $router_item['page_arguments'];
   $major_version = intval(str_replace('v', '', $major_version));
   $minor_version = !empty($_SERVER['HTTP_X_RESTFUL_MINOR_VERSION']) && is_numeric($_SERVER['HTTP_X_RESTFUL_MINOR_VERSION']) ? $_SERVER['HTTP_X_RESTFUL_MINOR_VERSION'] : 0;
-  return restful_get_restful_handler($resource, $major_version, $minor_version);
+  $handlers[$path] = restful_get_restful_handler($resource, $major_version, $minor_version);
+  return $handlers[$path];
 }
 
 /**

--- a/restful.module
+++ b/restful.module
@@ -528,7 +528,7 @@ function restful_get_restful_handler_for_path($path = NULL) {
   // We can only get the information if the current path was processed by
   // restful_menu_process_callback.
   if ($router_item['page_callback'] != 'restful_menu_process_callback') {
-    $handlers[$path] = NULL;
+    $handlers[$path] = FALSE;
     return;
   }
   list($major_version, $resource) = $router_item['page_arguments'];
@@ -731,7 +731,7 @@ function restful_delivery($var = NULL, $method = 'format') {
     }
   }
   try {
-    $formatter_handler = restful_output_format();
+    $formatter_handler = restful_output_format($restful_handler);
     $output = $formatter_handler->{$method}($var);
   }
   catch (\RestfulException $e) {
@@ -752,11 +752,14 @@ function restful_delivery($var = NULL, $method = 'format') {
 /**
  * Helper function to get the default output format from the current request.
  *
+ * @param \RestfulBase $restful_handler
+ *   The restful handler for the formatter.
+ *
  * @return \RestfulFormatterBase
  *   The formatter plugin to use.
  */
-function restful_output_format() {
-  if ($restful_handler = restful_get_restful_handler_for_path()) {
+function restful_output_format(\RestfulBase $restful_handler = NULL) {
+  if ($restful_handler || $restful_handler = restful_get_restful_handler_for_path()) {
     // If the plugin is specifying one particular output format, use that.
     if ($formatter_name = $restful_handler->getPluginInfo('formatter')) {
       return restful_get_formatter_handler($formatter_name, $restful_handler);

--- a/restful.module
+++ b/restful.module
@@ -759,11 +759,9 @@ function restful_delivery($var = NULL, $method = 'format') {
  *   The formatter plugin to use.
  */
 function restful_output_format(\RestfulBase $restful_handler = NULL) {
-  if ($restful_handler || $restful_handler = restful_get_restful_handler_for_path()) {
-    // If the plugin is specifying one particular output format, use that.
-    if ($formatter_name = $restful_handler->getPluginInfo('formatter')) {
-      return restful_get_formatter_handler($formatter_name, $restful_handler);
-    }
+  $restful_handler = $restful_handler ? $restful_handler : restful_get_restful_handler_for_path();
+  if ($restful_handler && $formatter_name = $restful_handler->getPluginInfo('formatter')) {
+    return restful_get_formatter_handler($formatter_name, $restful_handler);
   }
   // Sometimes we will get a default Accept: */* in that case we want to return
   // the default content type and not just any.
@@ -809,6 +807,9 @@ function restfult_match_content_type($content_type, $pattern) {
       '.*',
     );
     $patterns_quoted = preg_quote($pattern, '/');
+
+    // This will turn 'application/*' into '/^(application\/.*)(;.*)$/' allowing
+    // us to match 'application/json; charset: utf8'
     $regexps[$pattern] = '/^(' . preg_replace($to_replace, $replacements, $patterns_quoted) . ')(;.*)?$/i';
   }
   return (bool) preg_match($regexps[$pattern], $content_type);

--- a/restful.module
+++ b/restful.module
@@ -126,7 +126,6 @@ function restful_plugin_process_restful(&$plugin, $info) {
     'hook_menu' => TRUE,
     'cache' => array(),
     'autocomplete' => array(),
-    'formatter' => variable_get('restful_default_output_formatter', 'hal_json'),
   );
 
   $plugin['cache'] += array(
@@ -441,11 +440,15 @@ function restful_get_restful_handler($resource_name, $major_version = 1, $minor_
  *
  * @return RestfulInterface | NULL
  *   The handler object if found, or NULL.
+ *
+ * @throws \RestfulException
  */
 function restful_get_restful_handler_by_name($plugin_name) {
   ctools_include('plugins');
   $plugin = ctools_get_plugins('restful', 'restful', $plugin_name);
-  $class = ctools_plugin_load_class('restful', 'restful', $plugin_name, 'class');
+  if (!$class = ctools_plugin_load_class('restful', 'restful', $plugin_name, 'class')) {
+    throw new \RestfulServiceUnavailable('Restful plugin class not found.');
+  }
   $handler = new $class($plugin);
   // If the restful plugin needs authentication load the corresponding
   // authentication plugin.
@@ -478,7 +481,9 @@ function restful_get_restful_handler_by_name($plugin_name) {
  */
 function restful_get_authentication_handler($auth_plugin_name) {
   $auth_plugin = restful_get_authentication_plugin($auth_plugin_name);
-  $auth_class = ctools_plugin_get_class($auth_plugin, 'class');
+  if (!$auth_class = ctools_plugin_get_class($auth_plugin, 'class')) {
+    throw new \RestfulServiceUnavailable('Authentication plugin class not found.');
+  }
   return new $auth_class($auth_plugin);
 }
 
@@ -498,7 +503,9 @@ function restful_get_authentication_handler($auth_plugin_name) {
  */
 function restful_get_formatter_handler($formatter_plugin_name, $restful_handler) {
   $formatter_plugin = restful_get_formatter_plugin($formatter_plugin_name);
-  $formatter_class = ctools_plugin_get_class($formatter_plugin, 'class');
+  if (!$formatter_class = ctools_plugin_get_class($formatter_plugin, 'class')) {
+    throw new \RestfulServiceUnavailable('Formatter plugin class not found.');
+  }
   return new $formatter_class($formatter_plugin, $restful_handler);
 }
 
@@ -521,6 +528,7 @@ function restful_get_restful_handler_for_path($path = NULL) {
   // We can only get the information if the current path was processed by
   // restful_menu_process_callback.
   if ($router_item['page_callback'] != 'restful_menu_process_callback') {
+    $handlers[$path] = NULL;
     return;
   }
   list($major_version, $resource) = $router_item['page_arguments'];
@@ -717,17 +725,21 @@ function restful_delivery($var = NULL, $method = 'format') {
 
   // Get the formatter for the current resource.
   if ($restful_handler = restful_get_restful_handler_for_path()) {
-    $formatter_name = $restful_handler->getPluginInfo('formatter');
     // Allow the handler to change the HTTP headers.
     foreach ($restful_handler->getHttpHeaders() as $key => $value) {
       drupal_add_http_header($key, $value);
     }
   }
-  else {
-    $formatter_name = variable_get('restful_default_output_formatter', 'hal_json');
+  try {
+    $formatter_handler = restful_output_format();
+    $output = $formatter_handler->{$method}($var);
   }
-  $formatter_handler = restful_get_formatter_handler($formatter_name, $restful_handler);
-  $output = $formatter_handler->{$method}($var);
+  catch (\RestfulException $e) {
+    // Handle if the formatter does not exist.
+    drupal_add_http_header('Status', $e->getCode());
+    echo $e->getMessage();
+    return;
+  }
 
   // The content type header is modified after the massaging if there is an
   // error code. Therefore we need to set the content type header after
@@ -735,6 +747,66 @@ function restful_delivery($var = NULL, $method = 'format') {
   drupal_add_http_header('Content-Type', $formatter_handler->getContentTypeHeader());
 
   echo $output;
+}
+
+/**
+ * Helper function to get the default output format from the current request.
+ *
+ * @return \RestfulFormatterBase
+ *   The formatter plugin to use.
+ */
+function restful_output_format() {
+  if ($restful_handler = restful_get_restful_handler_for_path()) {
+    // If the plugin is specifying one particular output format, use that.
+    if ($formatter_name = $restful_handler->getPluginInfo('formatter')) {
+      return restful_get_formatter_handler($formatter_name, $restful_handler);
+    }
+  }
+  if (!empty($GLOBALS['_SERVER']['HTTP_ACCEPT'])) {
+    foreach (explode(',', $GLOBALS['_SERVER']['HTTP_ACCEPT']) as $accepted_content_type) {
+      // Loop through all the formatters and find the first one that matches the
+      // Content-Type header.
+      foreach (restful_get_formatter_plugins() as $formatter_info) {
+        $formatter = restful_get_formatter_handler($formatter_info['name'], $restful_handler);
+        if (restfult_match_content_type($formatter->getContentTypeHeader(), $accepted_content_type)) {
+          return $formatter;
+        }
+      }
+    }
+  }
+  $formatter_name = variable_get('restful_default_output_formatter', 'hal_json');
+  return restful_get_formatter_handler($formatter_name, $restful_handler);
+}
+
+/**
+ * Matches a string with path style wildcards.
+ *
+ * @param string $content_type
+ *   The string to check.
+ * @param string $pattern
+ *   The pattern to check against.
+ *
+ * @return bool
+ *   TRUE if the input matches the pattern.
+ *
+ * @see drupal_match_path().
+ */
+function restfult_match_content_type($content_type, $pattern) {
+  $regexps = &drupal_static(__FUNCTION__);
+
+  if (!isset($regexps[$pattern])) {
+    // Convert path settings to a regular expression.
+    // Therefore replace newlines with a logical or, /* with asterisks and the <front> with the frontpage.
+    $to_replace = array(
+      '/\\\\\*/', // asterisks
+    );
+    $replacements = array(
+      '.*',
+    );
+    $patterns_quoted = preg_quote($pattern, '/');
+    $regexps[$pattern] = '/^(' . preg_replace($to_replace, $replacements, $patterns_quoted) . ')(;.*)?$/i';
+  }
+  return (bool) preg_match($regexps[$pattern], $content_type);
 }
 
 /**

--- a/restful.module
+++ b/restful.module
@@ -799,7 +799,6 @@ function restfult_match_content_type($content_type, $pattern) {
 
   if (!isset($regexps[$pattern])) {
     // Convert path settings to a regular expression.
-    // Therefore replace newlines with a logical or, /* with asterisks and the <front> with the frontpage.
     $to_replace = array(
       '/\\\\\*/', // asterisks
     );

--- a/tests/RestfulViewEntityTestCase.test
+++ b/tests/RestfulViewEntityTestCase.test
@@ -236,7 +236,7 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
    * Test the generation of the Vary headers.
    */
   public function testHeaders() {
-    $node = $this->drupalCreateNode(array('type' => 'article', 'status' => NODE_PUBLISHED));
+    $node = $this->drupalCreateNode(array('type' => 'article'));
 
     // When there is no minor version passed in there is no need of Vary.
     $response = $this->httpRequest('api/v1/articles');
@@ -265,6 +265,13 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
       'Accept' => 'application/*',
     ));
     $this->assertEqual($response['code'], 200, 'Some output format detected for wildcard Accept.');
+
+    // Test that plugin definition takes precedence.
+    $response = $this->httpRequest('api/v1/articles/' . $node->nid, \RestfulInterface::GET, NULL, array(
+      'X-Restful-Minor-Version' => 6,
+      'Accept' => 'application/hal+json',
+    ));
+    $this->assertNotNull(new SimpleXMLElement($response['body']), 'Plugin definition takes precedence.');
 
     // The following should resolve to the 'invalid' formatter. It should raise
     // an exception.

--- a/tests/RestfulViewEntityTestCase.test
+++ b/tests/RestfulViewEntityTestCase.test
@@ -252,15 +252,13 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
     $response = $this->httpRequest('api/v1/articles/' . $node->nid, \RestfulInterface::GET, NULL, array(
       'Accept' => 'application/hal+json',
     ));
-    $result = drupal_json_decode($response['body']);
-    $this->assertNotNull($result, 'JSON output detected.');
+    $this->assertNotNull(drupal_json_decode($response['body']), 'JSON output detected.');
 
     // Test XML selection.
     $response = $this->httpRequest('api/v1/articles/' . $node->nid, \RestfulInterface::GET, NULL, array(
       'Accept' => 'application/xml',
     ));
-    $result = new SimpleXMLElement($response['body']);
-    $this->assertNotNull($result, 'JSON output detected.');
+    $this->assertNotNull(new SimpleXMLElement($response['body']), 'XML output detected.');
 
     // Test wildcard selection.
     $response = $this->httpRequest('api/v1/articles/' . $node->nid, \RestfulInterface::GET, NULL, array(

--- a/tests/RestfulViewEntityTestCase.test
+++ b/tests/RestfulViewEntityTestCase.test
@@ -31,206 +31,206 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
    * v1.4 - Non-existing "process callback" property.
    * v1.6 - XML output format.
    */
-//  function testViewEntity() {
-//    $user1 = $this->drupalCreateUser();
-//    $entity1 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
-//    $entity1->save();
-//
-//    $entity2 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
-//    $entity2->save();
-//
-//    $entity3 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
-//    $wrapper = entity_metadata_wrapper('entity_test', $entity3);
-//
-//    $text1 = $this->randomName();
-//    $text2 = $this->randomName();
-//
-//
-//    $wrapper->text_single->set($text1);
-//    $wrapper->text_multiple->set(array($text1, $text2));
-//
-//    $wrapper->entity_reference_single->set($entity1);
-//    $wrapper->entity_reference_multiple[] = $entity1;
-//    $wrapper->entity_reference_multiple[] = $entity2;
-//
-//    $wrapper->save();
-//
-//    $id = $entity3->pid;
-//
-//    $base_expected_result = array(
-//      'id' => $id,
-//      'label' => 'Main test type',
-//      'self' => url('custom/' . $id, array('absolute' => TRUE)),
-//    );
-//
-//    // v1.0 - Simple entity view (id, label, self).
-//    $handler = restful_get_restful_handler('main', 1, 0);
-//    $expected_result = $base_expected_result;
-//
-//    $response = $handler->get($id);
-//    $result = $response[0];
-//    $this->assertEqual($result, $expected_result, 'Entity view has expected result for "main" resource v1');
-//
-//    // v1.1 - Text and entity reference field.
-//    $handler = restful_get_restful_handler('main', 1, 1);
-//    $response = $handler->get($id);
-//    $result = $response[0];
-//
-//    $base_expected_result_v1 = $base_expected_result;
-//
-//    // NULL fields.
-//    $base_expected_result_v1 += array(
-//      'text_single_processing' => NULL,
-//      'text_multiple_processing' => NULL,
-//      'term_single' => NULL,
-//      'term_multiple' => NULL,
-//      'file_single' => NULL,
-//      'file_multiple' => NULL,
-//      'image_single' => NULL,
-//      'image_multiple' => NULL,
-//    );
-//
-//    $expected_result = $base_expected_result_v1;
-//    $expected_result['text_single'] = $text1;
-//    $expected_result['text_multiple'] = array($text1, $text2);
-//    $expected_result['entity_reference_single'] = $entity1->pid;
-//    $expected_result['entity_reference_multiple'] = array(
-//      $entity1->pid,
-//      $entity2->pid,
-//    );
-//
-//    $response = $handler->get($entity1->pid);
-//    $expected_result['entity_reference_single_resource'] = $response[0];
-//    $response1 = $handler->get($entity1->pid);
-//    $response2 = $handler->get($entity2->pid);
-//    $expected_result['entity_reference_multiple_resource'] = array(
-//      $response1[0],
-//      $response2[0],
-//    );
-//
-//    $stripped_result = $result;
-//    $stripped_result['text_single'] = trim(strip_tags($result['text_single']));
-//    $stripped_result['text_multiple'][0] = trim(strip_tags($result['text_multiple'][0]));
-//    $stripped_result['text_multiple'][1] = trim(strip_tags($result['text_multiple'][1]));
-//
-//    ksort($stripped_result);
-//    ksort($expected_result);
-//    $this->assertEqual($stripped_result, $expected_result, 'Entity view has correct result for "main" resource v1.1');
-//
-//    // Test the "full_view" property on a referenced entity.
-//    // We change the definition via the handler instead of creating another
-//    // plugin.
-//    $public_fields = $handler->getPublicFields();
-//    // Single entity reference field with "resource".
-//    $public_fields['entity_reference_single_resource']['resource'] = array(
-//      'main' => array(
-//        'name' => 'main',
-//        'full_view' => FALSE,
-//      ),
-//    );
-//    $handler->setPublicFields($public_fields);
-//
-//    $result = $handler->get($id);
-//    $this->assertEqual($result[0]['entity_reference_single_resource'], $entity1->pid, '"full_view" property is working properly.');
-//
-//    // Empty the text and entity reference fields.
-//    $wrapper->text_single->set(NULL);
-//    $wrapper->text_multiple->set(NULL);
-//    $wrapper->entity_reference_single->set(NULL);
-//    $wrapper->entity_reference_multiple->set(NULL);
-//    $wrapper->save();
-//
-//    $response = $handler->get($id);
-//    $result = $response[0];
-//    $expected_result = $base_expected_result_v1;
-//    $expected_result['text_single'] = NULL;
-//    $expected_result['text_multiple'] = NULL;
-//    $expected_result['text_single'] = NULL;
-//    $expected_result['text_multiple'] = NULL;
-//    $expected_result['entity_reference_single'] = NULL;
-//    $expected_result['entity_reference_multiple'] = NULL;
-//    $expected_result['entity_reference_single_resource'] = NULL;
-//    $expected_result['entity_reference_multiple_resource'] = NULL;
-//
-//    ksort($result);
-//    ksort($expected_result);
-//    $this->assertEqual($result, $expected_result, 'Entity view has correct result for "main" resource v1.1 with empty entity reference.');
-//
-//
-//    // v1.2 - "callback" and "process callback".
-//    $handler = restful_get_restful_handler('main', 1, 2);
-//    $response = $handler->get($id);
-//    $result = $response[0];
-//    $expected_result = $base_expected_result;
-//    $expected_result['callback'] = 'callback';
-//    $expected_result['process_callback_from_callback'] = 'callback processed from callback';
-//    $expected_result['process_callback_from_value'] = $id . ' processed from value';
-//    $this->assertEqual($result, $expected_result, 'Entity view has correct result for "main" resource v1.2');
-//
-//    // v1.3 - Non-existing "callback" property.
-//    $handler = restful_get_restful_handler('main', 1, 3);
-//    try {
-//      $handler->get($id);
-//      $this->fail('Non-existing "callback" property did not trigger an exception.');
-//    }
-//    catch(Exception $e) {
-//      $this->pass('Non-existing "callback" property triggered an exception.');
-//    }
-//
-//    // v1.4 - Non-existing "process callback" property.
-//    $handler = restful_get_restful_handler('main', 1, 4);
-//    try {
-//      $handler->get($id);
-//      $this->fail('Non-existing "process callback" property did not trigger an exception.');
-//    }
-//    catch(Exception $e) {
-//      $this->pass('Non-existing "process callback" property triggered an exception.');
-//    }
-//
-//    // v1.6 - XML output format.
-//    $settings = array(
-//      'type' => 'article',
-//      'uid' => $user1->uid,
-//    );
-//    $node = $this->drupalCreateNode($settings);
-//
-//    $headers = array('X-Restful-Minor-Version' => 6);
-//    $response = $this->httpRequest('api/v1/articles', \RestfulInterface::GET, NULL, $headers);
-//    // Returns something like:
-//    // <api>
-//    //   <data>
-//    //     <item0>
-//    //       <id>1</id>
-//    //       <label>Foo</label>
-//    //       <self>http://example.com/node/1</self>
-//    //       <body>...</body>
-//    //     </item0>
-//    //   </data>
-//    //   <count>50</count>
-//    //   <_links>
-//    //     <next>https://example.com/api/v1/articles</next>
-//    //   </_links>
-//    // </api>
-//
-//    $xml = new SimpleXMLElement($response['body']);
-//    $results = $xml->xpath('/api/data/item0/label');
-//    $result = reset($results);
-//
-//    $this->assertEqual($node->title, $result->__toString(), 'XML parsed correctlty.');
-//
-//    // Test Image variations based on image styles.
-//    $images = $this->drupalGetTestFiles('image');
-//    $image = reset($images);
-//    $image = file_save((object) $image);
-//    $article = $this->drupalCreateNode(array(
-//      'type' => 'article',
-//      'field_image' => array(LANGUAGE_NONE => array(array('fid' => $image->fid))),
-//    ));
-//    $handler = restful_get_restful_handler('articles', 1, 5);
-//    $result = $handler->get($article->nid);
-//    $this->assertEqual(array_keys($result[0]['image']['styles']) == array('thumbnail', 'medium', 'large'), 'The selected image styles are present.');
-//    $this->assertEqual(count(array_filter(array_values($result[0]['image']['styles']))) == 3, 'The image styles are populated.');
-//  }
+  function testViewEntity() {
+    $user1 = $this->drupalCreateUser();
+    $entity1 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
+    $entity1->save();
+
+    $entity2 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
+    $entity2->save();
+
+    $entity3 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
+    $wrapper = entity_metadata_wrapper('entity_test', $entity3);
+
+    $text1 = $this->randomName();
+    $text2 = $this->randomName();
+
+
+    $wrapper->text_single->set($text1);
+    $wrapper->text_multiple->set(array($text1, $text2));
+
+    $wrapper->entity_reference_single->set($entity1);
+    $wrapper->entity_reference_multiple[] = $entity1;
+    $wrapper->entity_reference_multiple[] = $entity2;
+
+    $wrapper->save();
+
+    $id = $entity3->pid;
+
+    $base_expected_result = array(
+      'id' => $id,
+      'label' => 'Main test type',
+      'self' => url('custom/' . $id, array('absolute' => TRUE)),
+    );
+
+    // v1.0 - Simple entity view (id, label, self).
+    $handler = restful_get_restful_handler('main', 1, 0);
+    $expected_result = $base_expected_result;
+
+    $response = $handler->get($id);
+    $result = $response[0];
+    $this->assertEqual($result, $expected_result, 'Entity view has expected result for "main" resource v1');
+
+    // v1.1 - Text and entity reference field.
+    $handler = restful_get_restful_handler('main', 1, 1);
+    $response = $handler->get($id);
+    $result = $response[0];
+
+    $base_expected_result_v1 = $base_expected_result;
+
+    // NULL fields.
+    $base_expected_result_v1 += array(
+      'text_single_processing' => NULL,
+      'text_multiple_processing' => NULL,
+      'term_single' => NULL,
+      'term_multiple' => NULL,
+      'file_single' => NULL,
+      'file_multiple' => NULL,
+      'image_single' => NULL,
+      'image_multiple' => NULL,
+    );
+
+    $expected_result = $base_expected_result_v1;
+    $expected_result['text_single'] = $text1;
+    $expected_result['text_multiple'] = array($text1, $text2);
+    $expected_result['entity_reference_single'] = $entity1->pid;
+    $expected_result['entity_reference_multiple'] = array(
+      $entity1->pid,
+      $entity2->pid,
+    );
+
+    $response = $handler->get($entity1->pid);
+    $expected_result['entity_reference_single_resource'] = $response[0];
+    $response1 = $handler->get($entity1->pid);
+    $response2 = $handler->get($entity2->pid);
+    $expected_result['entity_reference_multiple_resource'] = array(
+      $response1[0],
+      $response2[0],
+    );
+
+    $stripped_result = $result;
+    $stripped_result['text_single'] = trim(strip_tags($result['text_single']));
+    $stripped_result['text_multiple'][0] = trim(strip_tags($result['text_multiple'][0]));
+    $stripped_result['text_multiple'][1] = trim(strip_tags($result['text_multiple'][1]));
+
+    ksort($stripped_result);
+    ksort($expected_result);
+    $this->assertEqual($stripped_result, $expected_result, 'Entity view has correct result for "main" resource v1.1');
+
+    // Test the "full_view" property on a referenced entity.
+    // We change the definition via the handler instead of creating another
+    // plugin.
+    $public_fields = $handler->getPublicFields();
+    // Single entity reference field with "resource".
+    $public_fields['entity_reference_single_resource']['resource'] = array(
+      'main' => array(
+        'name' => 'main',
+        'full_view' => FALSE,
+      ),
+    );
+    $handler->setPublicFields($public_fields);
+
+    $result = $handler->get($id);
+    $this->assertEqual($result[0]['entity_reference_single_resource'], $entity1->pid, '"full_view" property is working properly.');
+
+    // Empty the text and entity reference fields.
+    $wrapper->text_single->set(NULL);
+    $wrapper->text_multiple->set(NULL);
+    $wrapper->entity_reference_single->set(NULL);
+    $wrapper->entity_reference_multiple->set(NULL);
+    $wrapper->save();
+
+    $response = $handler->get($id);
+    $result = $response[0];
+    $expected_result = $base_expected_result_v1;
+    $expected_result['text_single'] = NULL;
+    $expected_result['text_multiple'] = NULL;
+    $expected_result['text_single'] = NULL;
+    $expected_result['text_multiple'] = NULL;
+    $expected_result['entity_reference_single'] = NULL;
+    $expected_result['entity_reference_multiple'] = NULL;
+    $expected_result['entity_reference_single_resource'] = NULL;
+    $expected_result['entity_reference_multiple_resource'] = NULL;
+
+    ksort($result);
+    ksort($expected_result);
+    $this->assertEqual($result, $expected_result, 'Entity view has correct result for "main" resource v1.1 with empty entity reference.');
+
+
+    // v1.2 - "callback" and "process callback".
+    $handler = restful_get_restful_handler('main', 1, 2);
+    $response = $handler->get($id);
+    $result = $response[0];
+    $expected_result = $base_expected_result;
+    $expected_result['callback'] = 'callback';
+    $expected_result['process_callback_from_callback'] = 'callback processed from callback';
+    $expected_result['process_callback_from_value'] = $id . ' processed from value';
+    $this->assertEqual($result, $expected_result, 'Entity view has correct result for "main" resource v1.2');
+
+    // v1.3 - Non-existing "callback" property.
+    $handler = restful_get_restful_handler('main', 1, 3);
+    try {
+      $handler->get($id);
+      $this->fail('Non-existing "callback" property did not trigger an exception.');
+    }
+    catch(Exception $e) {
+      $this->pass('Non-existing "callback" property triggered an exception.');
+    }
+
+    // v1.4 - Non-existing "process callback" property.
+    $handler = restful_get_restful_handler('main', 1, 4);
+    try {
+      $handler->get($id);
+      $this->fail('Non-existing "process callback" property did not trigger an exception.');
+    }
+    catch(Exception $e) {
+      $this->pass('Non-existing "process callback" property triggered an exception.');
+    }
+
+    // v1.6 - XML output format.
+    $settings = array(
+      'type' => 'article',
+      'uid' => $user1->uid,
+    );
+    $node = $this->drupalCreateNode($settings);
+
+    $headers = array('X-Restful-Minor-Version' => 6);
+    $response = $this->httpRequest('api/v1/articles', \RestfulInterface::GET, NULL, $headers);
+    // Returns something like:
+    // <api>
+    //   <data>
+    //     <item0>
+    //       <id>1</id>
+    //       <label>Foo</label>
+    //       <self>http://example.com/node/1</self>
+    //       <body>...</body>
+    //     </item0>
+    //   </data>
+    //   <count>50</count>
+    //   <_links>
+    //     <next>https://example.com/api/v1/articles</next>
+    //   </_links>
+    // </api>
+
+    $xml = new SimpleXMLElement($response['body']);
+    $results = $xml->xpath('/api/data/item0/label');
+    $result = reset($results);
+
+    $this->assertEqual($node->title, $result->__toString(), 'XML parsed correctlty.');
+
+    // Test Image variations based on image styles.
+    $images = $this->drupalGetTestFiles('image');
+    $image = reset($images);
+    $image = file_save((object) $image);
+    $article = $this->drupalCreateNode(array(
+      'type' => 'article',
+      'field_image' => array(LANGUAGE_NONE => array(array('fid' => $image->fid))),
+    ));
+    $handler = restful_get_restful_handler('articles', 1, 5);
+    $result = $handler->get($article->nid);
+    $this->assertEqual(array_keys($result[0]['image']['styles']) == array('thumbnail', 'medium', 'large'), 'The selected image styles are present.');
+    $this->assertEqual(count(array_filter(array_values($result[0]['image']['styles']))) == 3, 'The image styles are populated.');
+  }
 
   /**
    * Test the generation of the Vary headers.

--- a/tests/RestfulViewEntityTestCase.test
+++ b/tests/RestfulViewEntityTestCase.test
@@ -31,216 +31,248 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
    * v1.4 - Non-existing "process callback" property.
    * v1.6 - XML output format.
    */
-  function testViewEntity() {
-    $user1 = $this->drupalCreateUser();
-    $entity1 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
-    $entity1->save();
-
-    $entity2 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
-    $entity2->save();
-
-    $entity3 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
-    $wrapper = entity_metadata_wrapper('entity_test', $entity3);
-
-    $text1 = $this->randomName();
-    $text2 = $this->randomName();
-
-
-    $wrapper->text_single->set($text1);
-    $wrapper->text_multiple->set(array($text1, $text2));
-
-    $wrapper->entity_reference_single->set($entity1);
-    $wrapper->entity_reference_multiple[] = $entity1;
-    $wrapper->entity_reference_multiple[] = $entity2;
-
-    $wrapper->save();
-
-    $id = $entity3->pid;
-
-    $base_expected_result = array(
-      'id' => $id,
-      'label' => 'Main test type',
-      'self' => url('custom/' . $id, array('absolute' => TRUE)),
-    );
-
-    // v1.0 - Simple entity view (id, label, self).
-    $handler = restful_get_restful_handler('main', 1, 0);
-    $expected_result = $base_expected_result;
-
-    $response = $handler->get($id);
-    $result = $response[0];
-    $this->assertEqual($result, $expected_result, 'Entity view has expected result for "main" resource v1');
-
-    // v1.1 - Text and entity reference field.
-    $handler = restful_get_restful_handler('main', 1, 1);
-    $response = $handler->get($id);
-    $result = $response[0];
-
-    $base_expected_result_v1 = $base_expected_result;
-
-    // NULL fields.
-    $base_expected_result_v1 += array(
-      'text_single_processing' => NULL,
-      'text_multiple_processing' => NULL,
-      'term_single' => NULL,
-      'term_multiple' => NULL,
-      'file_single' => NULL,
-      'file_multiple' => NULL,
-      'image_single' => NULL,
-      'image_multiple' => NULL,
-    );
-
-    $expected_result = $base_expected_result_v1;
-    $expected_result['text_single'] = $text1;
-    $expected_result['text_multiple'] = array($text1, $text2);
-    $expected_result['entity_reference_single'] = $entity1->pid;
-    $expected_result['entity_reference_multiple'] = array(
-      $entity1->pid,
-      $entity2->pid,
-    );
-
-    $response = $handler->get($entity1->pid);
-    $expected_result['entity_reference_single_resource'] = $response[0];
-    $response1 = $handler->get($entity1->pid);
-    $response2 = $handler->get($entity2->pid);
-    $expected_result['entity_reference_multiple_resource'] = array(
-      $response1[0],
-      $response2[0],
-    );
-
-    $stripped_result = $result;
-    $stripped_result['text_single'] = trim(strip_tags($result['text_single']));
-    $stripped_result['text_multiple'][0] = trim(strip_tags($result['text_multiple'][0]));
-    $stripped_result['text_multiple'][1] = trim(strip_tags($result['text_multiple'][1]));
-
-    ksort($stripped_result);
-    ksort($expected_result);
-    $this->assertEqual($stripped_result, $expected_result, 'Entity view has correct result for "main" resource v1.1');
-
-    // Test the "full_view" property on a referenced entity.
-    // We change the definition via the handler instead of creating another
-    // plugin.
-    $public_fields = $handler->getPublicFields();
-    // Single entity reference field with "resource".
-    $public_fields['entity_reference_single_resource']['resource'] = array(
-      'main' => array(
-        'name' => 'main',
-        'full_view' => FALSE,
-      ),
-    );
-    $handler->setPublicFields($public_fields);
-
-    $result = $handler->get($id);
-    $this->assertEqual($result[0]['entity_reference_single_resource'], $entity1->pid, '"full_view" property is working properly.');
-
-    // Empty the text and entity reference fields.
-    $wrapper->text_single->set(NULL);
-    $wrapper->text_multiple->set(NULL);
-    $wrapper->entity_reference_single->set(NULL);
-    $wrapper->entity_reference_multiple->set(NULL);
-    $wrapper->save();
-
-    $response = $handler->get($id);
-    $result = $response[0];
-    $expected_result = $base_expected_result_v1;
-    $expected_result['text_single'] = NULL;
-    $expected_result['text_multiple'] = NULL;
-    $expected_result['text_single'] = NULL;
-    $expected_result['text_multiple'] = NULL;
-    $expected_result['entity_reference_single'] = NULL;
-    $expected_result['entity_reference_multiple'] = NULL;
-    $expected_result['entity_reference_single_resource'] = NULL;
-    $expected_result['entity_reference_multiple_resource'] = NULL;
-
-    ksort($result);
-    ksort($expected_result);
-    $this->assertEqual($result, $expected_result, 'Entity view has correct result for "main" resource v1.1 with empty entity reference.');
-
-
-    // v1.2 - "callback" and "process callback".
-    $handler = restful_get_restful_handler('main', 1, 2);
-    $response = $handler->get($id);
-    $result = $response[0];
-    $expected_result = $base_expected_result;
-    $expected_result['callback'] = 'callback';
-    $expected_result['process_callback_from_callback'] = 'callback processed from callback';
-    $expected_result['process_callback_from_value'] = $id . ' processed from value';
-    $this->assertEqual($result, $expected_result, 'Entity view has correct result for "main" resource v1.2');
-
-    // v1.3 - Non-existing "callback" property.
-    $handler = restful_get_restful_handler('main', 1, 3);
-    try {
-      $handler->get($id);
-      $this->fail('Non-existing "callback" property did not trigger an exception.');
-    }
-    catch(Exception $e) {
-      $this->pass('Non-existing "callback" property triggered an exception.');
-    }
-
-    // v1.4 - Non-existing "process callback" property.
-    $handler = restful_get_restful_handler('main', 1, 4);
-    try {
-      $handler->get($id);
-      $this->fail('Non-existing "process callback" property did not trigger an exception.');
-    }
-    catch(Exception $e) {
-      $this->pass('Non-existing "process callback" property triggered an exception.');
-    }
-
-    // v1.6 - XML output format.
-    $settings = array(
-      'type' => 'article',
-      'uid' => $user1->uid,
-    );
-    $node = $this->drupalCreateNode($settings);
-
-    $headers = array('X-Restful-Minor-Version' => 6);
-    $response = $this->httpRequest('api/v1/articles', \RestfulInterface::GET, NULL, $headers);
-    // Returns something like:
-    // <api>
-    //   <data>
-    //     <item0>
-    //       <id>1</id>
-    //       <label>Foo</label>
-    //       <self>http://example.com/node/1</self>
-    //       <body>...</body>
-    //     </item0>
-    //   </data>
-    //   <count>50</count>
-    //   <_links>
-    //     <next>https://example.com/api/v1/articles</next>
-    //   </_links>
-    // </api>
-
-    $xml = new SimpleXMLElement($response['body']);
-    $results = $xml->xpath('/api/data/item0/label');
-    $result = reset($results);
-
-    $this->assertEqual($node->title, $result->__toString(), 'XML parsed correctlty.');
-
-    // Test Image variations based on image styles.
-    $images = $this->drupalGetTestFiles('image');
-    $image = reset($images);
-    $image = file_save((object) $image);
-    $article = $this->drupalCreateNode(array(
-      'type' => 'article',
-      'field_image' => array(LANGUAGE_NONE => array(array('fid' => $image->fid))),
-    ));
-    $handler = restful_get_restful_handler('articles', 1, 5);
-    $result = $handler->get($article->nid);
-    $this->assertEqual(array_keys($result[0]['image']['styles']) == array('thumbnail', 'medium', 'large'), 'The selected image styles are present.');
-    $this->assertEqual(count(array_filter(array_values($result[0]['image']['styles']))) == 3, 'The image styles are populated.');
-  }
+//  function testViewEntity() {
+//    $user1 = $this->drupalCreateUser();
+//    $entity1 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
+//    $entity1->save();
+//
+//    $entity2 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
+//    $entity2->save();
+//
+//    $entity3 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
+//    $wrapper = entity_metadata_wrapper('entity_test', $entity3);
+//
+//    $text1 = $this->randomName();
+//    $text2 = $this->randomName();
+//
+//
+//    $wrapper->text_single->set($text1);
+//    $wrapper->text_multiple->set(array($text1, $text2));
+//
+//    $wrapper->entity_reference_single->set($entity1);
+//    $wrapper->entity_reference_multiple[] = $entity1;
+//    $wrapper->entity_reference_multiple[] = $entity2;
+//
+//    $wrapper->save();
+//
+//    $id = $entity3->pid;
+//
+//    $base_expected_result = array(
+//      'id' => $id,
+//      'label' => 'Main test type',
+//      'self' => url('custom/' . $id, array('absolute' => TRUE)),
+//    );
+//
+//    // v1.0 - Simple entity view (id, label, self).
+//    $handler = restful_get_restful_handler('main', 1, 0);
+//    $expected_result = $base_expected_result;
+//
+//    $response = $handler->get($id);
+//    $result = $response[0];
+//    $this->assertEqual($result, $expected_result, 'Entity view has expected result for "main" resource v1');
+//
+//    // v1.1 - Text and entity reference field.
+//    $handler = restful_get_restful_handler('main', 1, 1);
+//    $response = $handler->get($id);
+//    $result = $response[0];
+//
+//    $base_expected_result_v1 = $base_expected_result;
+//
+//    // NULL fields.
+//    $base_expected_result_v1 += array(
+//      'text_single_processing' => NULL,
+//      'text_multiple_processing' => NULL,
+//      'term_single' => NULL,
+//      'term_multiple' => NULL,
+//      'file_single' => NULL,
+//      'file_multiple' => NULL,
+//      'image_single' => NULL,
+//      'image_multiple' => NULL,
+//    );
+//
+//    $expected_result = $base_expected_result_v1;
+//    $expected_result['text_single'] = $text1;
+//    $expected_result['text_multiple'] = array($text1, $text2);
+//    $expected_result['entity_reference_single'] = $entity1->pid;
+//    $expected_result['entity_reference_multiple'] = array(
+//      $entity1->pid,
+//      $entity2->pid,
+//    );
+//
+//    $response = $handler->get($entity1->pid);
+//    $expected_result['entity_reference_single_resource'] = $response[0];
+//    $response1 = $handler->get($entity1->pid);
+//    $response2 = $handler->get($entity2->pid);
+//    $expected_result['entity_reference_multiple_resource'] = array(
+//      $response1[0],
+//      $response2[0],
+//    );
+//
+//    $stripped_result = $result;
+//    $stripped_result['text_single'] = trim(strip_tags($result['text_single']));
+//    $stripped_result['text_multiple'][0] = trim(strip_tags($result['text_multiple'][0]));
+//    $stripped_result['text_multiple'][1] = trim(strip_tags($result['text_multiple'][1]));
+//
+//    ksort($stripped_result);
+//    ksort($expected_result);
+//    $this->assertEqual($stripped_result, $expected_result, 'Entity view has correct result for "main" resource v1.1');
+//
+//    // Test the "full_view" property on a referenced entity.
+//    // We change the definition via the handler instead of creating another
+//    // plugin.
+//    $public_fields = $handler->getPublicFields();
+//    // Single entity reference field with "resource".
+//    $public_fields['entity_reference_single_resource']['resource'] = array(
+//      'main' => array(
+//        'name' => 'main',
+//        'full_view' => FALSE,
+//      ),
+//    );
+//    $handler->setPublicFields($public_fields);
+//
+//    $result = $handler->get($id);
+//    $this->assertEqual($result[0]['entity_reference_single_resource'], $entity1->pid, '"full_view" property is working properly.');
+//
+//    // Empty the text and entity reference fields.
+//    $wrapper->text_single->set(NULL);
+//    $wrapper->text_multiple->set(NULL);
+//    $wrapper->entity_reference_single->set(NULL);
+//    $wrapper->entity_reference_multiple->set(NULL);
+//    $wrapper->save();
+//
+//    $response = $handler->get($id);
+//    $result = $response[0];
+//    $expected_result = $base_expected_result_v1;
+//    $expected_result['text_single'] = NULL;
+//    $expected_result['text_multiple'] = NULL;
+//    $expected_result['text_single'] = NULL;
+//    $expected_result['text_multiple'] = NULL;
+//    $expected_result['entity_reference_single'] = NULL;
+//    $expected_result['entity_reference_multiple'] = NULL;
+//    $expected_result['entity_reference_single_resource'] = NULL;
+//    $expected_result['entity_reference_multiple_resource'] = NULL;
+//
+//    ksort($result);
+//    ksort($expected_result);
+//    $this->assertEqual($result, $expected_result, 'Entity view has correct result for "main" resource v1.1 with empty entity reference.');
+//
+//
+//    // v1.2 - "callback" and "process callback".
+//    $handler = restful_get_restful_handler('main', 1, 2);
+//    $response = $handler->get($id);
+//    $result = $response[0];
+//    $expected_result = $base_expected_result;
+//    $expected_result['callback'] = 'callback';
+//    $expected_result['process_callback_from_callback'] = 'callback processed from callback';
+//    $expected_result['process_callback_from_value'] = $id . ' processed from value';
+//    $this->assertEqual($result, $expected_result, 'Entity view has correct result for "main" resource v1.2');
+//
+//    // v1.3 - Non-existing "callback" property.
+//    $handler = restful_get_restful_handler('main', 1, 3);
+//    try {
+//      $handler->get($id);
+//      $this->fail('Non-existing "callback" property did not trigger an exception.');
+//    }
+//    catch(Exception $e) {
+//      $this->pass('Non-existing "callback" property triggered an exception.');
+//    }
+//
+//    // v1.4 - Non-existing "process callback" property.
+//    $handler = restful_get_restful_handler('main', 1, 4);
+//    try {
+//      $handler->get($id);
+//      $this->fail('Non-existing "process callback" property did not trigger an exception.');
+//    }
+//    catch(Exception $e) {
+//      $this->pass('Non-existing "process callback" property triggered an exception.');
+//    }
+//
+//    // v1.6 - XML output format.
+//    $settings = array(
+//      'type' => 'article',
+//      'uid' => $user1->uid,
+//    );
+//    $node = $this->drupalCreateNode($settings);
+//
+//    $headers = array('X-Restful-Minor-Version' => 6);
+//    $response = $this->httpRequest('api/v1/articles', \RestfulInterface::GET, NULL, $headers);
+//    // Returns something like:
+//    // <api>
+//    //   <data>
+//    //     <item0>
+//    //       <id>1</id>
+//    //       <label>Foo</label>
+//    //       <self>http://example.com/node/1</self>
+//    //       <body>...</body>
+//    //     </item0>
+//    //   </data>
+//    //   <count>50</count>
+//    //   <_links>
+//    //     <next>https://example.com/api/v1/articles</next>
+//    //   </_links>
+//    // </api>
+//
+//    $xml = new SimpleXMLElement($response['body']);
+//    $results = $xml->xpath('/api/data/item0/label');
+//    $result = reset($results);
+//
+//    $this->assertEqual($node->title, $result->__toString(), 'XML parsed correctlty.');
+//
+//    // Test Image variations based on image styles.
+//    $images = $this->drupalGetTestFiles('image');
+//    $image = reset($images);
+//    $image = file_save((object) $image);
+//    $article = $this->drupalCreateNode(array(
+//      'type' => 'article',
+//      'field_image' => array(LANGUAGE_NONE => array(array('fid' => $image->fid))),
+//    ));
+//    $handler = restful_get_restful_handler('articles', 1, 5);
+//    $result = $handler->get($article->nid);
+//    $this->assertEqual(array_keys($result[0]['image']['styles']) == array('thumbnail', 'medium', 'large'), 'The selected image styles are present.');
+//    $this->assertEqual(count(array_filter(array_values($result[0]['image']['styles']))) == 3, 'The image styles are populated.');
+//  }
 
   /**
    * Test the generation of the Vary headers.
    */
-  public function testVaryHeader() {
+  public function testHeaders() {
+    $node = $this->drupalCreateNode(array('type' => 'article', 'status' => NODE_PUBLISHED));
+
     // When there is no minor version passed in there is no need of Vary.
     $response = $this->httpRequest('api/v1/articles');
     $this->assertFalse(preg_match('/X-Restful-Minor-Version/', $response['headers']), 'The Vary header was not added.');
 
     $response = $this->httpRequest('api/v1/articles', \RestfulInterface::GET, NULL, array('X-Restful-Minor-Version' => 1));
     $this->assertTrue(preg_match('/X-Restful-Minor-Version/', $response['headers']), 'The Vary header was added.');
+
+    // Test that if there is no explicit formatter in the plugin definition then
+    // it is selected based on the Accept header.
+    variable_set('restful_default_output_formatter', 'invalid');
+
+    $response = $this->httpRequest('api/v1/articles/' . $node->nid, \RestfulInterface::GET, NULL, array(
+      'Accept' => 'application/hal+json',
+    ));
+    $result = drupal_json_decode($response['body']);
+    $this->assertNotNull($result, 'JSON output detected.');
+
+    // Test XML selection.
+    $response = $this->httpRequest('api/v1/articles/' . $node->nid, \RestfulInterface::GET, NULL, array(
+      'Accept' => 'application/xml',
+    ));
+    $result = new SimpleXMLElement($response['body']);
+    $this->assertNotNull($result, 'JSON output detected.');
+
+    // Test wildcard selection.
+    $response = $this->httpRequest('api/v1/articles/' . $node->nid, \RestfulInterface::GET, NULL, array(
+      'Accept' => 'application/*',
+    ));
+    $this->assertEqual($response['code'], 200, 'Some output format detected for wildcard Accept.');
+
+    // The following should resolve to the 'invalid' formatter. It should raise
+    // an exception.
+    $response = $this->httpRequest('api/v1/articles/' . $node->nid, \RestfulInterface::GET, NULL, array(
+      'Accept' => 'non-existing',
+    ));
+    $this->assertEqual($response['code'], 503, 'Error shown for invalid formatter.');
   }
 }


### PR DESCRIPTION
If several output formats are available, allow clients to select one using the `Content-Type` header.
