### PR TITLE
doc restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ class RestfulExampleArticlesResource extends RestfulEntityBaseNode {
 
 ### Declaring image formats, references, view modes, and others
 
-See the [Defining a RESTful Plugin](./docs/plugin.md) documentation for more
-details.
+See the [Defining a RESTful Plugin](./docs/plugin.md) document for more details.
 
 
 ## Using your API from within Drupal

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ curl https://example.com/api/articles?autocomplete[string]=mystring
 
 ### Security, Caching, and Output
 
-See the [Consuming Your API](./docs/api_url.md) documentation for more details.
-Also, there are quite a few more URL parameters covered in that document.
+See the [Consuming Your API](./docs/api_url.md) document for more details.
+Also, there are quite a few URL parameters covered in that document.
 
 
 ## Modules integration

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 This module achieves a practical RESTful for Drupal following best practices.
 
+
 ## Concept
 The following also describes the difference between other modules such as RestWs and Services Entity.
 
@@ -22,6 +23,7 @@ with the ``field_`` prefix
 * Audience is developers and not site builders
 * Provide a key tool for a headless Drupal. See the [AngularJs form](https://github.com/Gizra/restful/blob/7.x-1.x/modules/restful_angular_example/README.md) example module.
 
+
 ## Module dependencies
 
   * [Entity API](https://drupal.org/project/entity), with the following patches:
@@ -29,19 +31,90 @@ with the ``field_`` prefix
   * [Prevent notice in entity_metadata_no_hook_node_access() when node is not saved](https://drupal.org/node/2086225#comment-8768373)
 
 
-## API via Drupal
+## Declaring a REST Endpoint
 
-Assuming you have enabled the RESTful example module
+A RESTful endpoint is declared via a custom module that includes a plugin which
+describes the resource you want to make available.  Here are the bare
+essentials from [the example module](./modules/restful_example):
 
-### Getting handlers
+restful_example/restful_example.info
+```ini
+name = RESTful example
+description = Example module for the RESTful module.
+core = 7.x
+dependencies[] = restful
+```
+
+restful_example/restful_example.module
+```php
+/**
+ * Implements hook_ctools_plugin_directory().
+ */
+ function restful_example_ctools_plugin_directory($module, $plugin) {
+   if ($module == 'restful') {
+     return 'plugins/' . $plugin;
+   }
+ }
+```
+
+restful_example/plugins/restful/myplugin.inc
+```php
+$plugin = array(
+  'label' => t('Articles'),
+  'resource' => 'articles',
+  'name' => 'articles',
+  'entity_type' => 'node',
+  'bundle' => 'article',
+  'description' => t('Export the article content type.'),
+  'class' => 'RestfulExampleArticlesResource',
+);
+```
+
+restful_example/plugins/restful/RestfulExampleArticlesResource.class.php
+```php
+class RestfulExampleArticlesResource extends RestfulEntityBaseNode {
+
+  /**
+   * Overrides RestfulEntityBaseNode::publicFieldsInfo().
+   */
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
+
+    $public_fields['body'] = array(
+      'property' => 'body',
+      'sub_property' => 'value',
+    );
+
+    return $public_fields;
+  }
+}
+```
+
+### Declaring image formats, references, view modes, and others
+
+See the [Defining a RESTful Plugin](./docs/plugin.md) documentation for more
+details.
+
+
+## Using your API from within Drupal
+
+The following examples use the _articles_ resource from the example module.
+
+### Getting the default RESTful handler for a resource
 
 ```php
 // Get handler v1.0
 $handler = restful_get_restful_handler('articles');
+```
 
+
+### Getting a specific version of a RESTful handler for a resource
+
+```php
 // Get handler v1.1
 $handler = restful_get_restful_handler('articles', 1, 1);
 ```
+
 
 ### Create and update an entity
 ```php
@@ -55,118 +128,6 @@ $request['label'] = 'new title';
 $handler->patch($id, $request);
 ```
 
-### View an entity
-By default the RESTful module will expose the ID, label and URL of the entity.
-You probably want to expose more than that. To do so you will need to implement
-the `publicFieldsInfo` method defining the names in the output array and how
-those are mapped to the queried entity. For instance the following example will
-retrieve the basic fields plus the body, tags and images from an article node.
-The RESTful module will know to use the `MyRestfulPlugin` class because your
-plugin definition will say so.
-
-```php
-class MyArticlesResource extends \RestfulEntityBase {
-
-  /**
-   * Overrides \RestfulEntityBase::publicFieldsInfo().
-   */
-  public function publicFieldsInfo() {
-    $public_fields = parent::publicFieldsInfo();
-
-    $public_fields['body'] = array(
-      'property' => 'body',
-      'sub_property' => 'value',
-    );
-
-    $public_fields['tags'] = array(
-      'property' => 'field_tags',
-      'resource' => array(
-        'tags' => 'tags',
-      ),
-    );
-
-    $public_fields['image'] = array(
-      'property' => 'field_image',
-      'process_callbacks' => array(
-        array($this, 'imageProcess'),
-      ),
-      // This will add 3 image variants in the output.
-      'image_styles' => array('thumbnail', 'medium', 'large'),
-    );
-
-    return $public_fields;
-  }
-
-}
-```
-
-```php
-// Handler v1.0
-$handler = restful_get_restful_handler('articles');
-// GET method.
-$result = $handler->get(1);
-
-// Output:
-array(
-  'id' => 1,
-  'label' => 'example title',
-  'self' => 'https://example.com/node/1',
-);
-
-// Handler v1.1 extends v1.0, and removes the "self" property from the
-// exposed properties.
-$handler = restful_get_restful_handler('articles', 1, 1);
-$result = $handler->get(1);
-
-// Output:
-array(
-  'id' => 1,
-  'label' => 'example title',
-);
-```
-
-#### View an entity using a view mode
-You can leverage Drupal core's view modes to render an entity and expose it as a
-resource with RESTful. All you need is to set up a view mode that renders the
-output you want to expose and tell RESTful to use it. This simplifies the
-workflow of exposing your resource a lot, since you don't even need to create a
-resource class, but it also offers you less features that are configured in the
-`publicFieldsInfo` method.
-
-Use this method when you don't need any of the extra features that are added via
-`publicFieldsInfo` (like the discovery metadata, image styles for images,
-process callbacks, custom access callbacks for properties, etc.). This is also a
-good way to stub a resource really quick and then move to the more fine grained
-method.
-
-To use this method just set it in the plugin definition file, as demonstrated in
-[this example](https://github.com/Gizra/restful/blob/7.x-1.x/modules/restful_example/plugins/restful/node/articles/1.7/articles__1_7.inc#L3-L23).
-
-#### Filtering fields
-Using the ``?fields`` query string, you can declare which fields should be
-returned.
-
-```php
-$handler = restful_get_restful_handler('articles');
-
-// Define the fields.
-$request['fields'] = 'id,label';
-$result = $handler->get(2, $request);
-
-// Output:
-array(
-  'id' => 2,
-  'label' => 'another title',
-);
-```
-
-#### Image derivatives
-Many client side technologies have lots of problems resizing images to serve
-them optimized and thus avoiding browser scaling. For that reason the RESTful
-module will let you specify an array of image style names to get an array of
-image derivatives for your image fields. Just add an `'image_styles'` key in
-your public field info (as shown above) with the list of styles to use and be
-done with it.
 
 ### List entities
 ```php
@@ -190,133 +151,18 @@ array(
 );
 ```
 
-#### Sort
-You can sort the list of entities by multiple properties. Prefixing the property
-with a dash (``-``) will sort is in a descending order.
-If no sorting is specified the default sorting is by the entity ID.
 
-```php
-$handler = restful_get_restful_handler('articles');
+### Sort, Filter, Range, Sub Requests
 
-// Define the sorting by ID (descending) and label (ascending).
-$request['sort'] = '-id,label';
-$result = $handler->get('', $request);
+See the [Using Your API Within Drupal](./docs/api_drupal.md) documentation for more
+ details.
 
-// Output:
-array(
-  'data' => array(
-    array(
-      'id' => 2,
-      'label' => 'another title',
-      'self' => 'https://example.com/node/2',
-    ),
-    array(
-      'id' => 1,
-      'label' => 'example title',
-      'self' => 'https://example.com/node/1',
-    ),
-  ),
-);
-```
 
-The sort parameter can be disabled in your resource plugin definition:
+## Consuming your API
 
-```php
-$plugin = array(
-  ...
-  'url_params' => array(
-    'sort' => FALSE,
-  ),
-);
-```
+The following examples use the _articles_ resource from the example module.
 
-You can also define default sort fields in your plugin, by overriding
-`defaultSortInfo()` in your class definition.
-
-This method should return an associative array, with each element having a key
-that matches a field from `publicFieldsInfo()`, and a value of either 'ASC' or 'DESC'.
-
-This default sort will be ignored if the request URL contains a sort query.
-
-```php
-class MyPlugin extends \RestfulEntityBaseTaxonomyTerm {
-  /**
-   * Overrides \RestfulEntityBase::defaultSortInfo().
-   */
-  public function defaultSortInfo() {
-    // Sort by 'id' in descending order.
-    return array('id' => 'DESC');
-  }
-}
-```
-
-### Filter
-RESTful allows filtering of a list.
-
-```php
-$handler = restful_get_restful_handler('articles');
-// Single value property.
-$request['filter'] = array('label' => 'abc');
-$result = $handler->get('', $request);
-```
-
-The filter parameter can be disabled in your resource plugin definition:
-
-```php
-$plugin = array(
-  ...
-  'url_params' => array(
-    'filter' => FALSE,
-  ),
-);
-```
-
-### Autocomplete
-By passing the autocomplete query string in the request, it is possible to change
-the normal listing behavior into autocomplete.
-
-The following is the API equivilent of
-``https://example.com?autocomplete[string]=foo&autocomplete[operator]=STARTS_WITH``
-
-```php
-$handler = restful_get_restful_handler('articles');
-
-$request = array(
-  'autocomplete' => array(
-    'string' => 'foo',
-    // Optional, defaults to "CONTAINS".
-    'operator' => 'STARTS_WITH',
-  ),
-);
-
-$handler->get('', $request);
-```
-
-### Range
-RESTful allows you to cotrol the number of elements per page you want to show. This value will always be limited by the `$range` variable in your resource class. This variable, in turn, defaults to 50.
-
-```php
-$handler = restful_get_restful_handler('articles');
-// Single value property.
-$request['range'] = 25;
-$result = $handler->get('', $request);
-```
-
-The range parameter can be disabled in your resource plugin definition:
-
-```php
-$plugin = array(
-  ...
-  'url_params' => array(
-    'range' => FALSE,
-  ),
-);
-```
-
-## API via URL
-
-### View an Article
-
+### Consuming specific versions of your API
 ```shell
 # Handler v1.0
 curl https://example.com/api/articles/1 \
@@ -331,6 +177,7 @@ curl https://example.com/api/articles/1 \
 curl https://example.com/api/v1.1/articles/1
 ```
 
+
 ### View multiple Articles at once
 
 ```shell
@@ -339,444 +186,24 @@ curl https://example.com/api/articles/1,2 \
   -H "X-API-Version: v1.1"
 ```
 
-### Filtering fields
-Using the ``?fields`` query string, you can declare which fields should be
-returned.
+
+### Returning autocomplete results
 
 ```shell
-# Handler v1.0
-curl https://example.com/api/v1/articles/2?fields=id
+curl https://example.com/api/articles?autocomplete[string]=mystring
 ```
 
-Returns:
 
-```javascript
-{
-  "data": [{
-    "id": "2",
-    "label": "Foo"
-  }]
-}
-```
+### Security, Caching, and Output
 
-### Filter
-RESTful allows filtering of a list.
+See the [Consuming Your API](./docs/api_url.md) documentation for more details.
+Also, there are quite a few more URL parameters covered in that document.
 
-```php
-# Handler v1.0
-curl https://example.com/api/v1/articles?filter[label]=abc
-```
-
-You can even filter results using basic operators. For instance to get all the
-articles after a certain date:
-
-```shell
-# Handler v1.0
-curl https://example.com/api/articles?filter[created][value]=1417591992&filter[created][operator]=">="
-```
-
-## Authentication providers
-
-Restful comes with ``cookie``, ``base_auth`` (user name and password in the HTTP header)
-authentications providers, as well as a "RESTful token auth" module that has a
-``token`` authentication provider.
-
-Note: if you use cookie-based authentication then you also need to set the
-HTTP ``X-CSRF-Token`` header on all writing requests (POST, PUT and DELETE).
-You can retrieve the token from ``/api/session/token`` with a standard HTTP
-GET request.
-
-See [this](https://github.com/Gizra/angular-restful-auth) AngularJs example that shows a login from a fully decoupled web app
-to a Drupal backend.
-
-
-```bash
-# (Change username and password)
-curl -u "username:password" https://example.com/api/login
-
-# Response has access token.
-{"access_token":"YOUR_TOKEN"}
-
-# Call a "protected" with token resource (Articles resource version 1.3 in "Restful example")
-curl https://example.com/api/v1.3/articles/1?access_token=YOUR_TOKEN
-```
-
-### Error handling
-While a PHP ``Exception`` is thrown when using the API via Drupal, this is not the
-case when consuming the API externally. Instead of the exception a valid JSON
-with ``code``, ``message`` and ``description`` would be returned.
-
-The RESTful module adheres to the [Problem Details for HTTP
-APIs](http://tools.ietf.org/html/draft-nottingham-http-problem-06) draft to
-improve DX when dealing with HTTP API errors. Download and enable the [Advanced
-Help](https://drupal.org/project/advanced_help) module for more information
-about the errors.
-
-For example, trying to sort a list by an invalid key
-
-```shell
-curl https://example.com/api/v1/articles?sort=wrong_key
-```
-
-Will result with an HTTP code 400, and the following JSON:
-
-```javascript
-{
-  'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1',
-  'title' => 'The sort wrong_key is not allowed for this path.',
-  'status' => 400,
-  'detail' => 'Bad Request.',
-}
-```
-
-## Reference fields and properties
-
-It is considered a best practice to map a reference field (i.e. entity
-reference or taxonomy term reference) or a reference property (e.g. the ``uid``
-property on the node entity) to the resource it belongs to.
-
-
-```php
-public function publicFieldsInfo() {
-  $public_fields = parent::publicFieldsInfo();
-  // ...
-  $public_fields['user'] = array(
-    'property' => 'author',
-    'resource' => array(
-      // The bundle of the entity.
-      'user' => array(
-      // The name of the resource to map to.
-      'name' => 'users',
-      // Determines if the entire resource should appear, or only the ID.
-      'full_view' => TRUE,
-    ),
-  );
-  // ...
-  return $public_fields;
-}
-```
-
-## Sub-requests
-It is possible to create multiple referencing entities in a single request. A
-typical example would be a node referencing a new taxonomy term. For example if
-there was a taxonomy reference or entity reference field called ``field_tags``
-on the  Article bundle (node) with an ``articles`` and a Tags bundle (taxonomy
-term) with a ``tags`` resource, we would define the relation via the
-``RestfulEntityBase::publicFieldsInfo()``
-
-```php
-public function publicFieldsInfo() {
-  $public_fields = parent::publicFieldsInfo();
-  // ...
-  $public_fields['tags'] = array(
-    'property' => 'field_tags',
-    'resource' => array(
-      'tags' => 'tags',
-    ),
-  );
-  // ...
-  return $public_fields;
-}
-
-```
-
-And create both entities with a single request:
-
-```php
-$handler = restful_get_restful_handler('articles');
-$request = array(
-  'label' => 'parent',
-  'body' => 'Drupal',
-  'tags' => array(
-    array(
-      // Create a new term.
-      'label' => 'child1',
-    ),
-    array(
-      // PATCH an existing term.
-      'label' => 'new title by PATCH',
-    ),
-    array(
-      '__application' => array(
-        'method' => \RestfulInterface::PUT,
-      ),
-      // PUT an existing term.
-      'label' => 'new title by PUT',
-    ),
-  ),
-);
-
-$handler->post('', $request);
-
-```
-## Output formats
-
-The RESTful module outputs all resources by using HAL+JSON encoding by default.
-That means that when you have the following data:
-
-```php
-array(
-  array(
-    'id' => 2,
-    'label' => 'another title',
-    'self' => 'https://example.com/node/2',
-  ),
-  array(
-    'id' => 1,
-    'label' => 'example title',
-    'self' => 'https://example.com/node/1',
-  ),
-);
-```
-
-Then the following output is generated (using the header
-`ContentType:application/hal+json; charset=utf-8`):
-
-```javascript
-{
-  "data": [
-    {
-      "id": 2,
-      "label": "another title",
-      "self": "https:\/\/example.com\/node\/2"
-    },
-    {
-      "id": 1,
-      "label": "example title",
-      "self": "https:\/\/example.com\/node\/1"
-    }
-  ],
-  "count": 2,
-  "_links": []
-}
-```
-
-You can change that to be anything that you need. You have a plugin that will
-allow you to output XML instead of JSON in
-[the example module](./modules/restful_example/plugins/formatter). Take that
-example and create you custom module that contains the formatter plugin the you
-need (maybe you need to output JSON but following a different data structure,
-you may even want to use YAML, ...). All that you will need is to create a
-formatter plugin and tell your restful resource to use that in the restful
-plugin definition:
-
-```php
-$plugin = array(
-  'label' => t('Articles'),
-  'resource' => 'articles',
-  'description' => t('Export the article content type in my cool format.'),
-  ...
-  'formatter' => 'my_formatter', // <-- The name of the formatter plugin.
-);
-```
-
-### Changing the default output format.
-If you need to change the output format for everything at once then you just
-have to set a special variable with the name of the new output format plugin.
-When you do that all the resources that don't specify a `'formatter'` key in the
-plugin definition will use that output format by default. Ex:
-
-```php
-variable_set('restful_default_output_formatter', 'my_formatter');
-```
-
-## Render Cache.
-The RESTful module is compatible and leverages the popular
-[Entity Cache](https://drupal.org/project/entitycache) module and adds a new
-cache layer on its own for the rendered entity. Two requests made by the same
-user requesting the same fields on the same entity will benefit from the render
-cache layer. This means that no entity will need to be loaded if it was rendered
-in the past under the same conditions.
-
-Developers have absolute control where the cache is stored and the expiration
-for every resource, meaning that very volatile resources can skip cache entirely
-while other resources can have its cache in MemCached or the database. To
-configure this developers just have to specify the following keys in their
-_restful_ plugin definition:
-
-```php
-<?php
-
-$plugin = array(
-  ...
-  'render_cache' => array(
-    // Enables the render cache.
-    'render' => TRUE,
-    // Defaults to 'cache_restful' (optional).
-    'bin' => 'cache_bin_name',
-    // Expiration logic. Defaults to CACHE_PERMANENT (optional).
-    'expire' => CACHE_TEMPORARY,
-    // Enable cache invalidation for entity based resources. Defaults to TRUE (optional).
-    'simple_invalidate' => TRUE,
-    // Use a different cache backend for this resource. Defaults to variable_get('cache_default_class', 'DrupalDatabaseCache') (optional).
-    'class' => 'MemCacheDrupal',
-    // Account cache granularity. Instead of caching per user you can choose to cache per role. Default: DRUPAL_CACHE_PER_USER.
-    'granularity' => DRUPAL_CACHE_PER_ROLE,
-  ),
-);
-```
-
-Additionally you can define a cache backend for a given cache bin by setting the variable `cache_class_<cache-bin-name>` to the class to be used. This way all the resouces caching to that particular bin will use that cache backend instead of the default one.
-
-## Rate Limit
-RESTful provides rate limit functionality out of the box. A rate limit is a way
-to protect your API service from flooding, basically consisting on checking is
-the number of times an event has happened in a given period is greater that the
-maximum allowed.
-
-### Rate Limit events
-You can define your own rate limit events for your resources and define the
-limit an period for those, for that you only need to create a new _rate\_limit_
-CTools plugin and implement the `isRequestedEvent` method. Every request the
-`isRequestedEvent` will be evaluated and if it returns true that request will
-increase the number of hits -for that particular user- for that event. If the
-number of hits is bigger than the allowed limit an exception will be raised.
-
-Two events are provided out of the box: the request event -that is always true
-for every request- and the global event -that is always true and is not
-contained for a given resource, all resources will increment the hit counter-.
-
-This way, for instance, you could define different limit for read operations
-than for write operations by checking the HTTP method in `isRequestedEvent`.
-
-### Configuring your Rate Limits
-You can configure the declared Rate Limit events in every resource by providing
-a configuration array. The following is taken from the example resource articles
-1.4 (articles\_\_1\_4.inc):
-
-```php
-…
-  'rate_limit' => array(
-    // The 'request' event is the basic event. You can declare your own events.
-    'request' => array(
-      'event' => 'request',
-      // Rate limit is cleared every day.
-      'period' => new \DateInterval('P1D'),
-      'limits' => array(
-        'authenticated user' => 3,
-        'anonymous user' => 2,
-        'administrator' => \RestfulRateLimitManager::UNLIMITED_RATE_LIMIT,
-      ),
-    ),
-  ),
-…
-```
-
-As you can see in the example you can set the rate limit differently depending
-on the role of the visiting user.
-
-Since the global event is not tied to any resource the limit and period is specified by setting the following variables:
-  - `restful_global_rate_limit`: The number of allowed hits. This is global for
-    all roles.
-  - `restful_global_rate_period`: The period string compatible with
-    \DateInterval.
-
-## Documenting your API
-It is of most importance to document your API, this is why the RESTful module
-provides a way to comprehensively document your resources and endpoints. This
-documentation can be accessed through the HTTP methods and through extending
-modules. The API will be documented both for humans and for machine consumption,
-allowing client implementations to know about the API without explicit
-programming.
-
-### Documenting your resources.
-A resource can will be documented in the plugin definition using the `'label'`
-and `'description'` keys:
-
-```php
-$plugin = array(
-  // This is the human readable name of the resource.
-  'label' => t('User'),
-  // Use de description to provide more extended information about the resource.
-  'description' => t('Export the "User" entity.'),
-  'resource' => 'users',
-  'class' => 'RestfulEntityBaseUser',
-  ...
-);
-```
-
-This should not include any information about the endpoints or the allowed HTTP
-methods on them, since those will be accessed directly on the aforementioned
-endpoint. This information aims to describe what the accessed resource
-represents.
-
-To access this information just use the `discovery` resource at the api
-homepage:
-
-```shell
-# List resources
-curl -u user:password https://example.org/api
-```
-
-### Documenting your fields.
-When declaring your public field and their mappings you will have the
-opportunity to also provide information about the field itself. This includes
-basic information about the field, information about the data the field holds
-and about how to generate a form element in the client side for this particular
-field. By declaring this information a client can write an implementation that
-reads this information and provide form elements _for free_ via reusable form
-components.
-
-```php
-$public_fields['text_multiple'] = array(
-  'property' => 'text_multiple',
-  'discovery' => array(
-    // Basic information about the field for human consumption.
-    'info' => array(
-      // The name of the field. Defaults to: ''.
-      'name' => t('Text multiple'),
-      // The description of the field. Defaults to: ''.
-      'description' => t('This field holds different text inputs.'),
-    ),
-    // Information about the data that the field holds. Typically used to help the client to manage the data appropriately.
-    'data' => array(
-      // The type of data. For instance: 'int', 'string', 'boolean', 'object', 'array', ... Defaults to: NULL.
-      'type' => 'string',
-      // The number of elements that this field can contain. Defaults to: 1.
-      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
-      // Avoid updating/setting this field. Typically used in fields representing the ID for the resource. Defaults to: FALSE.
-      'read_only' => FALSE,
-    ),
-    'form_element' => array(
-      // The type of the input element as in Form API. Defaults to: NULL.
-      'type' => 'textfield',
-      // The default value for the form element. Defaults to: ''.
-      'default_value' => '',
-      // The placeholder text for the form element. Defaults to: ''.
-      'placeholder' => t('This is helpful.'),
-      // The size of the form element (if applies). Defaults to: NULL.
-      'size' => 255,
-      // The allowed values for form elements with a limited set of options. Defaults to: NULL.
-      'allowed_values' => NULL,
-    ),
-  ),
-);
-```
-
-This is the default set of information provided by RESTful. You can add your own
-information to the `'discovery'` property and it will be exposed as well.
-
-To access the information about an specific endpoint just make an `OPTIONS` call
-to it. You will get the field information in the body, the information about the
-available output formats and the permitted HTTP methods will be contained in the
-corresponding headers.
-
-#### Auto-documented fields.
-If your resource is an entity then some of this information will be populated
-for you out of the box, without you needing to do anything else. This
-information will be derived from the Entity API and Field API. The following
-will be populated automatically:
-
-  - `$discovery_info['info']['label']`.
-  - `$discovery_info['info']['description']`.
-  - `$discovery_info['data']['type']`.
-  - `$discovery_info['data']['required']`.
-  - `$discovery_info['form_element']['default_value']`.
-  - `$discovery_info['form_element']['allowed_values']` for text lists.
 
 ## Modules integration
 * [Entity validator](https://www.drupal.org/project/entity_validator): Integrate
 with a robust entity validation
+
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ curl https://example.com/api/v1.1/articles/1
 ```
 
 
-### View multiple Articles at once
+### View multiple articles at once
 
 ```shell
 # Handler v1.1
@@ -202,7 +202,7 @@ curl https://example.com/api/articles?autocomplete[string]=mystring
 ```
 
 
-### URL Query Strings, HTTP headers, and HTTP requests
+### URL Query strings, HTTP headers, and HTTP requests
 
 See the [Consuming Your API](./docs/api_url.md) document for more details.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ class RestfulCustomResource extends RestfulEntityBaseNode {
 After declaring this plugin, the resource could be accessed at its root URL,
 which would be `http://example.com/api/v1.0/articles`.
 
-### Security, caching, and output
+### Security, caching, output, and customization
 
 See the [Defining a RESTful Plugin](./docs/plugin.md) document for more details.
 
@@ -107,7 +107,7 @@ See the [Defining a RESTful Plugin](./docs/plugin.md) document for more details.
 The following examples use the _articles_ resource from the _restful\_example_
 module.
 
-### Getting the default RESTful handler for a resource
+#### Getting the default RESTful handler for a resource
 
 ```php
 // Get handler v1.0
@@ -115,7 +115,7 @@ $handler = restful_get_restful_handler('articles');
 ```
 
 
-### Getting a specific version of a RESTful handler for a resource
+#### Getting a specific version of a RESTful handler for a resource
 
 ```php
 // Get handler v1.1
@@ -123,7 +123,7 @@ $handler = restful_get_restful_handler('articles', 1, 1);
 ```
 
 
-### Create and update an entity
+#### Create and update an entity
 ```php
 $handler = restful_get_restful_handler('articles');
 // POST method, to create.
@@ -136,7 +136,7 @@ $handler->patch($id, $request);
 ```
 
 
-### List entities
+#### List entities
 ```php
 $handler = restful_get_restful_handler('articles');
 $result = $handler->get();
@@ -170,7 +170,7 @@ more details.
 The following examples use the _articles_ resource from the _restful\_example_
 module.
 
-### Consuming specific versions of your API
+#### Consuming specific versions of your API
 ```shell
 # Handler v1.0
 curl https://example.com/api/articles/1 \
@@ -186,7 +186,7 @@ curl https://example.com/api/v1.1/articles/1
 ```
 
 
-### View multiple articles at once
+#### View multiple articles at once
 
 ```shell
 # Handler v1.1
@@ -195,14 +195,14 @@ curl https://example.com/api/articles/1,2 \
 ```
 
 
-### Returning autocomplete results
+#### Returning autocomplete results
 
 ```shell
 curl https://example.com/api/articles?autocomplete[string]=mystring
 ```
 
 
-### URL Query strings, HTTP headers, and HTTP requests
+#### URL Query strings, HTTP headers, and HTTP requests
 
 See the [Consuming Your API](./docs/api_url.md) document for more details.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ class RestfulCustomResource extends RestfulEntityBaseNode {
 After declaring this plugin, the resource could be accessed at its root URL,
 which would be `http://example.com/api/v1.0/articles`.
 
-### Declaring image formats, references, view modes, and others
+### Security, caching, and output
 
 See the [Defining a RESTful Plugin](./docs/plugin.md) document for more details.
 
@@ -202,10 +202,9 @@ curl https://example.com/api/articles?autocomplete[string]=mystring
 ```
 
 
-### Security, Caching, and Output
+### URL Query Strings, HTTP headers, and HTTP requests
 
 See the [Consuming Your API](./docs/api_url.md) document for more details.
-Also, there are quite a few URL parameters covered in that document.
 
 
 ## Documenting your API

--- a/README.md
+++ b/README.md
@@ -2,25 +2,28 @@
 
 # RESTful best practices for Drupal
 
-This module achieves a practical RESTful for Drupal following best practices.
+This module allows Drupal to be operated via RESTful HTTP requests, using best
+practices for security, performance, and usability.
 
 
 ## Concept
-The following also describes the difference between other modules such as RestWs and Services Entity.
+Here are the differences between RESTful and other modules, such as RestWs and
+Services Entity:
 
-* Restful module requires explicitly declaring the exposed API. When enabling the
-module nothing will happen until the implementing developer will declare it
-* Instead of exposing resources by entity type (e.g. node, taxonomy term), Restful
-cares about bundles. So for example you may expose the ``Article`` content type, but
-not the ``Page`` content type
-* The exposed properties need to be explicitly declared. This allows a _clean_ output
-without Drupal's internal implementation leaking out. This means the consuming
-client doesn't need to know if an entity is a node or a term, nor will they be presented
-with the ``field_`` prefix
-* One of the core features is versioning. While it's debatable if this feature
- is indeed a pure REST, we believe it's a best practice one
-* It has configurable output formats. It ships with JSON and XML as examples. HAL+JSON is the recommended default.
-* Audience is developers and not site builders
+* RESTful requires explicitly declaring the exposed API. When enabling
+the module, nothing happens until a plugin declares it.
+* Resources are exposed by bundle, rather than by entity.  This would allow a
+developer to expose only nodes of a certain type, for example.
+* The exposed properties need to be explicitly declared. This allows a _clean_
+output without Drupal's internal implementation leaking out. This means the
+consuming client doesn't need to know if an entity is a node or a term, nor will
+ they be presented with the ``field_`` prefix.
+* Resource versioning is built-in, so that resources can be reused with multiple
+consumers.  The versions are at the resource level, for more flexibility and
+control.
+* It has configurable output formats. It ships with JSON and XML as examples.
+HAL+JSON is the recommended default.
+* Audience is developers and not site builders.
 * Provide a key tool for a headless Drupal. See the [AngularJs form](https://github.com/Gizra/restful/blob/7.x-1.x/modules/restful_angular_example/README.md) example module.
 
 
@@ -35,29 +38,30 @@ with the ``field_`` prefix
 
 A RESTful endpoint is declared via a custom module that includes a plugin which
 describes the resource you want to make available.  Here are the bare
-essentials from [the example module](./modules/restful_example):
+essentials from one of the multiple examples in
+[the example module](./modules/restful_example):
 
-restful_example/restful_example.info
+####restful\_custom/restful\_custom.info
 ```ini
-name = RESTful example
-description = Example module for the RESTful module.
+name = RESTful custom
+description = Custom RESTful resource.
 core = 7.x
 dependencies[] = restful
 ```
 
-restful_example/restful_example.module
+####restful\_custom/restful\_custom.module
 ```php
 /**
  * Implements hook_ctools_plugin_directory().
  */
- function restful_example_ctools_plugin_directory($module, $plugin) {
+ function restful_custom_ctools_plugin_directory($module, $plugin) {
    if ($module == 'restful') {
      return 'plugins/' . $plugin;
    }
  }
 ```
 
-restful_example/plugins/restful/myplugin.inc
+####restful\_custom/plugins/restful/myplugin.inc
 ```php
 $plugin = array(
   'label' => t('Articles'),
@@ -66,13 +70,13 @@ $plugin = array(
   'entity_type' => 'node',
   'bundle' => 'article',
   'description' => t('Export the article content type.'),
-  'class' => 'RestfulExampleArticlesResource',
+  'class' => 'RestfulCustomResource',
 );
 ```
 
-restful_example/plugins/restful/RestfulExampleArticlesResource.class.php
+####restful\_custom/plugins/restful/RestfulCustomResource.class.php
 ```php
-class RestfulExampleArticlesResource extends RestfulEntityBaseNode {
+class RestfulCustomResource extends RestfulEntityBaseNode {
 
   /**
    * Overrides RestfulEntityBaseNode::publicFieldsInfo().
@@ -90,6 +94,9 @@ class RestfulExampleArticlesResource extends RestfulEntityBaseNode {
 }
 ```
 
+After declaring this plugin, the resource could be accessed at its root URL,
+which would be `http://example.com/api/v1.0/articles`.
+
 ### Declaring image formats, references, view modes, and others
 
 See the [Defining a RESTful Plugin](./docs/plugin.md) document for more details.
@@ -97,7 +104,8 @@ See the [Defining a RESTful Plugin](./docs/plugin.md) document for more details.
 
 ## Using your API from within Drupal
 
-The following examples use the _articles_ resource from the example module.
+The following examples use the _articles_ resource from the _restful\_example_
+module.
 
 ### Getting the default RESTful handler for a resource
 
@@ -151,15 +159,16 @@ array(
 ```
 
 
-### Sort, Filter, Range, Sub Requests
+### Sort, Filter, Range, and Sub Requests
 
-See the [Using Your API Within Drupal](./docs/api_drupal.md) documentation for more
- details.
+See the [Using your API within drupal](./docs/api_drupal.md) documentation for
+more details.
 
 
 ## Consuming your API
 
-The following examples use the _articles_ resource from the example module.
+The following examples use the _articles_ resource from the _restful\_example_
+module.
 
 ### Consuming specific versions of your API
 ```shell
@@ -197,6 +206,58 @@ curl https://example.com/api/articles?autocomplete[string]=mystring
 
 See the [Consuming Your API](./docs/api_url.md) document for more details.
 Also, there are quite a few URL parameters covered in that document.
+
+
+## Documenting your API
+
+Clients can access documentation about a resource by making an `OPTIONS` HTTP
+request to its root URL. The resource will respond with the field information
+in the body, and the information about the available output formats and the
+permitted HTTP methods will be contained in the headers.
+
+
+### Automatic documentation
+
+If your resource is an entity, then it will be partially self-documented,
+without you needing to do anything else. This information is automatically
+derived from the Entity API and Field API.
+
+Here is a snippet from a typical JSON response using only the automatic
+documentation:
+
+```javascript
+{
+  "myfield": {
+    "info": {
+      "label": "My Field",
+      "description": "A field within my resource."
+    },
+    "data": {
+      "type": "string",
+      "read_only": false,
+      "cardinality": 1,
+      "required": false
+    },
+    "form_element": {
+      "type": "texfield",
+      "default_value": "",
+      "placeholder": "",
+      "size": 255,
+      "allowed_values": null
+    }
+  }
+  // { ... other fields would follow ... }
+}
+```
+
+Each field you've defined in `publicFieldsInfo` will output an object similar
+to the one listed above.
+
+
+### Manual documentation
+In addition to the automatic documentation provided to you out of the box, you
+have the ability to manually document your resources.  See the [Documenting your API](./docs/documentation.md)
+documentation for more details.
 
 
 ## Modules integration

--- a/docs/api_drupal.md
+++ b/docs/api_drupal.md
@@ -1,5 +1,6 @@
 # Using Your API Within Drupal
 
+
 ## Sort
 You can sort the list of entities by multiple properties. Prefixing the property
 with a dash (``-``) will sort is in a descending order.
@@ -29,6 +30,7 @@ array(
 );
 ```
 
+
 ## Filter
 RESTful allows filtering of a list.
 
@@ -39,7 +41,7 @@ $request['filter'] = array('label' => 'abc');
 $result = $handler->get('', $request);
 ```
 
-### Autocomplete
+## Autocomplete
 By passing the autocomplete query string in the request, it is possible to change
 the normal listing behavior into autocomplete.
 
@@ -59,6 +61,7 @@ $request = array(
 
 $handler->get('', $request);
 ```
+
 
 ## Range
 RESTful allows you to cotrol the number of elements per page you want to show. This value will always be limited by the `$range` variable in your resource class. This variable, in turn, defaults to 50.
@@ -122,6 +125,7 @@ $request = array(
 
 $handler->post('', $request);
 ```
+
 
 ### Error handling
 If an error occurs while using the API within Drupal, a PHP ``Exception``

--- a/docs/api_drupal.md
+++ b/docs/api_drupal.md
@@ -1,0 +1,128 @@
+# Using Your API Within Drupal
+
+## Sort
+You can sort the list of entities by multiple properties. Prefixing the property
+with a dash (``-``) will sort is in a descending order.
+If no sorting is specified the default sorting is by the entity ID.
+
+```php
+$handler = restful_get_restful_handler('articles');
+
+// Define the sorting by ID (descending) and label (ascending).
+$request['sort'] = '-id,label';
+$result = $handler->get('', $request);
+
+// Output:
+array(
+  'data' => array(
+    array(
+      'id' => 2,
+      'label' => 'another title',
+      'self' => 'https://example.com/node/2',
+    ),
+    array(
+      'id' => 1,
+      'label' => 'example title',
+      'self' => 'https://example.com/node/1',
+    ),
+  ),
+);
+```
+
+## Filter
+RESTful allows filtering of a list.
+
+```php
+$handler = restful_get_restful_handler('articles');
+// Single value property.
+$request['filter'] = array('label' => 'abc');
+$result = $handler->get('', $request);
+```
+
+### Autocomplete
+By passing the autocomplete query string in the request, it is possible to change
+the normal listing behavior into autocomplete.
+
+The following is the API equivilent of
+``https://example.com?autocomplete[string]=foo&autocomplete[operator]=STARTS_WITH``
+
+```php
+$handler = restful_get_restful_handler('articles');
+
+$request = array(
+  'autocomplete' => array(
+    'string' => 'foo',
+    // Optional, defaults to "CONTAINS".
+    'operator' => 'STARTS_WITH',
+  ),
+);
+
+$handler->get('', $request);
+```
+
+## Range
+RESTful allows you to cotrol the number of elements per page you want to show. This value will always be limited by the `$range` variable in your resource class. This variable, in turn, defaults to 50.
+
+```php
+$handler = restful_get_restful_handler('articles');
+// Single value property.
+$request['range'] = 25;
+$result = $handler->get('', $request);
+```
+
+## Sub-requests
+It is possible to create multiple referencing entities in a single request. A
+typical example would be a node referencing a new taxonomy term. For example if
+there was a taxonomy reference or entity reference field called ``field_tags``
+on the  Article bundle (node) with an ``articles`` and a Tags bundle (taxonomy
+term) with a ``tags`` resource, we would define the relation via the
+``RestfulEntityBase::publicFieldsInfo()``
+
+```php
+public function publicFieldsInfo() {
+  $public_fields = parent::publicFieldsInfo();
+  // ...
+  $public_fields['tags'] = array(
+    'property' => 'field_tags',
+    'resource' => array(
+      'tags' => 'tags',
+    ),
+  );
+  // ...
+  return $public_fields;
+}
+
+```
+
+And create both entities with a single request:
+
+```php
+$handler = restful_get_restful_handler('articles');
+$request = array(
+  'label' => 'parent',
+  'body' => 'Drupal',
+  'tags' => array(
+    array(
+      // Create a new term.
+      'label' => 'child1',
+    ),
+    array(
+      // PATCH an existing term.
+      'label' => 'new title by PATCH',
+    ),
+    array(
+      '__application' => array(
+        'method' => \RestfulInterface::PUT,
+      ),
+      // PUT an existing term.
+      'label' => 'new title by PUT',
+    ),
+  ),
+);
+
+$handler->post('', $request);
+```
+
+### Error handling
+If an error occurs while using the API within Drupal, a PHP ``Exception``
+is thrown.

--- a/docs/api_drupal.md
+++ b/docs/api_drupal.md
@@ -1,9 +1,28 @@
 # Using Your API Within Drupal
 
+The RESTful module allows your resources to be used within Drupal itself. For
+example, you could define a resource, and then operate it within another
+custom module.
 
-## Sort
-You can sort the list of entities by multiple properties. Prefixing the property
-with a dash (``-``) will sort is in a descending order.
+In general, this is accomplished by using `restful_get_restful_handler` to get a
+handler for your resource, and then calling methods such as `get` or `post` to
+make a request, which will operate the resource.
+
+The request itself can be customized by passing in an array of key/value pairs.
+
+
+
+## Read Contexts
+
+The following keys apply to read contexts, in which you are using the `get`
+method to return results from a resource.
+
+### Sort
+You can use the `'sort'` key to sort the list of entities by multiple
+properties.  List every property in a comma-separated string, in the order that
+you want to sort by.  Prefixing the property name with a dash (``-``) will sort
+ by that property in a descending order; the default is ascending.
+
 If no sorting is specified the default sorting is by the entity ID.
 
 ```php
@@ -31,8 +50,8 @@ array(
 ```
 
 
-## Filter
-RESTful allows filtering of a list.
+### Filter
+Use the `'filter'` key to filter the list.
 
 ```php
 $handler = restful_get_restful_handler('articles');
@@ -41,12 +60,14 @@ $request['filter'] = array('label' => 'abc');
 $result = $handler->get('', $request);
 ```
 
-## Autocomplete
-By passing the autocomplete query string in the request, it is possible to change
-the normal listing behavior into autocomplete.
+### Autocomplete
+By using the `'autocomplete'` key and supplying a query string, it is possible
+to change the normal listing behavior into autocomplete.  This also changes
+the normal output objects into key/value pairs which can be fed directly into
+a Drupal autocomplete field.
 
-The following is the API equivilent of
-``https://example.com?autocomplete[string]=foo&autocomplete[operator]=STARTS_WITH``
+The following is the API equivalent of
+`https://example.com?autocomplete[string]=foo&autocomplete[operator]=STARTS_WITH`
 
 ```php
 $handler = restful_get_restful_handler('articles');
@@ -63,8 +84,10 @@ $handler->get('', $request);
 ```
 
 
-## Range
-RESTful allows you to cotrol the number of elements per page you want to show. This value will always be limited by the `$range` variable in your resource class. This variable, in turn, defaults to 50.
+### Range
+Using the `'range'` key, you can control the number of elements per page you
+want to show. This value will always be limited by the `$range` variable in your
+ resource class. This variable defaults to 50.
 
 ```php
 $handler = restful_get_restful_handler('articles');
@@ -73,7 +96,12 @@ $request['range'] = 25;
 $result = $handler->get('', $request);
 ```
 
-## Sub-requests
+## Write Contexts
+
+The following techniques apply to write contexts, in which you are using the
+`post` method to create an entity defined by a resource.
+
+### Sub-requests
 It is possible to create multiple referencing entities in a single request. A
 typical example would be a node referencing a new taxonomy term. For example if
 there was a taxonomy reference or entity reference field called ``field_tags``
@@ -127,6 +155,7 @@ $handler->post('', $request);
 ```
 
 
-### Error handling
-If an error occurs while using the API within Drupal, a PHP ``Exception``
-is thrown.
+## Error handling
+If an error occurs while using the API within Drupal, a custom exception is
+thrown.  All the exceptions thrown by the RESTful module extend the
+`\RestfulException` class.

--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -122,3 +122,30 @@ curl -u "username:password" https://example.com/api/login
 # Call a "protected" with token resource (Articles resource version 1.3 in "Restful example")
 curl https://example.com/api/v1.3/articles/1?access_token=YOUR_TOKEN
 ```
+
+## Error handling
+If an error occurs when operating the REST endpoint via URL, A valid JSON object
+ with ``code``, ``message`` and ``description`` would be returned.
+
+The RESTful module adheres to the [Problem Details for HTTP
+APIs](http://tools.ietf.org/html/draft-nottingham-http-problem-06) draft to
+improve DX when dealing with HTTP API errors. Download and enable the [Advanced
+Help](https://drupal.org/project/advanced_help) module for more information
+about the errors.
+
+For example, trying to sort a list by an invalid key
+
+```shell
+curl https://example.com/api/v1/articles?sort=wrong_key
+```
+
+Will result with an HTTP code 400, and the following JSON:
+
+```javascript
+{
+  'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1',
+  'title' => 'The sort wrong_key is not allowed for this path.',
+  'status' => 400,
+  'detail' => 'Bad Request.',
+}
+```

--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -233,32 +233,32 @@ Since the global event is not tied to any resource the limit and period is speci
   - `restful_global_rate_period`: The period string compatible with
     \DateInterval.
 
-    ## Error handling
-    If an error occurs when operating the REST endpoint via URL, A valid JSON object
-     with ``code``, ``message`` and ``description`` would be returned.
+## Error handling
+If an error occurs when operating the REST endpoint via URL, A valid JSON object
+ with ``code``, ``message`` and ``description`` would be returned.
 
-    The RESTful module adheres to the [Problem Details for HTTP
-    APIs](http://tools.ietf.org/html/draft-nottingham-http-problem-06) draft to
-    improve DX when dealing with HTTP API errors. Download and enable the [Advanced
-    Help](https://drupal.org/project/advanced_help) module for more information
-    about the errors.
+The RESTful module adheres to the [Problem Details for HTTP
+APIs](http://tools.ietf.org/html/draft-nottingham-http-problem-06) draft to
+improve DX when dealing with HTTP API errors. Download and enable the [Advanced
+Help](https://drupal.org/project/advanced_help) module for more information
+about the errors.
 
-    For example, trying to sort a list by an invalid key
+For example, trying to sort a list by an invalid key
 
-    ```shell
-    curl https://example.com/api/v1/articles?sort=wrong_key
-    ```
+```shell
+curl https://example.com/api/v1/articles?sort=wrong_key
+```
 
-    Will result with an HTTP code 400, and the following JSON:
+Will result with an HTTP code 400, and the following JSON:
 
-    ```javascript
-    {
-      'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1',
-      'title' => 'The sort wrong_key is not allowed for this path.',
-      'status' => 400,
-      'detail' => 'Bad Request.',
-    }
-    ```
+```javascript
+{
+  'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1',
+  'title' => 'The sort wrong_key is not allowed for this path.',
+  'status' => 400,
+  'detail' => 'Bad Request.',
+}
+```
 
 
 ## Documenting your API

--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -1,5 +1,63 @@
 # Consuming your API
 
+The RESTful module allows your resources to be used by external clients via
+HTTP requests.  This is the module's primary purpose.
+
+You can manipulate the resources using different HTTP request types
+(e.g. `POST`, `GET`, `DELETE`), HTTP headers, and special query strings
+passed in the URL itself.
+
+
+## Getting information about the resource
+
+
+### Exploring the resource
+
+Using a HTTP `GET` request on a resource's root URL will return information
+about that resource, in addition to the data itself.
+
+The data results are stored in the `data` property of the JSON response, while
+the `self` and `next` objects contain information about the resource.
+
+```javascript
+{
+  "data": [
+    {
+      "self": "https://example.com/api/v1.0/articles/123",
+      "field": "A field value",
+      "field2": "Another field value"
+    },
+    // { ... more results follow ... }
+  ],
+  "count": 100,
+  "self": {
+    "title": "Self",
+    "href": "https://example.com/api/v1.0/articles"
+  },
+  "next": {
+    "title": "Next",
+    "href": "https://example.com/api/v1.0/articles?page=2"
+  }
+}
+```
+
+
+### Returning documentation about the resource
+
+Using an HTTP `OPTIONS` request, you can return documentation about the
+resource.  To do so, make an OPTIONS request to the resource's root URL.
+
+```shell
+curl -X OPTIONS -i https://example.com/api/v1.0/articles
+```
+
+The resource will respond with a JSON object that contains documentation for
+each field defined by the resource.
+
+See the _Documenting your API_ section of the [README file](../README.md)
+for examples of the types of information returned by such a request.
+
+
 ## Returning specific fields
 Using the ``?fields`` query string, you can declare which fields should be
 returned.  Note that you can only return fields already being returned by
@@ -40,122 +98,10 @@ curl https://example.com/api/articles?filter[created][value]=1417591992&filter[c
 ```
 
 
-## Output formats
-The RESTful module outputs all resources by using HAL+JSON encoding by default.
-That means that when you have the following data:
-
-```php
-array(
-  array(
-    'id' => 2,
-    'label' => 'another title',
-    'self' => 'https://example.com/node/2',
-  ),
-  array(
-    'id' => 1,
-    'label' => 'example title',
-    'self' => 'https://example.com/node/1',
-  ),
-);
-```
-
-Then the following output is generated (using the header
-`ContentType:application/hal+json; charset=utf-8`):
-
-```javascript
-{
-  "data": [
-    {
-      "id": 2,
-      "label": "another title",
-      "self": "https:\/\/example.com\/node\/2"
-    },
-    {
-      "id": 1,
-      "label": "example title",
-      "self": "https:\/\/example.com\/node\/1"
-    }
-  ],
-  "count": 2,
-  "_links": []
-}
-```
-
-You can change that to be anything that you need. You have a plugin that will
-allow you to output XML instead of JSON in
-[the example module](./modules/restful_example/plugins/formatter). Take that
-example and create you custom module that contains the formatter plugin the you
-need (maybe you need to output JSON but following a different data structure,
-you may even want to use YAML, ...). All that you will need is to create a
-formatter plugin and tell your restful resource to use that in the restful
-plugin definition:
-
-```php
-$plugin = array(
-  'label' => t('Articles'),
-  'resource' => 'articles',
-  'description' => t('Export the article content type in my cool format.'),
-  ...
-  'formatter' => 'my_formatter', // <-- The name of the formatter plugin.
-);
-```
-
-
-### Changing the default output format
-If you need to change the output format for everything at once then you just
-have to set a special variable with the name of the new output format plugin.
-When you do that all the resources that don't specify a `'formatter'` key in the
-plugin definition will use that output format by default. Ex:
-
-```php
-variable_set('restful_default_output_formatter', 'my_formatter');
-```
-
-
-## Render cache
-The RESTful module is compatible and leverages the popular
-[Entity Cache](https://drupal.org/project/entitycache) module and adds a new
-cache layer on its own for the rendered entity. Two requests made by the same
-user requesting the same fields on the same entity will benefit from the render
-cache layer. This means that no entity will need to be loaded if it was rendered
-in the past under the same conditions.
-
-Developers have absolute control where the cache is stored and the expiration
-for every resource, meaning that very volatile resources can skip cache entirely
-while other resources can have its cache in MemCached or the database. To
-configure this developers just have to specify the following keys in their
-_restful_ plugin definition:
-
-```php
-$plugin = array(
-  ...
-  'render_cache' => array(
-    // Enables the render cache.
-    'render' => TRUE,
-    // Defaults to 'cache_restful' (optional).
-    'bin' => 'cache_bin_name',
-    // Expiration logic. Defaults to CACHE_PERMANENT (optional).
-    'expire' => CACHE_TEMPORARY,
-    // Enable cache invalidation for entity based resources. Defaults to TRUE (optional).
-    'simple_invalidate' => TRUE,
-    // Use a different cache backend for this resource. Defaults to variable_get('cache_default_class', 'DrupalDatabaseCache') (optional).
-    'class' => 'MemCacheDrupal',
-    // Account cache granularity. Instead of caching per user you can choose to cache per role. Default: DRUPAL_CACHE_PER_USER.
-    'granularity' => DRUPAL_CACHE_PER_ROLE,
-  ),
-);
-```
-
-Additionally you can define a cache backend for a given cache bin by setting the
- variable `cache_class_<cache-bin-name>` to the class to be used. This way all
-the resouces caching to that particular bin will use that cache backend instead
-of the default one.
-
-
-## Authentication providers
-Restful comes with ``cookie``, ``base_auth`` (user name and password in the HTTP header)
-authentications providers, as well as a "RESTful token auth" module that has a
-``token`` authentication provider.
+## Working with authentication providers
+Restful comes with ``cookie``, ``base_auth`` (user name and password in the HTTP
+header) authentications providers, as well as a "RESTful token auth" module that
+ has a `token` authentication provider.
 
 Note: if you use cookie-based authentication then you also need to set the
 HTTP ``X-CSRF-Token`` header on all writing requests (POST, PUT and DELETE).
@@ -176,95 +122,3 @@ curl -u "username:password" https://example.com/api/login
 # Call a "protected" with token resource (Articles resource version 1.3 in "Restful example")
 curl https://example.com/api/v1.3/articles/1?access_token=YOUR_TOKEN
 ```
-
-
-## Rate limit
-RESTful provides rate limit functionality out of the box. A rate limit is a way
-to protect your API service from flooding, basically consisting on checking is
-the number of times an event has happened in a given period is greater that the
-maximum allowed.
-
-
-### Rate limit events
-You can define your own rate limit events for your resources and define the
-limit an period for those, for that you only need to create a new _rate\_limit_
-CTools plugin and implement the `isRequestedEvent` method. Every request the
-`isRequestedEvent` will be evaluated and if it returns true that request will
-increase the number of hits -for that particular user- for that event. If the
-number of hits is bigger than the allowed limit an exception will be raised.
-
-Two events are provided out of the box: the request event -that is always true
-for every request- and the global event -that is always true and is not
-contained for a given resource, all resources will increment the hit counter-.
-
-This way, for instance, you could define different limit for read operations
-than for write operations by checking the HTTP method in `isRequestedEvent`.
-
-
-### Configuring your rate limits
-You can configure the declared Rate Limit events in every resource by providing
-a configuration array. The following is taken from the example resource articles
-1.4 (articles\_\_1\_4.inc):
-
-```php
-…
-  'rate_limit' => array(
-    // The 'request' event is the basic event. You can declare your own events.
-    'request' => array(
-      'event' => 'request',
-      // Rate limit is cleared every day.
-      'period' => new \DateInterval('P1D'),
-      'limits' => array(
-        'authenticated user' => 3,
-        'anonymous user' => 2,
-        'administrator' => \RestfulRateLimitManager::UNLIMITED_RATE_LIMIT,
-      ),
-    ),
-  ),
-…
-```
-
-As you can see in the example you can set the rate limit differently depending
-on the role of the visiting user.
-
-Since the global event is not tied to any resource the limit and period is specified by setting the following variables:
-  - `restful_global_rate_limit`: The number of allowed hits. This is global for
-    all roles.
-  - `restful_global_rate_period`: The period string compatible with
-    \DateInterval.
-
-## Error handling
-If an error occurs when operating the REST endpoint via URL, A valid JSON object
- with ``code``, ``message`` and ``description`` would be returned.
-
-The RESTful module adheres to the [Problem Details for HTTP
-APIs](http://tools.ietf.org/html/draft-nottingham-http-problem-06) draft to
-improve DX when dealing with HTTP API errors. Download and enable the [Advanced
-Help](https://drupal.org/project/advanced_help) module for more information
-about the errors.
-
-For example, trying to sort a list by an invalid key
-
-```shell
-curl https://example.com/api/v1/articles?sort=wrong_key
-```
-
-Will result with an HTTP code 400, and the following JSON:
-
-```javascript
-{
-  'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1',
-  'title' => 'The sort wrong_key is not allowed for this path.',
-  'status' => 400,
-  'detail' => 'Bad Request.',
-}
-```
-
-
-## Documenting your API
-It is of most importance to document your API, this is why the RESTful module
-provides a way to comprehensively document your resources and endpoints. This
-documentation can be accessed through the HTTP methods and through extending
-modules. The API will be documented both for humans and for machine consumption,
-allowing client implementations to know about the API without explicit
-programming.

--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -1,0 +1,262 @@
+# Consuming your API
+
+## Hiding fields
+Using the ``?fields`` query string, you can declare which fields should be
+returned.
+
+```shell
+# Handler v1.0
+curl https://example.com/api/v1/articles/2?fields=id
+```
+
+Returns:
+
+```javascript
+{
+  "data": [{
+    "id": "2",
+    "label": "Foo"
+  }]
+}
+```
+
+## Filter
+RESTful allows filtering of a list.
+
+```php
+# Handler v1.0
+curl https://example.com/api/v1/articles?filter[label]=abc
+```
+
+You can even filter results using basic operators. For instance to get all the
+articles after a certain date:
+
+```shell
+# Handler v1.0
+curl https://example.com/api/articles?filter[created][value]=1417591992&filter[created][operator]=">="
+```
+
+## Error handling
+If an error occurs when operating the REST endpoint via URL, A valid JSON object
+ with ``code``, ``message`` and ``description`` would be returned.
+
+The RESTful module adheres to the [Problem Details for HTTP
+APIs](http://tools.ietf.org/html/draft-nottingham-http-problem-06) draft to
+improve DX when dealing with HTTP API errors. Download and enable the [Advanced
+Help](https://drupal.org/project/advanced_help) module for more information
+about the errors.
+
+For example, trying to sort a list by an invalid key
+
+```shell
+curl https://example.com/api/v1/articles?sort=wrong_key
+```
+
+Will result with an HTTP code 400, and the following JSON:
+
+```javascript
+{
+  'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1',
+  'title' => 'The sort wrong_key is not allowed for this path.',
+  'status' => 400,
+  'detail' => 'Bad Request.',
+}
+```
+
+## Authentication providers
+
+Restful comes with ``cookie``, ``base_auth`` (user name and password in the HTTP header)
+authentications providers, as well as a "RESTful token auth" module that has a
+``token`` authentication provider.
+
+Note: if you use cookie-based authentication then you also need to set the
+HTTP ``X-CSRF-Token`` header on all writing requests (POST, PUT and DELETE).
+You can retrieve the token from ``/api/session/token`` with a standard HTTP
+GET request.
+
+See [this](https://github.com/Gizra/angular-restful-auth) AngularJs example that shows a login from a fully decoupled web app
+to a Drupal backend.
+
+
+```bash
+# (Change username and password)
+curl -u "username:password" https://example.com/api/login
+
+# Response has access token.
+{"access_token":"YOUR_TOKEN"}
+
+# Call a "protected" with token resource (Articles resource version 1.3 in "Restful example")
+curl https://example.com/api/v1.3/articles/1?access_token=YOUR_TOKEN
+```
+
+
+## Output formats
+
+The RESTful module outputs all resources by using HAL+JSON encoding by default.
+That means that when you have the following data:
+
+```php
+array(
+  array(
+    'id' => 2,
+    'label' => 'another title',
+    'self' => 'https://example.com/node/2',
+  ),
+  array(
+    'id' => 1,
+    'label' => 'example title',
+    'self' => 'https://example.com/node/1',
+  ),
+);
+```
+
+Then the following output is generated (using the header
+`ContentType:application/hal+json; charset=utf-8`):
+
+```javascript
+{
+  "data": [
+    {
+      "id": 2,
+      "label": "another title",
+      "self": "https:\/\/example.com\/node\/2"
+    },
+    {
+      "id": 1,
+      "label": "example title",
+      "self": "https:\/\/example.com\/node\/1"
+    }
+  ],
+  "count": 2,
+  "_links": []
+}
+```
+
+You can change that to be anything that you need. You have a plugin that will
+allow you to output XML instead of JSON in
+[the example module](./modules/restful_example/plugins/formatter). Take that
+example and create you custom module that contains the formatter plugin the you
+need (maybe you need to output JSON but following a different data structure,
+you may even want to use YAML, ...). All that you will need is to create a
+formatter plugin and tell your restful resource to use that in the restful
+plugin definition:
+
+```php
+$plugin = array(
+  'label' => t('Articles'),
+  'resource' => 'articles',
+  'description' => t('Export the article content type in my cool format.'),
+  ...
+  'formatter' => 'my_formatter', // <-- The name of the formatter plugin.
+);
+```
+
+### Changing the default output format.
+If you need to change the output format for everything at once then you just
+have to set a special variable with the name of the new output format plugin.
+When you do that all the resources that don't specify a `'formatter'` key in the
+plugin definition will use that output format by default. Ex:
+
+```php
+variable_set('restful_default_output_formatter', 'my_formatter');
+```
+
+## Render Cache
+The RESTful module is compatible and leverages the popular
+[Entity Cache](https://drupal.org/project/entitycache) module and adds a new
+cache layer on its own for the rendered entity. Two requests made by the same
+user requesting the same fields on the same entity will benefit from the render
+cache layer. This means that no entity will need to be loaded if it was rendered
+in the past under the same conditions.
+
+Developers have absolute control where the cache is stored and the expiration
+for every resource, meaning that very volatile resources can skip cache entirely
+while other resources can have its cache in MemCached or the database. To
+configure this developers just have to specify the following keys in their
+_restful_ plugin definition:
+
+```php
+$plugin = array(
+  ...
+  'render_cache' => array(
+    // Enables the render cache.
+    'render' => TRUE,
+    // Defaults to 'cache_restful' (optional).
+    'bin' => 'cache_bin_name',
+    // Expiration logic. Defaults to CACHE_PERMANENT (optional).
+    'expire' => CACHE_TEMPORARY,
+    // Enable cache invalidation for entity based resources. Defaults to TRUE (optional).
+    'simple_invalidate' => TRUE,
+    // Use a different cache backend for this resource. Defaults to variable_get('cache_default_class', 'DrupalDatabaseCache') (optional).
+    'class' => 'MemCacheDrupal',
+    // Account cache granularity. Instead of caching per user you can choose to cache per role. Default: DRUPAL_CACHE_PER_USER.
+    'granularity' => DRUPAL_CACHE_PER_ROLE,
+  ),
+);
+```
+
+Additionally you can define a cache backend for a given cache bin by setting the
+ variable `cache_class_<cache-bin-name>` to the class to be used. This way all
+the resouces caching to that particular bin will use that cache backend instead
+of the default one.
+
+## Rate Limit
+RESTful provides rate limit functionality out of the box. A rate limit is a way
+to protect your API service from flooding, basically consisting on checking is
+the number of times an event has happened in a given period is greater that the
+maximum allowed.
+
+### Rate Limit events
+You can define your own rate limit events for your resources and define the
+limit an period for those, for that you only need to create a new _rate\_limit_
+CTools plugin and implement the `isRequestedEvent` method. Every request the
+`isRequestedEvent` will be evaluated and if it returns true that request will
+increase the number of hits -for that particular user- for that event. If the
+number of hits is bigger than the allowed limit an exception will be raised.
+
+Two events are provided out of the box: the request event -that is always true
+for every request- and the global event -that is always true and is not
+contained for a given resource, all resources will increment the hit counter-.
+
+This way, for instance, you could define different limit for read operations
+than for write operations by checking the HTTP method in `isRequestedEvent`.
+
+### Configuring your Rate Limits
+You can configure the declared Rate Limit events in every resource by providing
+a configuration array. The following is taken from the example resource articles
+1.4 (articles\_\_1\_4.inc):
+
+```php
+…
+  'rate_limit' => array(
+    // The 'request' event is the basic event. You can declare your own events.
+    'request' => array(
+      'event' => 'request',
+      // Rate limit is cleared every day.
+      'period' => new \DateInterval('P1D'),
+      'limits' => array(
+        'authenticated user' => 3,
+        'anonymous user' => 2,
+        'administrator' => \RestfulRateLimitManager::UNLIMITED_RATE_LIMIT,
+      ),
+    ),
+  ),
+…
+```
+
+As you can see in the example you can set the rate limit differently depending
+on the role of the visiting user.
+
+Since the global event is not tied to any resource the limit and period is specified by setting the following variables:
+  - `restful_global_rate_limit`: The number of allowed hits. This is global for
+    all roles.
+  - `restful_global_rate_period`: The period string compatible with
+    \DateInterval.
+
+## Documenting your API
+It is of most importance to document your API, this is why the RESTful module
+provides a way to comprehensively document your resources and endpoints. This
+documentation can be accessed through the HTTP methods and through extending
+modules. The API will be documented both for humans and for machine consumption,
+allowing client implementations to know about the API without explicit
+programming.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,78 @@
+# Documenting your API
+
+## Documenting your fields
+When declaring your public field and their mappings you will have the
+opportunity to also provide information about the field itself. This includes
+basic information about the field, information about the data the field holds
+and about how to generate a form element in the client side for this particular
+field. By declaring this information a client can write an implementation that
+reads this information and provide form elements _for free_ via reusable form
+components.
+
+```php
+$public_fields['text_multiple'] = array(
+  'property' => 'text_multiple',
+  'discovery' => array(
+    // Basic information about the field for human consumption.
+    'info' => array(
+      // The name of the field. Defaults to: ''.
+      'name' => t('Text multiple'),
+      // The description of the field. Defaults to: ''.
+      'description' => t('This field holds different text inputs.'),
+      // A custom piece of information we want to add to the documentation.
+      'custom' => t('This is custom documentation'),
+    ),
+    // Information about the data that the field holds. Typically used to help the client to manage the data appropriately.
+    'data' => array(
+      // The type of data. For instance: 'int', 'string', 'boolean', 'object', 'array', ... Defaults to: NULL.
+      'type' => 'string',
+      // The number of elements that this field can contain. Defaults to: 1.
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
+      // Avoid updating/setting this field. Typically used in fields representing the ID for the resource. Defaults to: FALSE.
+      'read_only' => FALSE,
+    ),
+    'form_element' => array(
+      // The type of the input element as in Form API. Defaults to: NULL.
+      'type' => 'textfield',
+      // The default value for the form element. Defaults to: ''.
+      'default_value' => '',
+      // The placeholder text for the form element. Defaults to: ''.
+      'placeholder' => t('This is helpful.'),
+      // The size of the form element (if applies). Defaults to: NULL.
+      'size' => 255,
+      // The allowed values for form elements with a limited set of options. Defaults to: NULL.
+      'allowed_values' => NULL,
+    ),
+  ),
+);
+```
+
+Note the `'custom'` key; you can add your own information to the `'discovery'`
+property and it will be exposed as well.
+
+Here is a snippet from the JSON response to an HTTP OPTIONS request made to the
+above resource:
+
+```json
+"text_multiple": {
+  "info": {
+    "label": "",
+    "description": "This field holds different text inputs.",
+    "name": "Text multiple",
+    "custom": "This is custom documentation"
+  },
+  "data": {
+    "type": "string",
+    "read_only": false,
+    "cardinality": -1,
+    "required": false
+  },
+  "form_element": {
+    "type": "textfield",
+    "default_value": "",
+    "placeholder": "This is helpful.",
+    "size": 255,
+    "allowed_values": null
+  }
+},
+```

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,13 +1,13 @@
 # Documenting your API
 
 ## Documenting your fields
-When declaring your public field and their mappings you will have the
-opportunity to also provide information about the field itself. This includes
-basic information about the field, information about the data the field holds
-and about how to generate a form element in the client side for this particular
-field. By declaring this information a client can write an implementation that
-reads this information and provide form elements _for free_ via reusable form
-components.
+When declaring a public field and its mappings, you can also provide information
+about the field itself. This includes basic information about the field,
+information about the data the field holds, and information about the form
+element to generate on the client side for this field.
+
+By declaring this information, you make it possible for clients to provide
+form elements for your API using reusable form components.
 
 ```php
 $public_fields['text_multiple'] = array(

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -70,7 +70,8 @@ array(
 );
 ```
 
-### View an entity using a view mode
+
+## View an entity using a view mode
 You can leverage Drupal core's view modes to render an entity and expose it as a
 resource with RESTful. All you need is to set up a view mode that renders the
 output you want to expose and tell RESTful to use it. This simplifies the
@@ -87,7 +88,8 @@ method.
 To use this method just set it in the plugin definition file, as demonstrated in
 [this example](https://github.com/Gizra/restful/blob/7.x-1.x/modules/restful_example/plugins/restful/node/articles/1.7/articles__1_7.inc#L3-L23).
 
-### Filtering fields
+
+## Filtering fields
 Using the ``?fields`` query string, you can declare which fields should be
 returned.
 
@@ -105,29 +107,21 @@ array(
 );
 ```
 
-### Image derivatives
-Many client side technologies have lots of problems resizing images to serve
-them optimized and thus avoiding browser scaling. For that reason the RESTful
-module will let you specify an array of image style names to get an array of
-image derivatives for your image fields. Just add an `'image_styles'` key in
-your public field info (as shown above) with the list of styles to use and be
-done with it.
 
-### Disabling sort functionality.
-
-The sort parameter can be disabled in your resource plugin definition:
+## Disable filter capability
+The filter parameter can be disabled in your resource plugin definition:
 
 ```php
 $plugin = array(
   ...
   'url_params' => array(
-    'sort' => FALSE,
+    'filter' => FALSE,
   ),
 );
 ```
 
-### Defining a default sort.
 
+## Defining a default sort
 You can also define default sort fields in your plugin, by overriding
 `defaultSortInfo()` in your class definition.
 
@@ -148,26 +142,24 @@ class MyPlugin extends \RestfulEntityBaseTaxonomyTerm {
 }
 ```
 
-# Disable filter functionaliy
 
-The filter parameter can be disabled in your resource plugin definition:
+## Disabling sort capability
+The sort parameter can be disabled in your resource plugin definition:
 
 ```php
 $plugin = array(
   ...
   'url_params' => array(
-    'filter' => FALSE,
+    'sort' => FALSE,
   ),
 );
-```
 
 
-### Setting the default range
-
+## Setting the default range
 The range can be specified by setting $this->range in your plugin definition.
 
-### Disabling the range parameter
 
+### Disabling the range parameter
 The range parameter can be disabled in your resource plugin definition:
 
 ```php
@@ -180,12 +172,19 @@ $plugin = array(
 ```
 
 
-## Reference fields and properties
+## Image derivatives
+Many client side technologies have lots of problems resizing images to serve
+them optimized and thus avoiding browser scaling. For that reason the RESTful
+module will let you specify an array of image style names to get an array of
+image derivatives for your image fields. Just add an `'image_styles'` key in
+your public field info (as shown above) with the list of styles to use and be
+done with it.
 
+
+## Reference fields and properties
 It is considered a best practice to map a reference field (i.e. entity
 reference or taxonomy term reference) or a reference property (e.g. the ``uid``
 property on the node entity) to the resource it belongs to.
-
 
 ```php
 public function publicFieldsInfo() {
@@ -206,6 +205,7 @@ public function publicFieldsInfo() {
   return $public_fields;
 }
 ```
+
 
 ## Documenting your resources.
 A resource can be documented in the plugin definition using the `'label'`
@@ -237,7 +237,7 @@ curl -u user:password https://example.org/api
 ```
 
 
-## Documenting your fields.
+## Documenting your fields
 When declaring your public field and their mappings you will have the
 opportunity to also provide information about the field itself. This includes
 basic information about the field, information about the data the field holds
@@ -290,7 +290,8 @@ to it. You will get the field information in the body, the information about the
 available output formats and the permitted HTTP methods will be contained in the
 corresponding headers.
 
-### Auto-documented fields.
+
+### Auto-documented fields
 If your resource is an entity then some of this information will be populated
 for you out of the box, without you needing to do anything else. This
 information will be derived from the Entity API and Field API. The following

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -360,32 +360,6 @@ specified by setting the following variables:
   - `restful_global_rate_period`: The period string compatible with
     \DateInterval.
 
-## Error handling
-If an error occurs when operating the REST endpoint via URL, A valid JSON object
- with ``code``, ``message`` and ``description`` would be returned.
-
-The RESTful module adheres to the [Problem Details for HTTP
-APIs](http://tools.ietf.org/html/draft-nottingham-http-problem-06) draft to
-improve DX when dealing with HTTP API errors. Download and enable the [Advanced
-Help](https://drupal.org/project/advanced_help) module for more information
-about the errors.
-
-For example, trying to sort a list by an invalid key
-
-```shell
-curl https://example.com/api/v1/articles?sort=wrong_key
-```
-
-Will result with an HTTP code 400, and the following JSON:
-
-```javascript
-{
-  'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1',
-  'title' => 'The sort wrong_key is not allowed for this path.',
-  'status' => 400,
-  'detail' => 'Bad Request.',
-}
-```
 
 
 ## Documenting your resources.

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -1,0 +1,304 @@
+# Defining a RESTful Plugin
+
+## View an entity
+By default the RESTful module will expose the ID, label and URL of the entity.
+You probably want to expose more than that. To do so you will need to implement
+the `publicFieldsInfo` method defining the names in the output array and how
+those are mapped to the queried entity. For instance the following example will
+retrieve the basic fields plus the body, tags and images from an article node.
+The RESTful module will know to use the `MyRestfulPlugin` class because your
+plugin definition will say so.
+
+```php
+class MyArticlesResource extends \RestfulEntityBase {
+
+  /**
+   * Overrides \RestfulEntityBase::publicFieldsInfo().
+   */
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
+
+    $public_fields['body'] = array(
+      'property' => 'body',
+      'sub_property' => 'value',
+    );
+
+    $public_fields['tags'] = array(
+      'property' => 'field_tags',
+      'resource' => array(
+        'tags' => 'tags',
+      ),
+    );
+
+    $public_fields['image'] = array(
+      'property' => 'field_image',
+      'process_callbacks' => array(
+        array($this, 'imageProcess'),
+      ),
+      // This will add 3 image variants in the output.
+      'image_styles' => array('thumbnail', 'medium', 'large'),
+    );
+
+    return $public_fields;
+  }
+
+}
+```
+
+```php
+// Handler v1.0
+$handler = restful_get_restful_handler('articles');
+// GET method.
+$result = $handler->get(1);
+
+// Output:
+array(
+  'id' => 1,
+  'label' => 'example title',
+  'self' => 'https://example.com/node/1',
+);
+
+// Handler v1.1 extends v1.0, and removes the "self" property from the
+// exposed properties.
+$handler = restful_get_restful_handler('articles', 1, 1);
+$result = $handler->get(1);
+
+// Output:
+array(
+  'id' => 1,
+  'label' => 'example title',
+);
+```
+
+### View an entity using a view mode
+You can leverage Drupal core's view modes to render an entity and expose it as a
+resource with RESTful. All you need is to set up a view mode that renders the
+output you want to expose and tell RESTful to use it. This simplifies the
+workflow of exposing your resource a lot, since you don't even need to create a
+resource class, but it also offers you less features that are configured in the
+`publicFieldsInfo` method.
+
+Use this method when you don't need any of the extra features that are added via
+`publicFieldsInfo` (like the discovery metadata, image styles for images,
+process callbacks, custom access callbacks for properties, etc.). This is also a
+good way to stub a resource really quick and then move to the more fine grained
+method.
+
+To use this method just set it in the plugin definition file, as demonstrated in
+[this example](https://github.com/Gizra/restful/blob/7.x-1.x/modules/restful_example/plugins/restful/node/articles/1.7/articles__1_7.inc#L3-L23).
+
+### Filtering fields
+Using the ``?fields`` query string, you can declare which fields should be
+returned.
+
+```php
+$handler = restful_get_restful_handler('articles');
+
+// Define the fields.
+$request['fields'] = 'id,label';
+$result = $handler->get(2, $request);
+
+// Output:
+array(
+  'id' => 2,
+  'label' => 'another title',
+);
+```
+
+### Image derivatives
+Many client side technologies have lots of problems resizing images to serve
+them optimized and thus avoiding browser scaling. For that reason the RESTful
+module will let you specify an array of image style names to get an array of
+image derivatives for your image fields. Just add an `'image_styles'` key in
+your public field info (as shown above) with the list of styles to use and be
+done with it.
+
+### Disabling sort functionality.
+
+The sort parameter can be disabled in your resource plugin definition:
+
+```php
+$plugin = array(
+  ...
+  'url_params' => array(
+    'sort' => FALSE,
+  ),
+);
+```
+
+### Defining a default sort.
+
+You can also define default sort fields in your plugin, by overriding
+`defaultSortInfo()` in your class definition.
+
+This method should return an associative array, with each element having a key
+that matches a field from `publicFieldsInfo()`, and a value of either 'ASC' or 'DESC'.
+
+This default sort will be ignored if the request URL contains a sort query.
+
+```php
+class MyPlugin extends \RestfulEntityBaseTaxonomyTerm {
+  /**
+   * Overrides \RestfulEntityBase::defaultSortInfo().
+   */
+  public function defaultSortInfo() {
+    // Sort by 'id' in descending order.
+    return array('id' => 'DESC');
+  }
+}
+```
+
+# Disable filter functionaliy
+
+The filter parameter can be disabled in your resource plugin definition:
+
+```php
+$plugin = array(
+  ...
+  'url_params' => array(
+    'filter' => FALSE,
+  ),
+);
+```
+
+
+### Setting the default range
+
+The range can be specified by setting $this->range in your plugin definition.
+
+### Disabling the range parameter
+
+The range parameter can be disabled in your resource plugin definition:
+
+```php
+$plugin = array(
+  ...
+  'url_params' => array(
+    'range' => FALSE,
+  ),
+);
+```
+
+
+## Reference fields and properties
+
+It is considered a best practice to map a reference field (i.e. entity
+reference or taxonomy term reference) or a reference property (e.g. the ``uid``
+property on the node entity) to the resource it belongs to.
+
+
+```php
+public function publicFieldsInfo() {
+  $public_fields = parent::publicFieldsInfo();
+  // ...
+  $public_fields['user'] = array(
+    'property' => 'author',
+    'resource' => array(
+      // The bundle of the entity.
+      'user' => array(
+      // The name of the resource to map to.
+      'name' => 'users',
+      // Determines if the entire resource should appear, or only the ID.
+      'full_view' => TRUE,
+    ),
+  );
+  // ...
+  return $public_fields;
+}
+```
+
+## Documenting your resources.
+A resource can be documented in the plugin definition using the `'label'`
+and `'description'` keys:
+
+```php
+$plugin = array(
+  // This is the human readable name of the resource.
+  'label' => t('User'),
+  // Use de description to provide more extended information about the resource.
+  'description' => t('Export the "User" entity.'),
+  'resource' => 'users',
+  'class' => 'RestfulEntityBaseUser',
+  ...
+);
+```
+
+This should not include any information about the endpoints or the allowed HTTP
+methods on them, since those will be accessed directly on the aforementioned
+endpoint. This information aims to describe what the accessed resource
+represents.
+
+To access this information just use the `discovery` resource at the api
+homepage:
+
+```shell
+# List resources
+curl -u user:password https://example.org/api
+```
+
+
+## Documenting your fields.
+When declaring your public field and their mappings you will have the
+opportunity to also provide information about the field itself. This includes
+basic information about the field, information about the data the field holds
+and about how to generate a form element in the client side for this particular
+field. By declaring this information a client can write an implementation that
+reads this information and provide form elements _for free_ via reusable form
+components.
+
+```php
+$public_fields['text_multiple'] = array(
+  'property' => 'text_multiple',
+  'discovery' => array(
+    // Basic information about the field for human consumption.
+    'info' => array(
+      // The name of the field. Defaults to: ''.
+      'name' => t('Text multiple'),
+      // The description of the field. Defaults to: ''.
+      'description' => t('This field holds different text inputs.'),
+    ),
+    // Information about the data that the field holds. Typically used to help the client to manage the data appropriately.
+    'data' => array(
+      // The type of data. For instance: 'int', 'string', 'boolean', 'object', 'array', ... Defaults to: NULL.
+      'type' => 'string',
+      // The number of elements that this field can contain. Defaults to: 1.
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
+      // Avoid updating/setting this field. Typically used in fields representing the ID for the resource. Defaults to: FALSE.
+      'read_only' => FALSE,
+    ),
+    'form_element' => array(
+      // The type of the input element as in Form API. Defaults to: NULL.
+      'type' => 'textfield',
+      // The default value for the form element. Defaults to: ''.
+      'default_value' => '',
+      // The placeholder text for the form element. Defaults to: ''.
+      'placeholder' => t('This is helpful.'),
+      // The size of the form element (if applies). Defaults to: NULL.
+      'size' => 255,
+      // The allowed values for form elements with a limited set of options. Defaults to: NULL.
+      'allowed_values' => NULL,
+    ),
+  ),
+);
+```
+
+This is the default set of information provided by RESTful. You can add your own
+information to the `'discovery'` property and it will be exposed as well.
+
+To access the information about an specific endpoint just make an `OPTIONS` call
+to it. You will get the field information in the body, the information about the
+available output formats and the permitted HTTP methods will be contained in the
+corresponding headers.
+
+### Auto-documented fields.
+If your resource is an entity then some of this information will be populated
+for you out of the box, without you needing to do anything else. This
+information will be derived from the Entity API and Field API. The following
+will be populated automatically:
+
+  - `$discovery_info['info']['label']`.
+  - `$discovery_info['info']['description']`.
+  - `$discovery_info['data']['type']`.
+  - `$discovery_info['data']['required']`.
+  - `$discovery_info['form_element']['default_value']`.
+  - `$discovery_info['form_element']['allowed_values']` for text lists.


### PR DESCRIPTION
#299

Here's my first stab at this.

The idea is to trim the main README down to "everything you need to know in 5 minutes", and then break out the rest into topic documents.
