### PR TITLE
$plugin['cache'] is a reserved property

### DIFF
--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -759,7 +759,7 @@ abstract class RestfulBase implements RestfulInterface {
       return $cache_object;
     }
 
-    $cache_info = $this->getPluginInfo('cache');
+    $cache_info = $this->getPluginInfo('render_cache');
     $class = $cache_info['class'];
     if (empty($class)) {
       $class = variable_get('cache_class_' . $cache_info['bin']);
@@ -784,7 +784,7 @@ abstract class RestfulBase implements RestfulInterface {
    * @see \RestfulEntityInterface::viewEntity().
    */
   protected function getRenderedCache(array $context = array()) {
-    $cache_info = $this->getPluginInfo('cache');
+    $cache_info = $this->getPluginInfo('render_cache');
     if (!$cache_info['render']) {
       return;
     }
@@ -808,7 +808,7 @@ abstract class RestfulBase implements RestfulInterface {
    * @see \RestfulEntityInterface::viewEntity().
    */
   protected function setRenderedCache($data, array $context = array()) {
-    $cache_info = $this->getPluginInfo('cache');
+    $cache_info = $this->getPluginInfo('render_cache');
     if (!$cache_info['render']) {
       return;
     }
@@ -865,7 +865,7 @@ abstract class RestfulBase implements RestfulInterface {
    *   The wildcard cache id to invalidate.
    */
   public function cacheInvalidate($cid) {
-    $cache_info = $this->getPluginInfo('cache');
+    $cache_info = $this->getPluginInfo('render_cache');
     if (!$cache_info['simple_invalidate']) {
       // Simple invalidation is disabled. This means it is up to the
       // implementing module to take care of the invalidation.

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -185,7 +185,7 @@ abstract class RestfulEntityBase extends RestfulBase implements RestfulEntityInt
     $ids = array_keys($result[$entity_type]);
 
     // Pre-load all entities if there is no render cache.
-    $cache_info = $this->getPluginInfo('cache');
+    $cache_info = $this->getPluginInfo('render_cache');
     if (!$cache_info['render']) {
       entity_load($entity_type, $ids);
     }

--- a/restful.module
+++ b/restful.module
@@ -63,7 +63,7 @@ function restful_plugin_process(&$plugin, $info) {
  * - hook_menu: Determines if RESTful module should declare the resource in its
  *   pwn hook_menu(). If FALSE, it is up to the implementing module to declare
  *   it. Defaults to TRUE.
- * - cache: Stores the cache settings. An associative array with:
+ * - render_cache: Stores the cache settings. An associative array with:
  *   - render: Set it to FALSE to disable the render cache completely
  *     Defaults to FALSE.
  *   - class: The cache class for this resource. Defaults to NULL, which
@@ -124,11 +124,11 @@ function restful_plugin_process_restful(&$plugin, $info) {
     'authentication_types' => array(),
     'authentication_optional' => FALSE,
     'hook_menu' => TRUE,
-    'cache' => array(),
+    'render_cache' => array(),
     'autocomplete' => array(),
   );
 
-  $plugin['cache'] += array(
+  $plugin['render_cache'] += array(
     'render' => FALSE,
     'class' => NULL,
     'bin' => 'cache_restful',

--- a/tests/RestfulRenderCacheTestCase.test
+++ b/tests/RestfulRenderCacheTestCase.test
@@ -38,7 +38,7 @@ class RestfulRenderCacheTestCase extends DrupalWebTestCase {
     $handler->setAccount($account);
     $cache = $handler->getCacheController();
     // Make sure the cache is activated.
-    $cache_info = $handler->getPluginInfo('cache');
+    $cache_info = $handler->getPluginInfo('render_cache');
     $this->assertTrue($cache_info['render'], 'Cache render is activated');
 
     // Empty the cache.

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.1/test_articles__1_1.inc
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.1/test_articles__1_1.inc
@@ -11,7 +11,7 @@ $plugin = array(
   'bundle' => 'article',
   'description' => t('Export the article content type.'),
   'class' => 'RestfulTestArticlesResource__1_1',
-  'cache' => array(
+  'render_cache' => array(
     'render' => TRUE,
   ),
   'minor_version' => 1,


### PR DESCRIPTION
`ctools_plugin_get_plugin_type_info()` looks for $plugin['cache'] -- which we currently abuse for Restful's own cache.

We should set `$plugin['cache'] = TRUE`, and change the key to something not already used by CTools
