### PR TITLE
Issue #257: Do not generate underscores for tokens.

### DIFF
--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -1424,4 +1424,19 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
     throw new \RestfulNotImplementedException(format_string('The "@method" method is not implemented in class @class.', array('@method' => $operation, '@class' => __CLASS__)));
   }
 
+  /**
+   * Get a CSRF token.
+   *
+   * @return string
+   *   Get a CSRF token suitable for an HTTP header.
+   */
+  public static function getToken() {
+    $token = drupal_get_token(\RestfulInterface::TOKEN_VALUE);
+    $replacements = array('_' => '-');
+    foreach ($replacements as $original => $new) {
+      $token = str_replace($original, $new, $token);
+    }
+    return $token;
+  }
+
 }

--- a/restful.module
+++ b/restful.module
@@ -689,5 +689,5 @@ function restful_cron() {
  * Page callback: returns a session token for the currently active user.
  */
 function restful_csrf_session_token() {
-  return array('X-CSRF-Token' => drupal_get_token(\RestfulInterface::TOKEN_VALUE));
+  return array('X-CSRF-Token' => \RestfulBase::getToken());
 }


### PR DESCRIPTION
My point is that we are forcing users to send us a specific header that we generate. Those header that we generate contain invalid characters. They should not.

Before the changes there were tokens generated with underscores:

``` shell
vagrant@restful:/var/www/docroot/sites/default/modules/restful$ for i in $(seq 1 20); do drush ev 'print \RestfulBase::getToken() . PHP_EOL'; done
nYO9aOqGSYqHfuDhRyGUpxKnMXMYuYK6JzbsMcHYJPU
BevQztxI61sBHHD0NkAzgkRMCiukJMYZXqoepJ_NfeI
-0WO_Oj3OL0pQsR9IlizotnpNXz6kRJGmMjBvcRkj3Y
nKRIYi8LaaRsbDWlzUm9Uv2TU4OCK2I38kqIjqbHsfI
DC9Zdurav9FMx-dg3dXQcvGAkvF4JdbvOaoRYA3slu4
JiJNkeq8pd-6TSl-YBxk7g5LnOWU_eK7w2vHK45dyK4
Qx-zySmW5et0ufMeHMO-njiMYbrHYm6_4RmBnNNI_qI
uWAgv7l2ud71HN_bcJdM1JVU37tAi9yyiuMao3M8pns
uA-gF4wujh8mxg20_aH6kLN-P2824lDk-vbAnxKoc50
CX8DNvorEEyRTCgBDxpOvpdKKQKq2A4qKAVBDU0qpTA
O73FRKPH59kgbjhS-AnfQDGHDXXn9nb4USubyAT3pKg
taCx6SNHw8paPRzHCKJj2oXs0I8HryhxbDKx3Ut38S4
QT6hhJevd7NnbrTVagT4e9MYtqeuVOi9MDH_HH1xGmw
yLeEiQCi9eMtrN8N7uTb5216wLtj1xIBGhfgm53djLE
DnhyVehdPlnUaXBaVLuAL-NpTr_yVDfne2yLlrOngLQ
f7hSH0MZxYuoZvSVLiEl4W-MGo7yRO6ISo7PuHy6ugw
3aLy-7DHLLweAKxbYV5HYJCqjpu4angwKSVdrr8We10
Y3lH0jBSEhwnzNf7w8ZWWTSLoF2mry2fX72PK_LOF8M
IE2zToZjqLrkpQrIZCsoe3uUDZlHcZn0ECVP7UAju_E
1Yt_WqB1OOFb1IWQnPIw-TDjhO464Vgti-AXgbgZvCU
```

After the changes there are no more underscores:

``` shell
vagrant@restful:/var/www/docroot/sites/default/modules/restful$ for i in $(seq 1 20); do drush ev 'print \RestfulBase::getToken() . PHP_EOL'; done
SS7RsxzNhIa0TqS81YeQza5ej8xspEPpeLm0BULBzko
ONHEO9Hivv75xzJLcjhzIc8xYUo9vHfjjlO4xXqUuoI
iLodQ3r3hFCc4YPPeX0YB-3rXHHJ8V4EpI8ArUzEza0
FAtXagTYSRS3tSPAjM3BbRo-29yNdJo8U1Io94IwOck
4KjEg4SZ-zG8jUZzOgergw5D63Emh8XbCsx6meZ2NMo
79h5-nh1o478mUs-hjwzQYUc21G-vUttzqy4yqG0aBI
0TDvXEv24naNvoC5hzzyaRhKZlBTH9zqFvqto8JRL-E
pBDxadD0E-DRd6qP5r6C69RhFDEuYtr3VDioazSjRLU
1mcPdrBt0edH-gEKAbujdRZtfL7c52SinrX378nwehw
e31NYNZrXa-0V7LiKAYh79KXeoAn-ecbseTYBWSY-Qg
0Jp1yjRiOTTRd-PDQyd9AIv-lBNr1sTIJzt9ifFLAr0
p7OxJ2-N2PHyY75wwpUmDbSe1MTYW1yxay-MpZ3xGHs
8kj6fTqDo-PclGLp6UvRbuU8E4X7Q-HE8RtSut-U1oM
86uY1NHeXwa4ENHZVI7g6MHEBPIrXSZ4URgzrAD3YsQ
8xGzzngKC2Mr5rHwAjtmJqHSATsqivFjfLIZZQzP1rg
6ueej46Kidy4-HxDzpoAQxftvadyQ6T2-aq5OlJzfoE
Z6TWpdjrKQeaWIrpmp4d0Ahg9qvLs0sAF8LGsgmR2YA
54iloL7t6Sx0bpBaNN3EPzsC-DrJHklN8X9Vlz5OnVE
z-VID64prrqeCHIabEiytls87JH6YXufdcL02ABJhf8
h1qjiQqe450O2W4s5Ev0TloJQ-yP5BXsXrLrBd-JL5E
```

AFAIK this is the only header that we enforce the user to send an underscore, all other headers are safe. This thing was introduced as a security measure, so I think we should just honour it instead of working around it.
