### PR TITLE
Return resource version in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,13 +241,13 @@ $handler->get('', $request);
 ```shell
 # Handler v1.0
 curl https://example.com/api/articles/1 \
-  -H "X-Restful-Version: v1.0"
+  -H "X-API-Version: v1.0"
 # or
 curl https://example.com/api/v1.0/articles/1
 
 # Handler v1.1
 curl https://example.com/api/articles/1 \
-  -H "X-Restful-Version: v1.1"
+  -H "X-API-Version: v1.1"
 # or
 curl https://example.com/api/v1.1/articles/1
 ```
@@ -257,7 +257,7 @@ curl https://example.com/api/v1.1/articles/1
 ```shell
 # Handler v1.1
 curl https://example.com/api/articles/1,2 \
-  -H "X-Restful-Version: v1.1"
+  -H "X-API-Version: v1.1"
 ```
 
 ### Filtering fields

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -629,6 +629,8 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
     $this->setMethod($method);
     $this->setPath($path);
     $this->setRequest($request);
+    $version = $this->getVersion();
+    $this->setHttpHeaders('X-API-Version', 'v' . $version['major']  . '.' . $version['minor']);
 
     if (!$method_name = $this->getControllerFromPath()) {
       throw new RestfulBadRequestException('Path does not exist');
@@ -1192,8 +1194,8 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
       return $version;
     }
     // If there is no version in the URL check the header.
-    if (!empty($_SERVER['HTTP_X_RESTFUL_VERSION'])) {
-      $version =  static::parseVersionString($_SERVER['HTTP_X_RESTFUL_VERSION'], $resource_name);
+    if (!empty($_SERVER['HTTP_X_API_VERSION'])) {
+      $version =  static::parseVersionString($_SERVER['HTTP_X_API_VERSION'], $resource_name);
       return $version;
     }
     // If there is no version negotiation information return the latest version.

--- a/restful.module
+++ b/restful.module
@@ -602,11 +602,11 @@ function restful_menu_process_callback($resource_name, $version = NULL) {
     throw new \RestfulServiceUnavailable(format_string('The selected plugin (@plugin) does not implement \RestfulDataProviderInterface.', array('@plugin' => $resource_name . ' v' . $major_version . '.' . $minor_version)));
   }
 
-  // Vary the response with the presence of the X-Restful-Version header.
-  if (!empty($_SERVER['HTTP_X_RESTFUL_VERSION'])) {
+  // Vary the response with the presence of the X-API-Version header.
+  if (!empty($_SERVER['HTTP_X_API_VERSION'])) {
     $headers = $handler->getHttpHeaders();
     $vary = empty($headers['Vary']) ? '' : $headers['Vary'];
-    $handler->setHttpHeaders('Vary', implode(',', array($vary, 'X-Restful-Version')));
+    $handler->setHttpHeaders('Vary', implode(',', array($vary, 'X-API-Version')));
   }
 
   // Always add the allow origin if configured.

--- a/tests/RestfulHookMenuTestCase.test
+++ b/tests/RestfulHookMenuTestCase.test
@@ -114,7 +114,7 @@ class RestfulHookMenuTestCase extends RestfulCurlBaseTestCase {
    */
   function testVersionNegotiation() {
     // Fake the HTTP header.
-    $original_header = empty($_SERVER['HTTP_X_RESTFUL_VERSION']) ? NULL : $_SERVER['HTTP_X_RESTFUL_VERSION'];
+    $original_header = empty($_SERVER['HTTP_X_API_VERSION']) ? NULL : $_SERVER['HTTP_X_API_VERSION'];
 
     // 1. my-api/v1.1/articles yields version 1.1
     $handler = restful_get_restful_handler_for_path('api/v1.1/articles');
@@ -125,30 +125,30 @@ class RestfulHookMenuTestCase extends RestfulCurlBaseTestCase {
     $handler = restful_get_restful_handler_for_path('api/v1/articles');
     $this->assertEqual($handler->getVersion(), array('major' => 1, 'minor' => 6), 'api/v1.6/articles resolves 1.6');
 
-    // 3. my-api/articles with header X-Restful-Version: v1.1 yields 1.1
+    // 3. my-api/articles with header X-API-Version: v1.1 yields 1.1
     // Fake the HTTP header.
-    $_SERVER['HTTP_X_RESTFUL_VERSION'] = 'v1.1';
+    $_SERVER['HTTP_X_API_VERSION'] = 'v1.1';
     drupal_static_reset('RestfulBase::getVersionFromRequest');
     $handler = restful_get_restful_handler_for_path('api/articles');
     $this->assertEqual($handler->getVersion(), array('major' => 1, 'minor' => 1), 'api/articles resolves 1.1');
 
-    // 4. my-api/articles with header X-Restful-Version: v1 yields 1.6
+    // 4. my-api/articles with header X-API-Version: v1 yields 1.6
     // Fake the HTTP header.
-    $_SERVER['HTTP_X_RESTFUL_VERSION'] = 'v1';
+    $_SERVER['HTTP_X_API_VERSION'] = 'v1';
     drupal_static_reset('RestfulBase::getVersionFromRequest');
     drupal_static_reset('restful_get_restful_handler_for_path');
     $handler = restful_get_restful_handler_for_path('api/articles');
     $this->assertEqual($handler->getVersion(), array('major' => 1, 'minor' => 6), 'api/articles resolves 1.6');
 
-    // 5. my-api/articles without header X-Restful-Version yields 2.0
+    // 5. my-api/articles without header X-API-Version yields 2.0
     drupal_static_reset('RestfulBase::getVersionFromRequest');
     drupal_static_reset('restful_get_restful_handler_for_path');
-    unset($_SERVER['HTTP_X_RESTFUL_VERSION']);
+    unset($_SERVER['HTTP_X_API_VERSION']);
     $handler = restful_get_restful_handler_for_path('api/articles');
     $this->assertEqual($handler->getVersion(), array('major' => 2, 'minor' => 0), 'api/articles resolves 2.0');
 
     // Restore the original header.
-    $_SERVER['HTTP_X_RESTFUL_VERSION'] = $original_header;
+    $_SERVER['HTTP_X_API_VERSION'] = $original_header;
   }
 
 }

--- a/tests/RestfulViewEntityTestCase.test
+++ b/tests/RestfulViewEntityTestCase.test
@@ -274,10 +274,16 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
 
     // When there is no header version passed in there is no need of Vary.
     $response = $this->httpRequest('api/v1.1/articles');
-    $this->assertFalse(preg_match('/X-Restful-Version/', $response['headers']), 'The Vary header was not added.');
+    $this->assertFalse(preg_match('/X-API-Version/', $response['headers']), 'The Vary header was not added.');
 
-    $response = $this->httpRequest('api/articles', \RestfulInterface::GET, NULL, array('X-Restful-Version' => 'v1.1'));
-    $this->assertTrue(preg_match('/X-Restful-Version/', $response['headers']), 'The Vary header was added.');
+    // Make sure that the version header is present in the response.
+    $this->assertTrue(preg_match('/v1\.1/', $response['headers']), 'The Vary header was added.');
+
+    $response = $this->httpRequest('api/articles', \RestfulInterface::GET, NULL, array('X-API-Version' => 'v1.1'));
+    $this->assertTrue(preg_match('/X-API-Version/', $response['headers']), 'The Vary header was added.');
+
+    // Make sure that the version header is present in the response.
+    $this->assertTrue(preg_match('/v1\.1/', $response['headers']), 'The Vary header was added.');
 
     // Test that if there is no explicit formatter in the plugin definition then
     // it is selected based on the Accept header.


### PR DESCRIPTION
When one does `api/articles` they should know which resource's version served their response.

So we can return the version for all cases (e.g. also in `api/v1.0/articles`)
