### PR TITLE
Corrected the values given by angularFileUpload to restful

### DIFF
--- a/modules/restful_angular_example/components/restful-app/dist/restful-app.js
+++ b/modules/restful_angular_example/components/restful-app/dist/restful-app.js
@@ -155,8 +155,8 @@ angular.module('restfulApp')
       for (var i = 0; i < $files.length; i++) {
         var file = $files[i];
         FileUpload.upload(file).then(function(data) {
-          $scope.data.image = data.data.list[0].id;
-          $scope.serverSide.image = data.data.list[0];
+          $scope.data.image = data.data.data[0].id;
+          $scope.serverSide.image = data.data.data[0];
         });
       }
     };


### PR DESCRIPTION
I couldn't get file uploads working in the restful_angular_example.module at `/restful-example/form`. The file was being sent to drupal, uploaded fine, and showed up in the file_managed table, but this wasn't being reflected in angular.

The issue is that the name of the array within `data` returned by angularFileUpload is slightly different from what restful-app.js was using. I've attached a screenshot of the data structure (I did a `console.log(data)` in the same place as the code changes in this pull request).

Basically, it should be `data.data.data` not `data.data.list`

This change then allowed angular to show that a file had been uploaded, and when I created an article node the image was there too (previously it wasn't).

![screen shot 2014-10-29 at 6 17 53 pm](https://cloud.githubusercontent.com/assets/787653/4829580/fbfda066-5f87-11e4-9578-b5f1e549d5dc.png)
