### PR TITLE
Allow configuring the range (max items per page in listings)

### DIFF
--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -661,10 +661,17 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
     $this->setMethod($method);
     $this->setPath($path);
     $this->setRequest($request);
-    if (!empty($request['range']) && is_int($request['range']) && $request['range'] < $this->getRange()) {
-      // If there is a valid range property in the request override the range.
-      $this->setRange($request['range']);
+    // Override the range with the value int he URL.
+    if (!empty($request['range'])) {
+      if (!ctype_digit((string) $request['range']) || $request['range'] < 1) {
+        throw new \RestfulBadRequestException('"Range" property should be numeric and higher than 0.');
+      }
+      if ($request['range'] < $this->getRange()) {
+        // If there is a valid range property in the request override the range.
+        $this->setRange($request['range']);
+      }
     }
+
     $version = $this->getVersion();
     $this->setHttpHeaders('X-API-Version', 'v' . $version['major']  . '.' . $version['minor']);
 

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -661,8 +661,8 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
     $this->setMethod($method);
     $this->setPath($path);
     $this->setRequest($request);
-    if (!empty($request['range']) && is_int($request['range'])) {
-      // If there is a range property in the request override the range.
+    if (!empty($request['range']) && is_int($request['range']) && $request['range'] < $this->getRange()) {
+      // If there is a valid range property in the request override the range.
       $this->setRange($request['range']);
     }
     $version = $this->getVersion();

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -661,7 +661,7 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
     $this->setMethod($method);
     $this->setPath($path);
     $this->setRequest($request);
-    if (!empty($request['range'])) {
+    if (!empty($request['range']) && is_int($request['range'])) {
       // If there is a range property in the request override the range.
       $this->setRange($request['range']);
     }

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -661,6 +661,9 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
     $this->setMethod($method);
     $this->setPath($path);
     $this->setRequest($request);
+    if (!empty($request['range'])) {
+      $this->setRange($request['range']);
+    }
     $version = $this->getVersion();
     $this->setHttpHeaders('X-API-Version', 'v' . $version['major']  . '.' . $version['minor']);
 

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -661,7 +661,7 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
     $this->setMethod($method);
     $this->setPath($path);
     $this->setRequest($request);
-    // Override the range with the value int he URL.
+    // Override the range with the value in the URL.
     if (!empty($request['range'])) {
       if (!ctype_digit((string) $request['range']) || $request['range'] < 1) {
         throw new \RestfulBadRequestException('"Range" property should be numeric and higher than 0.');

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -662,6 +662,7 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
     $this->setPath($path);
     $this->setRequest($request);
     if (!empty($request['range'])) {
+      // If there is a range property in the request override the range.
       $this->setRange($request['range']);
     }
     $version = $this->getVersion();

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -155,9 +155,13 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
 
     // Test invalid range.
     $request['range'] = $this->randomName();
-    $result = $handler->get('', $request);
-    $range = $handler->getRange();
-    $this->assertEqual(count($result), min($range, count($expected_result)), 'Invalid range parameter ignored correctly');
+    try {
+      $handler->get('', $request);
+      $this->fail('Exception not raised on invalid range parameter.');
+    }
+    catch (\RestfulBadRequestException $e) {
+      $this->pass('Exception raised on invalid range parameter.');
+    }
 
     // Test the administrator's content listing.
     $role_name = 'administrator';

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -148,6 +148,17 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
       $this->pass('Exception thrown on illegal sort property, descending.');
     }
 
+    // Test the range overrides.
+    $request['range'] = 2;
+    $result = $handler->get('', $request);
+    $this->assertEqual(count($result), $request['range'], 'Range parameter overridden correctly');
+
+    // Test invalid range.
+    $request['range'] = $this->randomName();
+    $result = $handler->get('', $request);
+    $range = $handler->getRange();
+    $this->assertEqual(count($result), min($range, count($expected_result)), 'Invalid range parameter ignored correctly');
+
     // Test the administrator's content listing.
     $role_name = 'administrator';
     $handler = restful_get_restful_handler_by_name('per_role_content__1_0:' . $role_name);

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -149,6 +149,7 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
     }
 
     // Test the range overrides.
+    unset($request['sort']);
     $request['range'] = 2;
     $result = $handler->get('', $request);
     $this->assertEqual(count($result), $request['range'], 'Range parameter overridden correctly');


### PR DESCRIPTION
Right now this is what you are forced to do to override the limit of 50:

``` php
<?php

/**
 * @file
 * Contains RestfulExampleArticlesResource.
 */

class RestfulPerformanceArticlesResource__1_0 extends RestfulEntityBaseNode {

  protected $range = 300;

  /**
   * Overrides RestfulExampleArticlesResource::publicFieldsInfo().
   */
  public function publicFieldsInfo() {
    $public_fields = parent::publicFieldsInfo();

    $public_fields['body'] = array(
      'property' => 'body',
      'sub_property' => 'value',
    );

    return $public_fields;
  }
}
```
