### PR TITLE
Fix \RestfulEntityBase::getImageUris to work also for multiple value images

### DIFF
--- a/modules/restful_example/plugins/restful/node/articles/1.5/RestfulExampleArticlesResource__1_5.class.php
+++ b/modules/restful_example/plugins/restful/node/articles/1.5/RestfulExampleArticlesResource__1_5.class.php
@@ -33,6 +33,18 @@ class RestfulExampleArticlesResource__1_5 extends RestfulEntityBaseNode {
       'image_styles' => array('thumbnail', 'medium', 'large'),
     );
 
+    // By checking that the field exists, we allow re-using this class on
+    // different tests, where different fields exist.
+    if (field_info_field('field_images')) {
+      $public_fields['images'] = array(
+        'property' => 'field_images',
+        'process_callbacks' => array(
+          array($this, 'imageProcess'),
+        ),
+        'image_styles' => array('thumbnail', 'medium', 'large'),
+      );
+    }
+
     return $public_fields;
   }
 
@@ -46,6 +58,13 @@ class RestfulExampleArticlesResource__1_5 extends RestfulEntityBaseNode {
    *   A cleaned image array.
    */
   protected function imageProcess($value) {
+    if (static::isArrayNumeric($value)) {
+      $output = array();
+      foreach ($value as $item) {
+        $output[] = $this->imageProcess($item);
+      }
+      return $output;
+    }
     return array(
       'id' => $value['fid'],
       'self' => file_create_url($value['uri']),

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1420,10 +1420,38 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
     if (empty($image_styles)) {
       return $file_array;
     }
+    // If $file_array is an array of file arrays. Then call recursively for each
+    // item and return the result.
+    if (static::isArrayNumeric($file_array)) {
+      $output = array();
+      foreach ($file_array as $item) {
+        $output[] = $this->getImageUris($item, $image_styles);
+      }
+      return $output;
+    }
     $file_array['image_styles'] = array();
     foreach ($image_styles as $style) {
       $file_array['image_styles'][$style] = image_style_url($style, $file_array['uri']);
     }
     return $file_array;
   }
+
+  /**
+   * Helper method to determine if an array is numeric.
+   *
+   * @param array $input
+   *   The input array.
+   *
+   * @return boolean
+   *   TRUE if the array is numeric, false otherwise.
+   */
+  protected final static function isArrayNumeric(array $input) {
+    foreach (array_keys($input) as $key) {
+      if (!ctype_digit((string) $key)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
 }

--- a/tests/RestfulViewEntityTestCase.test
+++ b/tests/RestfulViewEntityTestCase.test
@@ -219,8 +219,25 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
     $this->assertEqual($node->title, $result->__toString(), 'XML parsed correctlty.');
 
     // Test Image variations based on image styles.
+    // Add the multiple images field to the article bundle.
+    $field = array(
+      'field_name' => 'field_images',
+      'type' => 'image',
+      'settings' => array(),
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'field_name' => 'field_images',
+      'entity_type' => 'node',
+      'label' => 'Image multiple',
+      'bundle' => 'article',
+    );
+    field_create_instance($instance);
+
     $images = $this->drupalGetTestFiles('image');
-    $image = reset($images);
+    $image = array_shift($images);
     $image = file_save((object) $image);
     $article = $this->drupalCreateNode(array(
       'type' => 'article',
@@ -230,6 +247,22 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
     $result = $handler->get($article->nid);
     $this->assertEqual(array_keys($result[0]['image']['styles']) == array('thumbnail', 'medium', 'large'), 'The selected image styles are present.');
     $this->assertEqual(count(array_filter(array_values($result[0]['image']['styles']))) == 3, 'The image styles are populated.');
+
+    // Test multiple Image variations based on image styles.
+    $article = array(
+      'type' => 'article',
+      'field_images' => array(LANGUAGE_NONE => array()),
+    );
+    foreach ($images as $image) {
+      $image = file_save((object) $image);
+      $article['field_images'][LANGUAGE_NONE][] = array('fid' => $image->fid);
+    }
+    $article = $this->drupalCreateNode($article);
+    $handler = restful_get_restful_handler('articles', 1, 5);
+    $result = $handler->get($article->nid);
+    $this->assertEqual(count($result[0]['images']), count($images), 'The number of images is correct.');
+    $this->assertEqual(array_keys($result[0]['images'][0]['styles']) == array('thumbnail', 'medium', 'large'), 'The selected image styles are present.');
+    $this->assertEqual(count(array_filter(array_values($result[0]['images'][0]['styles']))) == 3, 'The image styles are populated.');
   }
 
   /**


### PR DESCRIPTION
If the field is multiple then we get a notice, as the $file_array is actually an array of arrays.
We should probably add a wrapper method `\RestfulEntityBase::getImageUrisMultiple` that calls `\RestfulEntityBase::getImageUris`
