### PR TITLE
Is it necessary to check filter_access() on GET requests?

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -939,7 +939,8 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     // Check format access for text fields.
     if ($property_wrapper->type() == 'text_formatted' && $property_wrapper->value() && $property_wrapper->format->value()) {
       $format = (object) array('format' => $property_wrapper->format->value());
-      if (!filter_access($format, $account)) {
+      // Only check filter access on write contexts.
+      if (\RestfulBase::isWriteMethod($this->getMethod()) && !filter_access($format, $account)) {
         return FALSE;
       }
     }


### PR DESCRIPTION
In RestfulEntityBase, at line 946, we have the following code:

``` php
// Check format access for text fields.
    if ($property_wrapper->type() == 'text_formatted' && $property_wrapper->value() && $property_wrapper->format->value()) {
      $format = (object) array('format' => $property_wrapper->format->value());
      if (!filter_access($format, $account)) {
        return FALSE;
      }
    }
```

Basically, if a user makes a request to the endpoint, it makes sure that the user has access to the particular input filter that the property returns.

However, if you are just GETing the response, and viewing, for example, a blog article, then we shouldn't need to check this, correct?

Right now I'm doing this:

``` php
if ($property_wrapper->type() == 'text_formatted' &&
      $property_wrapper->value() &&
      $property_wrapper->format->value() &&
      $this->method != 'GET') {
      $format = (object) array('format' => $property_wrapper->format->value());
      if (!filter_access($format, $account)) {
        return FALSE;
      }
    }
```

My question is: is it necessary to check for filter access, if we're just viewing an entity?
