### PR TITLE
Don't throw exception in list of entities with un-accessible items

### DIFF
--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -267,16 +267,13 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
    *
    * @param int $entity_id
    *   The entity ID.
-   * @param bool $error_on_no_access
-   *   Determines if an exception should be thrown if user has no access to the
-   *   entity. Defaults to TRUE.
    *
    * @return array
    *   Array with the public fields populated.
    *
    * @throws Exception
    */
-  abstract public function viewEntity($entity_id, $error_on_no_access = TRUE);
+  abstract public function viewEntity($entity_id);
 
   /**
    * Get a list of entities based on a list of IDs.

--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -267,13 +267,16 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
    *
    * @param int $entity_id
    *   The entity ID.
+   * @param bool $error_on_no_access
+   *   Determines if an exception should be thrown if user has no access to the
+   *   entity. Defaults to TRUE.
    *
    * @return array
    *   Array with the public fields populated.
    *
    * @throws Exception
    */
-  abstract public function viewEntity($entity_id);
+  abstract public function viewEntity($entity_id, $error_on_no_access = TRUE);
 
   /**
    * Get a list of entities based on a list of IDs.

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -130,7 +130,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
     // If no IDs were requested, we should not throw an exception in case an
     // entity is un-accessible by the user.
-    $error_on_no_access = !empty($request['id']) || !empty($request['filter']['id']);
+    $error_on_no_access = !$this->isListRequest() || !empty($request['filter']['id']);
 
     foreach ($ids as $id) {
       if ($row = $this->viewEntity($id, $error_on_no_access)) {

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -130,7 +130,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
     // If no IDs were requested, we should not throw an exception in case an
     // entity is un-accessible by the user.
-    $error_on_no_access = !empty($request['id']);
+    $error_on_no_access = !empty($request['id']) || !empty($request['filter']['id']);
 
     foreach ($ids as $id) {
       if ($row = $this->viewEntity($id, $error_on_no_access)) {

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -130,10 +130,8 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
     // If no IDs were requested, we should not throw an exception in case an
     // entity is un-accessible by the user.
-    $error_on_no_access = !$this->isListRequest() || !empty($request['filter']['id']);
-
     foreach ($ids as $id) {
-      if ($row = $this->viewEntity($id, $error_on_no_access)) {
+      if ($row = $this->viewEntity($id)) {
         $return[] = $row;
       }
     }
@@ -269,7 +267,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
   /**
    * {@inheritdoc}
    */
-  public function viewEntity($entity_id, $error_on_no_access = TRUE) {
+  public function viewEntity($entity_id) {
     $request = $this->getRequest();
 
     $cached_data = $this->getRenderedCache(array(
@@ -280,7 +278,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
       return $cached_data->data;
     }
 
-    if (!$this->isValidEntity('view', $entity_id, $error_on_no_access)) {
+    if (!$this->isValidEntity('view', $entity_id)) {
       return;
     }
 
@@ -1001,9 +999,6 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    *   The operation to perform on the entity (view, update, delete).
    * @param $entity_id
    *   The entity ID.
-   * @param bool $error_on_no_access
-   *   Determines if an exception should be thrown if user has no access to the
-   *   entity. Defaults to TRUE.
    *
    * @return bool
    *   TRUE if entity is valid, and user can access it.
@@ -1011,7 +1006,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    * @throws RestfulUnprocessableEntityException
    * @throws RestfulForbiddenException
    */
-  protected function isValidEntity($op, $entity_id, $error_on_no_access = TRUE) {
+  protected function isValidEntity($op, $entity_id) {
     $entity_type = $this->entityType;
 
     $params = array(
@@ -1031,8 +1026,9 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     }
 
     if ($this->checkEntityAccess($op, $entity_type, $entity) === FALSE) {
-      if ($error_on_no_access) {
-        // Entity was explicitly denied.
+
+      if (!$this->isListRequest()) {
+        // Entity was explicitly requested so we need to throw an exception.
         throw new RestfulForbiddenException(format_string('You do not have access to entity ID @id of resource @resource', $params));
       }
 

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1027,15 +1027,15 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
     if ($this->checkEntityAccess($op, $entity_type, $entity) === FALSE) {
 
-      if (!$this->isListRequest()) {
-        // Entity was explicitly requested so we need to throw an exception.
-        throw new RestfulForbiddenException(format_string('You do not have access to entity ID @id of resource @resource', $params));
+      if ($op == 'view' && $this->isListRequest()) {
+        // Just return FALSE, without an exception, for example when a list of
+        // entities is requested, and we don't want to fail all the list because
+        // of a single item without access.
+        return FALSE;
       }
 
-      // Just return FALSE, without an exception, for example when a list of
-      // entities is requested, and we don't want to fail all the list because
-      // of a single item without access.
-      return FALSE;
+      // Entity was explicitly requested so we need to throw an exception.
+      throw new RestfulForbiddenException(format_string('You do not have access to entity ID @id of resource @resource', $params));
     }
 
     return TRUE;

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1027,7 +1027,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
     if ($this->checkEntityAccess($op, $entity_type, $entity) === FALSE) {
 
-      if ($op == 'view' && $this->isListRequest()) {
+      if ($op == 'view' && !$this->getPath()) {
         // Just return FALSE, without an exception, for example when a list of
         // entities is requested, and we don't want to fail all the list because
         // of a single item without access.

--- a/tests/RestfulEntityAndPropertyAccessTestCase.test
+++ b/tests/RestfulEntityAndPropertyAccessTestCase.test
@@ -62,7 +62,7 @@ class RestfulEntityAndPropertyAccessTestCase extends DrupalWebTestCase {
     catch (Exception $e) {
       $this->pass('Non-privileged user cannot create entity with unaccessible property that was passed in the request.');
     }
-    restful_test_clear_access();
+    restful_test_clear_access_field();
   }
 
   /**
@@ -121,7 +121,7 @@ class RestfulEntityAndPropertyAccessTestCase extends DrupalWebTestCase {
     catch (Exception $e) {
       $this->pass('Non-privileged user cannot update entity with unaccessible property that was passed in the request.');
     }
-    restful_test_clear_access();
+    restful_test_clear_access_field();
   }
 
   /**
@@ -155,7 +155,7 @@ class RestfulEntityAndPropertyAccessTestCase extends DrupalWebTestCase {
     $handler->setAccount($user1);
     $result = $handler->get($node1->nid, array());
     $this->assertTrue(!isset($result['body']), 'Privileged user can view entity but without unaccessible properties.');
-    restful_test_clear_access();
+    restful_test_clear_access_field();
 
     // Non-privileged user (Revoke "access content" permission).
     user_role_revoke_permissions(DRUPAL_ANONYMOUS_RID, array('access content'));

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -387,4 +387,61 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
     );
     field_create_instance($instance);
   }
+
+  /**
+   * Test error handeling when no access is granted to an entity in a list.
+   */
+  function testAccessHandeling() {
+    $settings = array(
+      'type' => 'article',
+    );
+
+    $node1 = $this->drupalCreateNode($settings);
+    $node2 = $this->drupalCreateNode($settings);
+    $node3 = $this->drupalCreateNode($settings);
+
+    // Deny access via hook_node_access() to a specific node.
+    restful_test_deny_access_node($node2->nid);
+
+    $handler = restful_get_restful_handler('articles');
+    $result = $handler->get();
+
+    $this->assertEqual($result['count'], 2);
+
+    // Get a list with specific IDs.
+    $ids = array(
+      $node1->nid,
+      $node2->nid,
+      $node3->nid,
+    );
+    try {
+      $handler->get(explode(',', $ids));
+      $this->fail('Exception was not thrown for un-accessible node for specific IDs list.');
+    }
+    catch (\RestfulForbiddenException $e) {
+      $this->pass('Exception was thrown for un-accessible node for specific IDs list.');
+    }
+    catch (\Exception $e) {
+      $this->fail('Exception of wrong type was thrown for un-accessible node for specific IDs list.');
+    }
+
+    $request = array(
+      'filter' => array(
+        'id' => array(
+          'value' => 1,
+          'operator' => '>='
+        ),
+      ),
+    );
+    try {
+      $handler->get('', $request);
+      $this->fail('Exception was not thrown for un-accessible node for list with filter on the ID.');
+    }
+    catch (\RestfulForbiddenException $e) {
+      $this->pass('Exception was thrown for un-accessible node for with filter on the ID.');
+    }
+    catch (\Exception $e) {
+      $this->fail('Exception of wrong type was thrown for un-accessible node for with filter on the ID.');
+    }
+  }
 }

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -400,13 +400,17 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
     $node2 = $this->drupalCreateNode($settings);
     $node3 = $this->drupalCreateNode($settings);
 
+    $user1 = $this->drupalCreateUser();
+
     // Deny access via hook_node_access() to a specific node.
     restful_test_deny_access_node($node2->nid);
 
     $handler = restful_get_restful_handler('articles');
+    $handler->setAccount($user1);
+
     $result = $handler->get();
 
-    $this->assertEqual($result['count'], 2);
+    $this->assertEqual(count($result), 2, 'List returned and ignored un-accessible entity.');
 
     // Get a list with specific IDs.
     $ids = array(
@@ -415,7 +419,7 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
       $node3->nid,
     );
     try {
-      $handler->get(explode(',', $ids));
+      $handler->get(implode(',', $ids));
       $this->fail('Exception was not thrown for un-accessible node for specific IDs list.');
     }
     catch (\RestfulForbiddenException $e) {

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -428,24 +428,5 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
     catch (\Exception $e) {
       $this->fail('Exception of wrong type was thrown for un-accessible node for specific IDs list.');
     }
-
-    $request = array(
-      'filter' => array(
-        'id' => array(
-          'value' => 1,
-          'operator' => '>='
-        ),
-      ),
-    );
-    try {
-      $handler->get('', $request);
-      $this->fail('Exception was not thrown for un-accessible node for list with filter on the ID.');
-    }
-    catch (\RestfulForbiddenException $e) {
-      $this->pass('Exception was thrown for un-accessible node for with filter on the ID.');
-    }
-    catch (\Exception $e) {
-      $this->fail('Exception of wrong type was thrown for un-accessible node for with filter on the ID.');
-    }
   }
 }

--- a/tests/modules/restful_test/restful_test.module
+++ b/tests/modules/restful_test/restful_test.module
@@ -17,6 +17,44 @@ function restful_test_ctools_plugin_directory($module, $plugin) {
 /**
  * Flag a field to not be accessible.
  *
+ * @param $nid
+ *   The node ID to deny access.
+ */
+function restful_test_deny_access_node($nid) {
+  variable_set('restful_test_deny_access_node', $nid);
+}
+
+/**
+ * Clear un-accessible node.
+ */
+function restful_test_clear_access_node() {
+  variable_del('restful_test_deny_access_node');
+}
+
+/**
+ * Implements hook_node_access().
+ */
+function restful_test_node_access($node, $op, $account) {
+  if (!$nid = variable_get('restful_test_deny_access_node')) {
+    return;
+  }
+
+  if (!$op != 'view') {
+    return;
+  }
+
+  if ($node->nid != $nid) {
+    return;
+  }
+
+  // Deny access.
+  return NODE_ACCESS_DENY;
+}
+
+
+/**
+ * Flag a field to not be accessible.
+ *
  * @param $field_name
  *   The field name. Defaults to "body".
  */
@@ -27,7 +65,7 @@ function restful_test_deny_access_field($field_name = 'body') {
 /**
  * Clear un-accessible fields.
  */
-function restful_test_clear_access() {
+function restful_test_clear_access_field() {
   variable_del('restful_test_deny_access_field');
 }
 

--- a/tests/modules/restful_test/restful_test.module
+++ b/tests/modules/restful_test/restful_test.module
@@ -39,7 +39,7 @@ function restful_test_node_access($node, $op, $account) {
     return;
   }
 
-  if (!$op != 'view') {
+  if ($op != 'view') {
     return;
   }
 


### PR DESCRIPTION
#239

If no IDs were requested, we should not throw an exception in case an
entity is un-accessible by the user.
