### PR TITLE
Discovery: Add special endpoint to get all the resources.

### DIFF
--- a/plugins/restful/discovery/RestfulDiscoveryResource.class.php
+++ b/plugins/restful/discovery/RestfulDiscoveryResource.class.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulDiscoveryResource.
+ */
+
+class RestfulDiscoveryResource extends \RestfulBase implements \RestfulDataProviderInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function publicFieldsInfo() {
+    return array(
+      'resources' => array(
+        'callback' => 'static::getResourceInfo',
+      ),
+    );
+  }
+
+  /**
+   * Value callback; Return the discovery info.
+   *
+   * @return array
+   */
+  protected static function getResourceInfo() {
+    $output = array();
+    foreach (restful_get_restful_plugins() as $plugin) {
+      // Remove the implementation specific keys.
+      unset($plugin['class']);
+      unset($plugin['hook_menu']);
+      unset($plugin['module']);
+      unset($plugin['get children']);
+      unset($plugin['get child']);
+      unset($plugin['path']);
+      unset($plugin['file']);
+      unset($plugin['plugin module']);
+      unset($plugin['plugin type']);
+      $plugin['render_cache'] = $plugin['render_cache']['render'];
+      $plugin['autocomplete'] = $plugin['autocomplete']['enable'];
+      $plugin['rate_limit'] = array_keys($plugin['rate_limit']);
+      if (!empty($plugin['menu_item'])) {
+        $plugin['uri'] = url($plugin['menu_item'], array('absolute' => TRUE));
+      }
+      unset($plugin['menu_item']);
+      $output[$plugin['name']] = $plugin;
+    }
+
+    return $output;
+  }
+
+  /**
+   * Overrides RestfulBase::access().
+   *
+   * Expose resource only to authenticated users.
+   */
+  public function access() {
+    return user_access('access discovery information', $this->getAccount());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function index() {
+    foreach ($this->getPublicFields() as $public_property => $info) {
+      $value = NULL;
+
+      if ($info['callback']) {
+        $value = static::executeCallback($info['callback']);
+      }
+
+      if ($value && $info['process_callbacks']) {
+        foreach ($info['process_callbacks'] as $process_callback) {
+          $value = static::executeCallback($process_callback, array($value));
+        }
+      }
+
+      $values[$public_property] = $value;
+    }
+
+    return $values;
+  }
+
+}

--- a/plugins/restful/discovery/discovery.inc
+++ b/plugins/restful/discovery/discovery.inc
@@ -1,0 +1,16 @@
+<?php
+
+$plugin = array(
+  'label' => t('Discovery'),
+  'resource' => 'discovery',
+  'name' => 'discovery',
+  // Resource is not an entity type.
+  'entity_type' => FALSE,
+  'description' => t('Export the plugin definitions.'),
+  'class' => 'RestfulDiscoveryResource',
+  'authentication_types' => TRUE,
+  // Csrf token should be exposed also to anonymous users.
+  'authentication_optional' => TRUE,
+  // We will declare our own custom menu item.
+  'hook_menu' => FALSE,
+);

--- a/restful.module
+++ b/restful.module
@@ -373,7 +373,28 @@ function restful_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items[$base_path . '/discovery'] = array(
+    'page callback' => 'restful_menu_process_callback',
+    'page arguments' => array('1', 'discovery'),
+    'access callback' => 'restful_menu_access_callback',
+    'access arguments' => array('v1', 'discovery'),
+    'delivery callback' => 'restful_unprepared_delivery',
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
+}
+
+/**
+ *  Implements hook_permission().
+ */
+function restful_permission() {
+  return array(
+    'access discovery information' => array(
+      'title' => t('Access discovery informantion'),
+      'description' => t('Access the discovery information about the resources.'),
+    ),
+  );
 }
 
 /**

--- a/tests/RestfulDiscoveryTestCase.test
+++ b/tests/RestfulDiscoveryTestCase.test
@@ -52,4 +52,17 @@ class RestfulDiscoveryTestCase extends RestfulCurlBaseTestCase {
     $this->assertTrue(in_array('*', $headers), 'Access-Control-Allow-Origin header is populated correctly.');
   }
 
+  /**
+   * Resource discovery callback.
+   */
+  public function testResourceDiscovery() {
+    // Create a user with the appropriate access.
+    $account = $this->drupalCreateUser(array('access discovery information'));
+    $handler = restful_get_restful_handler('discovery');
+    $handler->setAccount($account);
+    $result = $handler->get();
+    // Check the presence of a random resource.
+    $this->assertTrue(isset($result['resources']['main__1_1']), 'Resources are described.');
+  }
+
 }


### PR DESCRIPTION
Broken down to version and sub version. To dig for more information one would need to make an OPTIONS call to the particular resource (with the version options).

This and https://github.com/Gizra/restful/issues/197 are the _basics_ for discovery features that I can see. With this in place I can see a `restful_apiary` contrib module that generates automatic up-to date documentation.
