### PR TITLE
Allow loading entities by any field.

### DIFF
--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -97,6 +97,35 @@ articles after a certain date:
 curl https://example.com/api/articles?filter[created][value]=1417591992&filter[created][operator]=">="
 ```
 
+## Loading by an alternate ID.
+Some times you need to load an entity by an alternate ID that is not the regular
+entity ID. All that you need to do is provide the alternate ID as the regular
+resource ID and inform that the passed in ID is not the regular entity ID but a
+different field. To do so use the `loadByFieldName` query parameter.
+
+```
+curl -H 'X-API-version: v1.5' https://www.example.org/articles/1234-abcd-5678-efg0?loadByFieldName=uuid
+```
+
+That will load the article node and output it as usual. Since every REST
+resource object has a canonical URL, but we are using a different one, a _Link_
+header will be added to the response with the canonical URL so the consumer can
+use it in future requests.
+
+```
+HTTP/1.1 200 OK
+Date: Mon, 22 Dec 2014 08:08:53 GMT
+Content-Type: application/hal+json; charset=utf-8
+...
+Link: https://www.example.org/articles/12; rel="canonical"
+
+{
+  ...
+}
+```
+
+The only requirement to use this feature is that the value for your
+`loadByFieldName` field needs to be one of your exposed fields.
 
 ## Working with authentication providers
 Restful comes with ``cookie``, ``base_auth`` (user name and password in the HTTP

--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -99,16 +99,17 @@ curl https://example.com/api/articles?filter[created][value]=1417591992&filter[c
 
 ## Loading by an alternate ID.
 Some times you need to load an entity by an alternate ID that is not the regular
-entity ID. All that you need to do is provide the alternate ID as the regular
-resource ID and inform that the passed in ID is not the regular entity ID but a
-different field. To do so use the `loadByFieldName` query parameter.
+entity ID, for example a unique ID title. All that you need to do is provide the
+alternate ID as the regular resource ID and inform that the passed in ID is not
+the regular entity ID but a different field. To do so use the `loadByFieldName`
+query parameter.
 
 ```
 curl -H 'X-API-version: v1.5' https://www.example.org/articles/1234-abcd-5678-efg0?loadByFieldName=uuid
 ```
 
 That will load the article node and output it as usual. Since every REST
-resource object has a canonical URL, but we are using a different one, a _Link_
+resource object has a canonical URL (and we are using a different one) a _Link_
 header will be added to the response with the canonical URL so the consumer can
 use it in future requests.
 
@@ -125,7 +126,9 @@ Link: https://www.example.org/articles/12; rel="canonical"
 ```
 
 The only requirement to use this feature is that the value for your
-`loadByFieldName` field needs to be one of your exposed fields.
+`loadByFieldName` field needs to be one of your exposed fields. It is also up to
+you to make sure that that field is unique. Note that in case that more tha one
+entity matches the provided ID the first record will be loaded.
 
 ## Working with authentication providers
 Restful comes with ``cookie``, ``base_auth`` (user name and password in the HTTP

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -106,6 +106,7 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
       if (in_array($param, array(
         '__application',
         'filter',
+        'loadByFieldName',
         'page',
         'q',
         'range',
@@ -314,6 +315,21 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
    */
   public function getHttpHeaders() {
     return $this->httpHeaders;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addHttpHeaders($key, $value) {
+    $headers = $this->getHttpHeaders();
+    // Add a value to the (potentially) existing header.
+    $values = array();
+    if (!empty($headers[$key])) {
+      $values[] = $headers[$key];
+    }
+    $values[] = $value;
+    $header = implode(', ', $values);
+    $this->setHttpHeaders($key, $header);
   }
 
   /**
@@ -1383,13 +1399,15 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
    *   The path for the resource
    * @param array $options
    *   Array of options as in url().
+   * @param boolean $version_string
+   *   TRUE to add the version string to the URL. FALSE otherwise.
    *
    * @return string
    *   The fully qualified URL.
    *
    * @see url().
    */
-  public function versionedUrl($path = '', $options = array()) {
+  public function versionedUrl($path = '', $options = array(), $version_string = TRUE) {
     // Make the URL absolute by default.
     $options += array('absolute' => TRUE);
     $plugin = $this->getPlugin();
@@ -1399,7 +1417,11 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
     }
 
     $base_path = variable_get('restful_hook_menu_base_path', 'api');
-    $url = $base_path . '/v' . $plugin['major_version'] . '.' . $plugin['minor_version'] . '/' . $plugin['resource'] . '/' . $path;
+    $url = $base_path;
+    if ($version_string) {
+      $url .= '/v' . $plugin['major_version'] . '.' . $plugin['minor_version'];
+    }
+    $url .= '/' . $plugin['resource'] . '/' . $path;
     return url(rtrim($url, '/'), $options);
   }
 

--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -273,28 +273,28 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
   /**
    * View an entity.
    *
-   * @param int $entity_id
-   *   The entity ID.
+   * @param $id
+   *   The ID to load the entity.
    *
    * @return array
    *   Array with the public fields populated.
    *
    * @throws Exception
    */
-  abstract public function viewEntity($entity_id);
+  abstract public function viewEntity($id);
 
   /**
    * Get a list of entities based on a list of IDs.
    *
-   * @param string $entity_ids_string
-   *   Coma separated list of entities.
+   * @param string $ids_string
+   *   Coma separated list of ids.
    *
    * @return array
    *   Array of entities, as passed to RestfulEntityBase::viewEntity().
    *
    * @throws RestfulBadRequestException
    */
-  abstract public function viewEntities($entity_ids_string);
+  abstract public function viewEntities($ids_string);
 
   /**
    * Create a new entity.
@@ -310,8 +310,8 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
   /**
    * Update an entity.
    *
-   * @param $entity_id
-   *   The entity ID.
+   * @param $id
+   *   The ID to load the entity.
    * @param bool $null_missing_fields
    *   Determine if properties that are missing form the request array should
    *   be treated as NULL, or should be skipped. Defaults to FALSE, which will
@@ -321,16 +321,16 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
    *   Array with the output of the new entity, passed to
    *   RestfulEntityInterface::viewEntity().
    */
-  abstract protected function updateEntity($entity_id, $null_missing_fields = FALSE);
+  abstract protected function updateEntity($id, $null_missing_fields = FALSE);
 
   /**
    * Delete an entity using DELETE.
    *
    * No result is returned, just the HTTP header is set to 204.
    *
-   * @param $entity_id
-   *   The entity ID.
+   * @param $id
+   *   The ID to load the entity.
    */
-  abstract public function deleteEntity($entity_id);
+  abstract public function deleteEntity($id);
 
 }

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -86,7 +86,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
         // POST
         \RestfulInterface::POST => 'createEntity',
       ),
-      '^(\d+,)*\d+$' => array(
+      '^.*$' => array(
         \RestfulInterface::GET => 'viewEntities',
         \RestfulInterface::HEAD => 'viewEntities',
         \RestfulInterface::PUT => 'putEntity',
@@ -271,7 +271,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    * {@inheritdoc}
    */
   public function viewEntity($id) {
-    $entity_id = $this->entityID($id);
+    $entity_id = $this->entityId($id);
     $request = $this->getRequest();
 
     $cached_data = $this->getRenderedCache(array(
@@ -566,7 +566,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    * {@inheritdoc}
    */
   protected function updateEntity($id, $null_missing_fields = FALSE) {
-    $entity_id = $this->entityID($id);
+    $entity_id = $this->entityId($id);
     $this->isValidEntity('update', $entity_id);
 
     $wrapper = entity_metadata_wrapper($this->entityType, $entity_id);
@@ -1484,7 +1484,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    * @return int
    *   The entity ID.
    */
-  protected function entityID($id) {
+  protected function entityId($id) {
     $request = $this->getRequest();
     if (empty($request['loadByFieldName'])) {
       // The regular entity ID was provided.
@@ -1510,7 +1510,11 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     // Execute the query and gather the results.
     $results = $query->execute();
     if (empty($results[$this->getEntityType()])) {
-      return NULL;
+      throw new RestfulUnprocessableEntityException(format_string('The entity ID @id for @resource does not exist loaded by @name.', array(
+        '@id' => $id,
+        '@resource' => $this->getPluginKey('label'),
+        '@name' => $public_property_name,
+      )));
     }
 
     // There is nothing that guarantees that there is only one result, since

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -145,12 +145,12 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
   /**
    * {@inheritdoc}
    */
-  public function viewEntities($entity_ids_string) {
-    $entity_ids = array_unique(array_filter(explode(',', $entity_ids_string)));
+  public function viewEntities($ids_string) {
+    $ids = array_unique(array_filter(explode(',', $ids_string)));
     $output = array();
 
-    foreach ($entity_ids as $entity_id) {
-      $output[] = $this->viewEntity($entity_id);
+    foreach ($ids as $id) {
+      $output[] = $this->viewEntity($id);
     }
     return $output;
   }
@@ -270,8 +270,8 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
   /**
    * {@inheritdoc}
    */
-  public function viewEntity($entity_id) {
-    $entity_id = $this->entityID($entity_id);
+  public function viewEntity($id) {
+    $entity_id = $this->entityID($id);
     $request = $this->getRequest();
 
     $cached_data = $this->getRenderedCache(array(
@@ -565,8 +565,8 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
   /**
    * {@inheritdoc}
    */
-  protected function updateEntity($entity_id, $null_missing_fields = FALSE) {
-    $entity_id = $this->entityID($entity_id);
+  protected function updateEntity($id, $null_missing_fields = FALSE) {
+    $entity_id = $this->entityID($id);
     $this->isValidEntity('update', $entity_id);
 
     $wrapper = entity_metadata_wrapper($this->entityType, $entity_id);

--- a/plugins/restful/RestfulInterface.php
+++ b/plugins/restful/RestfulInterface.php
@@ -113,6 +113,16 @@ interface RestfulInterface {
   public function setHttpHeaders($key, $value);
 
   /**
+   * Add the a value to a multi-value HTTP header.
+   *
+   * @param string $key
+   *   The HTTP header key.
+   * @param string $value
+   *   The HTTP header value.
+   */
+  public function addHttpHeaders($key, $value);
+
+  /**
    * Determine if user can access the handler.
    *
    * @return bool

--- a/tests/RestfulViewEntityTestCase.test
+++ b/tests/RestfulViewEntityTestCase.test
@@ -158,6 +158,21 @@ class RestfulViewEntityTestCase extends RestfulCurlBaseTestCase {
     $this->assertEqual($result, $expected_result, 'Entity view has correct result for "main" resource v1.1 with empty entity reference.');
 
 
+    // Load an entity by an alternate field.
+    $entity4 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
+    $wrapper = entity_metadata_wrapper('entity_test', $entity4);
+    $text = $this->randomName();
+    $wrapper->text_single->set($text);
+    $wrapper->save();
+
+    $request = array('loadByFieldName' => 'text_single');
+    $result = $handler->get($text, $request);
+    $this->assertNotNull($result[0]);
+
+    // Make sure canonical header is added.
+    $headers = $handler->getHttpHeaders();
+    $this->assertEqual($headers['Link'], $handler->versionedUrl($wrapper->getIdentifier(), array(), FALSE) . '; rel="canonical"');
+
     // v1.2 - "callback" and "process callback".
     $handler = restful_get_restful_handler('main', 1, 2);
     $base_expected_result['self'] = $handler->versionedUrl($id);

--- a/tests/modules/restful_test/plugins/restful/node/test_articles/1.3/RestfulTestArticlesResource__1_3.class.php
+++ b/tests/modules/restful_test/plugins/restful/node/test_articles/1.3/RestfulTestArticlesResource__1_3.class.php
@@ -12,11 +12,11 @@ class RestfulTestArticlesResource__1_3 extends RestfulEntityBaseNode {
    */
   public static function controllersInfo() {
     $info = parent::controllersInfo();
-    $info['^(\d+,)*\d+$'][\RestfulInterface::GET] = array(
+    $info['^.*$'][\RestfulInterface::GET] = array(
       'callback' => 'viewEntities',
       'access callback' => 'accessViewEntityFalse',
     );
-    $info['^(\d+,)*\d+$'][\RestfulInterface::HEAD] = array(
+    $info['^.*$'][\RestfulInterface::HEAD] = array(
       'callback' => 'viewEntities',
       'access callback' => 'accessViewEntityTrue',
     );


### PR DESCRIPTION
I've found need this several times already. I need to be able to load an entity by a unique field or property attached to that particular entity.

This is the URL schema I'm looking for:

```
https://www.example.org/[resource-name]/[non-standard-id-value]?loadById=[non-standard-id-name]
```

At the same time we need to communicate to the API consumer that the canonical resource for what RESTful is returning is different. We should do that with a `Link` header and a `rel="canonical"` in the response. That is one of the REST principles that is really useful to normalize caches –among other things–.
### Real scenario

There's a _Segment_ content type that has a unique field. We want to be able to load by that ID.

```
https://www.example.org/segments/asdf-asdf-asdf-asdf?loadById=unique
```

Returns:

```
HTTP/1.1 200 OK
Date: Mon, 22 Dec 2014 08:08:53 GMT
Expires: -1
Cache-Control: private, max-age=0
Content-Type: text/html; charset=ISO-8859-1
X-XSS-Protection: 1; mode=block
X-Frame-Options: SAMEORIGIN
Alternate-Protocol: 80:quic,p=0.02
Transfer-Encoding: chunked
Link: https://www.example.org/segments/12; rel="canonical" <----

[RESPONSE BODY]
```
