### PR TITLE
Empty value should not create a new entity from a reference field.

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -643,6 +643,11 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    *   The value to set using the wrapped property.
    */
   protected function propertyValuesPreprocessReference($property_name, $value, $field_info, $public_field_name) {
+    if (!$value) {
+      // If value is empty, return NULL, so no new entity will be created.
+      return;
+    }
+
     if ($field_info['cardinality'] != 1 && !is_array($value)) {
       // If the field is entity reference type and its cardinality larger than
       // 1 set value to an array.


### PR DESCRIPTION
Sometimes a client may send a NULL value, but it is somehow translated to an empty string.
Following check makes sure with are returning a NULL value in that case.
