### PR TITLE
Fix PHP code delimiter in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ $plugin = array(
     'sort' => FALSE,
   ),
 );
+```
 
 You can also define default sort fields in your plugin, by overriding
 `defaultSortInfo()` in your class definition.


### PR DESCRIPTION
The  ``` got lost in the shuffle!
