### PR TITLE
Add allowed values for fields in OPTIONS

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1182,25 +1182,56 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     $discovery_info['data']['type'] = $field_info['type'];
     $discovery_info['data']['required'] = $instance_info['required'];
 
-    $discovery_info['form_element']['default_value'] = $instance_info['default_value'];
+    $discovery_info['form_element']['default_value'] = isset($instance_info['default_value']) ? $instance_info['default_value'] : NULL;
 
-    switch($field_info['type']) {
-      case 'list_text':
-        $discovery_info['form_element']['allowed_values'] = $field_info['settings']['allowed_values'];
-        break;
-    }
+    $this->getFormSchemaAllowedValues($field_info, $discovery_info);
+
 
     return array('discovery' => $discovery_info);
   }
 
+  /**
+   * Get allowed values for the form schema.
+   *
+   * @param array $field_info
+   *   The field info array.
+   * @param array $discovery_info
+   *   The discovery info array, passed by reference.
+   */
   protected function getFormSchemaAllowedValues($field_info, &$discovery_info) {
+    $this->getFormSchemaAllowedValuesList($field_info, $discovery_info);
+    $this->getFormSchemaAllowedValuesReference($field_info, $discovery_info);
+  }
+
+  /**
+   * Get allowed values from list fields.
+   *
+   * @param array $field_info
+   *   The field info array.
+   * @param array $discovery_info
+   *   The discovery info array, passed by reference.
+   *
+   * @see \RestfulEntityBase::getFormSchemaAllowedValues()
+   */
+  protected function getFormSchemaAllowedValuesList($field_info, &$discovery_info) {
     $field_types = module_exists('list') ? array_keys(list_field_info()) : array();
 
     if (in_array($field_info['type'], $field_types)) {
       $discovery_info['form_element']['allowed_values'] = $field_info['settings']['allowed_values'];
-      return;
     }
+  }
 
+  /**
+   * Get allowed values from entity reference and taxonomy reference fields.
+   *
+   * @param array $field_info
+   *   The field info array.
+   * @param array $discovery_info
+   *   The discovery info array, passed by reference.
+   *
+   * @see \RestfulEntityBase::getFormSchemaAllowedValues()
+   */
+  protected function getFormSchemaAllowedValuesReference($field_info, &$discovery_info) {
     $field_types = array('entityreference', 'taxonomy_term_reference');
 
     if (!in_array($field_info['type'], $field_types)) {
@@ -1243,7 +1274,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
     $entity = entity_create($entity_type, $values);
 
-    $options = _options_get_options($field_info, $instance_info, $properties, $this->getEntityType(), $entity)
+    $options = _options_get_options($field_info, $instance_info, $properties, $this->getEntityType(), $entity);
     $discovery_info['form_element']['allowed_values'] = $options;
   }
 

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1262,8 +1262,11 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     // Use Field API's widget to get the allowed values.
     $type = str_replace('options_', '', $instance_info['widget']['type']);
     $multiple = $field_info['cardinality'] > 1 || $field_info['cardinality'] == FIELD_CARDINALITY_UNLIMITED;
-    $required = $instance_info['required'];
-    $properties = _options_properties($type, $multiple, $required, FALSE);
+    // Always pass TRUE for "required" and "has_value", as we don't want to get
+    // the "none" option.
+    $required = TRUE;
+    $has_value = TRUE;
+    $properties = _options_properties($type, $multiple, $required, $has_value);
 
     // Mock an entity.
     $values = array();

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1263,7 +1263,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
       'entityreference_autocomplete_tags',
     );
 
-    return in_array($field['type'], $field_types) && in_array($instance['widget']['type'], $widget_types);
+    return !in_array($field['type'], $field_types) || !in_array($instance['widget']['type'], $widget_types);
   }
 
   /**

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1192,8 +1192,6 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
   /**
    * Get allowed values for the form schema.
    *
-   * Use Field API's widget to get the allowed values.
-   *
    * @param array $field_info
    *   The field info array.
    * @param array $discovery_info
@@ -1211,6 +1209,23 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     $bundle = $this->getBundle();
 
     $instance_info = field_info_instance($entity_type, $field_info['field_name'], $bundle);
+
+    $field_types = array(
+      'entityreference',
+      'taxonomy_term_reference',
+    );
+
+    $widget_types = array(
+      'taxonomy_autocomplete',
+      'entityreference_autocomplete',
+      'entityreference_autocomplete_tags',
+    );
+
+    if (in_array($field_info['type'], $field_types) && in_array($instance_info['widget']['type'], $widget_types)) {
+      // Field is reference, and widget is autocomplete, so for performance
+      // reasons we do not try to grab all the referenced entities.
+      return;
+    }
 
     // Use Field API's widget to get the allowed values.
     $type = str_replace('options_', '', $instance_info['widget']['type']);

--- a/tests/RestfulDiscoveryTestCase.test
+++ b/tests/RestfulDiscoveryTestCase.test
@@ -137,5 +137,91 @@ class RestfulDiscoveryTestCase extends RestfulCurlBaseTestCase {
     }
   }
 
+  /**
+   * Field discovery allowed values.
+   */
+  public function testFieldDiscoveryAllowedValues() {
+    $handler = restful_get_restful_handler('test_articles', 1, 2);
+
+    $node_type1 = $this->drupalCreateContentType();
+    $name_type1 = $node_type1->name;
+    $node_type1 = $node_type1->type;
+
+    $node_type2 = $this->drupalCreateContentType();
+    $name_type2 = $node_type2->name;
+    $node_type2 = $node_type2->type;
+
+    // Add entity reference and taxonomy term reference.
+    $vocabulary_id = restful_test_add_fields('node', $node_type1);
+
+    // Create 3 nodes in each node type.
+    $types = array(
+      $node_type1 => $name_type1,
+      $node_type2 => $name_type2,
+    );
+
+    foreach ($types as $type => $name) {
+      foreach (array(1, 2, 3) as $id) {
+        $title = $type . '/' . $id;
+        $settings = array(
+          'title' => $title,
+          'type' => $type,
+
+        );
+        $node = $this->drupalCreateNode($settings);
+        $nodes[$name][$node->nid] = $title;
+      }
+    }
+
+    // Set widget to select list.
+    $instance = field_info_instance('node', 'entity_reference_single', $node_type1);
+    $instance['widget']['type'] = 'options_select';
+    field_update_instance($instance);
+
+
+    $result = $handler->options();
+    $expected_result = array(
+      'allowed_values' => $nodes,
+    );
+
+    $this->assertEqual($result['entity_reference_single']['form_element']['allowed_values'], $expected_result);
+
+    // Switch to autocomplete.
+    $instance['widget']['type'] = 'entityreference_autocomplete';
+    field_update_instance($instance);
+    $this->assertTrue(empty($result['entity_reference_single']['form_element']['allowed_values']));
+
+    // Change the last term created via restful_test_add_fields() to be under
+    // the second term.
+    $tree = taxonomy_get_tree($vocabulary_id);
+
+    // Add a select list with allowed values.
+    // Text - multiple, with text processing.
+    $field = array(
+      'field_name' => 'list_text',
+      'type' => 'text_long',
+      'entity_types' => array('node'),
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
+    );
+    field_create_field($field);
+
+    $list = array(
+      'one' => 'One',
+      'two' => 'Two',
+      $this->randomName() => $this->randomString(),
+    );
+
+    $instance = array(
+      'field_name' => 'list_text',
+      'bundle' => $node_type1,
+      'entity_type' => 'node',
+      'label' => t('List text'),
+      'settings' => array(
+        'allowed_values' => $list,
+      ),
+    );
+    field_create_instance($instance);
+  }
+
 
 }

--- a/tests/RestfulDiscoveryTestCase.test
+++ b/tests/RestfulDiscoveryTestCase.test
@@ -143,85 +143,37 @@ class RestfulDiscoveryTestCase extends RestfulCurlBaseTestCase {
   public function testFieldDiscoveryAllowedValues() {
     $handler = restful_get_restful_handler('test_articles', 1, 2);
 
-    $node_type1 = $this->drupalCreateContentType();
-    $name_type1 = $node_type1->name;
-    $node_type1 = $node_type1->type;
-
-    $node_type2 = $this->drupalCreateContentType();
-    $name_type2 = $node_type2->name;
-    $node_type2 = $node_type2->type;
+    $node_type = $this->drupalCreateContentType();
+    $node_type = $node_type->type;
 
     // Add entity reference and taxonomy term reference.
-    $vocabulary_id = restful_test_add_fields('node', $node_type1);
+    restful_test_add_fields('node', $node_type);
 
-    // Create 3 nodes in each node type.
-    $types = array(
-      $node_type1 => $name_type1,
-      $node_type2 => $name_type2,
-    );
-
+    // Create 3 nodes.
     $expected_result = array();
-    foreach ($types as $type => $name) {
-      foreach (array(1, 2, 3) as $id) {
-        $title = $type . '/' . $id;
-        $settings = array(
-          'title' => $title,
-          'type' => $type,
+    foreach (array(1, 2, 3) as $id) {
+      $title = $node_type . '/' . $id;
+      $settings = array(
+        'title' => $title,
+        'type' => $node_type,
 
-        );
-        $node = $this->drupalCreateNode($settings);
-        $expected_result[$name][$node->nid] = $title;
-      }
+      );
+      $node = $this->drupalCreateNode($settings);
+      $expected_result[$node->nid] = $title;
     }
 
     // Set widget to select list.
-    $instance = field_info_instance('node', 'entity_reference_single', $node_type1);
+    $instance = field_info_instance('node', 'entity_reference_single', $node_type);
     $instance['widget']['type'] = 'options_select';
     field_update_instance($instance);
 
-
     $result = $handler->options();
-    $expected_result = array(
-      'allowed_values' => $nodes,
-    );
-
     $this->assertEqual($result['entity_reference_single']['form_element']['allowed_values'], $expected_result);
 
     // Switch to autocomplete.
     $instance['widget']['type'] = 'entityreference_autocomplete';
     field_update_instance($instance);
-    $this->assertTrue(empty($result['entity_reference_single']['form_element']['allowed_values']));
-
-    // Change the last term created via restful_test_add_fields() to be under
-    // the second term.
-    $tree = taxonomy_get_tree($vocabulary_id);
-
-    // Add a select list with allowed values.
-    // Text - multiple, with text processing.
-    $field = array(
-      'field_name' => 'list_text',
-      'type' => 'list_text',
-      'entity_types' => array('node'),
-      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
-    );
-    field_create_field($field);
-
-    $list = array(
-      'one' => 'One',
-      'two' => 'Two',
-      $this->randomName() => $this->randomString(),
-    );
-
-    $instance = array(
-      'field_name' => 'list_text',
-      'bundle' => $node_type1,
-      'entity_type' => 'node',
-      'label' => t('List text'),
-      'settings' => array(
-        'allowed_values' => $list,
-      ),
-    );
-    field_create_instance($instance);
+    $this->assertNull($result['entity_reference_single']['form_element']['allowed_values']);
   }
 
 

--- a/tests/RestfulDiscoveryTestCase.test
+++ b/tests/RestfulDiscoveryTestCase.test
@@ -160,6 +160,7 @@ class RestfulDiscoveryTestCase extends RestfulCurlBaseTestCase {
       $node_type2 => $name_type2,
     );
 
+    $expected_result = array();
     foreach ($types as $type => $name) {
       foreach (array(1, 2, 3) as $id) {
         $title = $type . '/' . $id;
@@ -169,7 +170,7 @@ class RestfulDiscoveryTestCase extends RestfulCurlBaseTestCase {
 
         );
         $node = $this->drupalCreateNode($settings);
-        $nodes[$name][$node->nid] = $title;
+        $expected_result[$name][$node->nid] = $title;
       }
     }
 
@@ -199,7 +200,7 @@ class RestfulDiscoveryTestCase extends RestfulCurlBaseTestCase {
     // Text - multiple, with text processing.
     $field = array(
       'field_name' => 'list_text',
-      'type' => 'text_long',
+      'type' => 'list_text',
       'entity_types' => array('node'),
       'cardinality' => FIELD_CARDINALITY_UNLIMITED,
     );

--- a/tests/RestfulDiscoveryTestCase.test
+++ b/tests/RestfulDiscoveryTestCase.test
@@ -143,19 +143,16 @@ class RestfulDiscoveryTestCase extends RestfulCurlBaseTestCase {
   public function testFieldDiscoveryAllowedValues() {
     $handler = restful_get_restful_handler('test_articles', 1, 2);
 
-    $node_type = $this->drupalCreateContentType();
-    $node_type = $node_type->type;
-
-    // Add entity reference and taxonomy term reference.
-    restful_test_add_fields('node', $node_type);
+    // Add entity reference fields.
+    restful_test_add_fields('node', 'article');
 
     // Create 3 nodes.
     $expected_result = array();
     foreach (array(1, 2, 3) as $id) {
-      $title = $node_type . '/' . $id;
+      $title = 'article' . '/' . $id;
       $settings = array(
         'title' => $title,
-        'type' => $node_type,
+        'type' => 'article',
 
       );
       $node = $this->drupalCreateNode($settings);
@@ -163,16 +160,21 @@ class RestfulDiscoveryTestCase extends RestfulCurlBaseTestCase {
     }
 
     // Set widget to select list.
-    $instance = field_info_instance('node', 'entity_reference_single', $node_type);
+    $instance = field_info_instance('node', 'entity_reference_single', 'article');
     $instance['widget']['type'] = 'options_select';
     field_update_instance($instance);
 
     $result = $handler->options();
     $this->assertEqual($result['entity_reference_single']['form_element']['allowed_values'], $expected_result);
 
-    // Switch to autocomplete.
+    // Set widget to autocomplete.
     $instance['widget']['type'] = 'entityreference_autocomplete';
     field_update_instance($instance);
+
+    // Invalidate public fields cache.
+    $handler->setPublicFields(array());
+
+    $result = $handler->options();
     $this->assertNull($result['entity_reference_single']['form_element']['allowed_values']);
   }
 

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
@@ -46,6 +46,12 @@ class RestfulTestArticlesResource__1_2 extends RestfulEntityBaseNode {
       );
     }
 
+    if (field_info_field('term_reference_single')) {
+      $public_fields['term_reference_single'] = array(
+        'property' => 'term_reference_single',
+      );
+    }
+
     if (field_info_field('integer_single')) {
       $public_fields['integer_single'] = array(
         'property' => 'integer_single',

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.2/RestfulTestArticlesResource__1_2.class.php
@@ -46,12 +46,6 @@ class RestfulTestArticlesResource__1_2 extends RestfulEntityBaseNode {
       );
     }
 
-    if (field_info_field('term_reference_single')) {
-      $public_fields['term_reference_single'] = array(
-        'property' => 'term_reference_single',
-      );
-    }
-
     if (field_info_field('integer_single')) {
       $public_fields['integer_single'] = array(
         'property' => 'integer_single',

--- a/tests/modules/restful_test/restful_test.module
+++ b/tests/modules/restful_test/restful_test.module
@@ -45,22 +45,30 @@ function restful_test_field_access($op, $field, $entity_type, $entity, $account)
 }
 
 /**
- * Helper function to add common fields to the entity test's "main" bundle.
+ * Helper function to add common fields.
+ *
+ * @param string $entity_type
+ *   The entity type. Defautls to "entity_test".
+ * @param string $bundle.
+ *   The bundle name. Defaults to "main".
+ *
+ * @return int
+ *   The vocabulary ID created.
  */
-function restful_test_add_fields() {
+function restful_test_add_fields($entity_type = 'entity_test', $bundle = 'main') {
   // Text - single.
   $field = array(
     'field_name' => 'text_single',
     'type' => 'text_long',
-    'entity_types' => array('entity_test'),
+    'entity_types' => array($entity_type),
     'cardinality' => 1,
   );
   field_create_field($field);
 
   $instance = array(
     'field_name' => 'text_single',
-    'bundle' => 'main',
-    'entity_type' => 'entity_test',
+    'bundle' => $bundle,
+    'entity_type' => $entity_type,
     'label' => t('Text single'),
     'settings' => array(
       // No text processing
@@ -73,15 +81,15 @@ function restful_test_add_fields() {
   $field = array(
     'field_name' => 'text_single_processing',
     'type' => 'text_long',
-    'entity_types' => array('entity_test'),
+    'entity_types' => array($entity_type),
     'cardinality' => 1,
   );
   field_create_field($field);
 
   $instance = array(
     'field_name' => 'text_single_processing',
-    'bundle' => 'main',
-    'entity_type' => 'entity_test',
+    'bundle' => $bundle,
+    'entity_type' => $entity_type,
     'label' => t('Text single with text processing'),
     'settings' => array(
       'text_processing' => 1,
@@ -93,15 +101,15 @@ function restful_test_add_fields() {
   $field = array(
     'field_name' => 'text_multiple',
     'type' => 'text_long',
-    'entity_types' => array('entity_test'),
+    'entity_types' => array($entity_type),
     'cardinality' => FIELD_CARDINALITY_UNLIMITED,
   );
   field_create_field($field);
 
   $instance = array(
     'field_name' => 'text_multiple',
-    'bundle' => 'main',
-    'entity_type' => 'entity_test',
+    'bundle' => $bundle,
+    'entity_type' => $entity_type,
     'label' => t('Text multiple'),
     'settings' => array(
       'text_processing' => 0,
@@ -113,15 +121,15 @@ function restful_test_add_fields() {
   $field = array(
     'field_name' => 'text_multiple_processing',
     'type' => 'text_long',
-    'entity_types' => array('entity_test'),
+    'entity_types' => array($entity_type),
     'cardinality' => FIELD_CARDINALITY_UNLIMITED,
   );
   field_create_field($field);
 
   $instance = array(
     'field_name' => 'text_multiple_processing',
-    'bundle' => 'main',
-    'entity_type' => 'entity_test',
+    'bundle' => $bundle,
+    'entity_type' => $entity_type,
     'label' => t('Text multiple with text processing'),
     'settings' => array(
       'text_processing' => 1,
@@ -131,10 +139,10 @@ function restful_test_add_fields() {
 
   // Entity reference - single.
   $field = array(
-    'entity_types' => array('entity_test'),
+    'entity_types' => array($entity_type),
     'settings' => array(
       'handler' => 'base',
-      'target_type' => 'entity_test',
+      'target_type' => $entity_type,
       'handler_settings' => array(
       ),
     ),
@@ -145,9 +153,9 @@ function restful_test_add_fields() {
   field_create_field($field);
 
   $instance = array(
-    'entity_type' => 'entity_test',
+    'entity_type' => $entity_type,
     'field_name' => 'entity_reference_single',
-    'bundle' => 'main',
+    'bundle' => $bundle,
     'label' => t('Entity reference single'),
   );
 
@@ -155,10 +163,10 @@ function restful_test_add_fields() {
 
   // Entity reference - multiple.
   $field = array(
-    'entity_types' => array('entity_test'),
+    'entity_types' => array($entity_type),
     'settings' => array(
       'handler' => 'base',
-      'target_type' => 'entity_test',
+      'target_type' => $entity_type,
       'handler_settings' => array(
       ),
     ),
@@ -169,9 +177,9 @@ function restful_test_add_fields() {
   field_create_field($field);
 
   $instance = array(
-    'entity_type' => 'entity_test',
+    'entity_type' => $entity_type,
     'field_name' => 'entity_reference_multiple',
-    'bundle' => 'main',
+    'bundle' => $bundle,
     'label' => t('Entity reference multiple'),
   );
 
@@ -183,15 +191,15 @@ function restful_test_add_fields() {
   $field = array(
     'field_name' => 'term_single',
     'type' => 'taxonomy_term_reference',
-    'entity_types' => array('entity_test'),
+    'entity_types' => array($entity_type),
     'cardinality' => 1,
   );
   field_create_field($field);
 
   $instance = array(
     'field_name' => 'term_single',
-    'bundle' => 'main',
-    'entity_type' => 'entity_test',
+    'bundle' => $bundle,
+    'entity_type' => $entity_type,
     'label' => t('Term reference single'),
     'settings' => array(
       'settings' => array(
@@ -209,15 +217,15 @@ function restful_test_add_fields() {
   $field = array(
     'field_name' => 'term_multiple',
     'type' => 'taxonomy_term_reference',
-    'entity_types' => array('entity_test'),
+    'entity_types' => array($entity_type),
     'cardinality' => FIELD_CARDINALITY_UNLIMITED,
   );
   field_create_field($field);
 
   $instance = array(
     'field_name' => 'term_multiple',
-    'bundle' => 'main',
-    'entity_type' => 'entity_test',
+    'bundle' => $bundle,
+    'entity_type' => $entity_type,
     'label' => t('Term reference multiple'),
     'settings' => array(
       'settings' => array(
@@ -242,9 +250,9 @@ function restful_test_add_fields() {
 
   $instance = array(
     'field_name' => 'file_single',
-    'entity_type' => 'entity_test',
+    'entity_type' => $entity_type,
     'label' => 'File single',
-    'bundle' => 'main',
+    'bundle' => $bundle,
   );
   field_create_instance($instance);
 
@@ -259,9 +267,9 @@ function restful_test_add_fields() {
 
   $instance = array(
     'field_name' => 'file_multiple',
-    'entity_type' => 'entity_test',
+    'entity_type' => $entity_type,
     'label' => 'File multiple',
-    'bundle' => 'main',
+    'bundle' => $bundle,
   );
   field_create_instance($instance);
 
@@ -276,9 +284,9 @@ function restful_test_add_fields() {
 
   $instance = array(
     'field_name' => 'image_single',
-    'entity_type' => 'entity_test',
+    'entity_type' => $entity_type,
     'label' => 'Image single',
-    'bundle' => 'main',
+    'bundle' => $bundle,
   );
   field_create_instance($instance);
 
@@ -293,11 +301,13 @@ function restful_test_add_fields() {
 
   $instance = array(
     'field_name' => 'image_multiple',
-    'entity_type' => 'entity_test',
+    'entity_type' => $entity_type,
     'label' => 'Image multiple',
-    'bundle' => 'main',
+    'bundle' => $bundle,
   );
   field_create_instance($instance);
+
+  return $vocabulary_id;
 }
 
 


### PR DESCRIPTION
This is a naive implementation that looks at the field's widget, and if it's not an autocomplete, it exposes the allowed values using `_options_get_options`. This will serves for both entity-reference module, and taxonomy term reference.

term reference:
![postman-3](https://cloud.githubusercontent.com/assets/125707/4850977/d87e6d36-606e-11e4-8bd2-2b5447de8c8e.jpg)

ER:
![postman-2](https://cloud.githubusercontent.com/assets/125707/4851038/418be3da-606f-11e4-817b-43d2c27d8f3d.jpg)
