### PR TITLE
Add support for multiple filters on the same field.

### DIFF
--- a/docs/api_drupal.md
+++ b/docs/api_drupal.md
@@ -51,12 +51,41 @@ array(
 
 
 ### Filter
-Use the `'filter'` key to filter the list.
+Use the `'filter'` key to filter the list. You can provide as many filters as
+you need.
 
 ```php
 $handler = restful_get_restful_handler('articles');
 // Single value property.
 $request['filter'] = array('label' => 'abc');
+$result = $handler->get('', $request);
+```
+
+Additionally you can provide multiple filters for the same field. That is
+specially useful when filtering on multiple value fields. The following example
+will get all the articles with the integer multiple field that contains all 1, 3
+and 5.
+
+```php
+$handler = restful_get_restful_handler('articles');
+// Single value property.
+$request['filter'] = array('integer_multiple' => array(
+  'values' => array(1, 3, 5),
+));
+$result = $handler->get('', $request);
+```
+
+You can do more advanced filtering by providing values and operators. The
+following example will get all the articles with an integer value less than 5
+and another equal to 10.
+
+```php
+$handler = restful_get_restful_handler('articles');
+// Single value property.
+$request['filter'] = array('integer_multiple' => array(
+  'values' => array(5, 10),
+  'operator' => array('>', '='),
+));
 $result = $handler->get('', $request);
 ```
 

--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -97,6 +97,23 @@ articles after a certain date:
 curl https://example.com/api/articles?filter[created][value]=1417591992&filter[created][operator]=">="
 ```
 
+Additionally you can provide multiple filters for the same field. That is
+specially useful when filtering on multiple value fields. The following example
+will get all the articles with the integer multiple field that contains all 1, 3
+and 5.
+
+```
+curl https://example.com/api/articles?filter[integer_multiple][value][0]=1&filter[integer_multiple][value][1]=3&filter[integer_multiple][value][2]=5
+```
+
+You can do more advanced filtering by providing values and operators. The
+following example will get all the articles with an integer value less than 5
+and another equal to 10.
+
+```
+curl https://example.com/api/articles?filter[integer_multiple][value][0]=5&filter[integer_multiple][value][1]=10&filter[integer_multiple][operator][0]=">"&filter[integer_multiple][operator][0]="="
+```
+
 ## Loading by an alternate ID.
 Some times you need to load an entity by an alternate ID that is not the regular
 entity ID, for example a unique ID title. All that you need to do is provide the

--- a/plugins/restful/RestfulDataProviderDbQuery.php
+++ b/plugins/restful/RestfulDataProviderDbQuery.php
@@ -161,7 +161,15 @@ abstract class RestfulDataProviderDbQuery extends \RestfulBase implements \Restf
   protected function queryForListFilter(\SelectQuery $query) {
     $public_fields = $this->getPublicFields();
     foreach ($this->parseRequestForListFilter() as $filter) {
-      $query->condition($public_fields[$filter['public_field']]['property'], $filter['value'], $filter['operator']);
+      if (in_array(strtoupper($filter['operator'][0]), array('IN', 'BETWEEN'))) {
+        $query->condition($public_fields[$filter['public_field']]['property'], $filter['value'], $filter['operator'][0]);
+        continue;
+      }
+      $condition = db_condition($filter['conjunction']);
+      for ($index = 0; $index < count($filter['value']); $index++) {
+        $condition->condition($public_fields[$filter['public_field']]['property'], $filter['value'][$index], $filter['operator'][$index]);
+      }
+      $query->condition($condition);
     }
   }
 

--- a/tests/RestfulDbQueryTestCase.test
+++ b/tests/RestfulDbQueryTestCase.test
@@ -103,6 +103,38 @@ class RestfulDbQueryTestCase extends DrupalWebTestCase {
     // Testing list.
     $result = $handler->get();
     $this->assertEqual($result, array($mock_data4), 'All the content listed successfully.');
+
+    // Testing filters.
+    $mock_data5 = array(
+      'str_field' => $this->randomName(),
+      'int_field' => 101,
+    );
+    $mock_data5['serialized_field'] = serialize($mock_data5);
+    db_insert($this->tableName)
+      ->fields($mock_data5)
+      ->execute();
+    $mock_data6 = array(
+      'str_field' => $this->randomName(),
+      'int_field' => 102,
+    );
+    $mock_data6['serialized_field'] = serialize($mock_data6);
+    db_insert($this->tableName)
+      ->fields($mock_data6)
+      ->execute();
+
+    $request = array('filter' => array('integer' => array(
+      'value' => array(101, 102),
+      'conjunction' => 'OR',
+    )));
+    $result = $handler->get('', $request);
+    $this->assertEqual(count($result), 2);
+    $request = array('filter' => array('integer' => array(
+      'value' => array(101, 102),
+      'operator' => array('=', '>='),
+      'conjunction' => 'OR',
+    )));
+    $result = $handler->get('', $request);
+    $this->assertEqual(count($result), 2);
   }
 
   /**

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -359,6 +359,27 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
     $result = $this->httpRequest('api/v1.0/articles/1', \RestfulInterface::GET, $query);
     $this->assertEqual($result['code'], '200', 'Invalid filter key was ignored on non-list query.');
 
+    // Test multiple filters on the same field.
+    $request = array('filter' => array('integer_single' => array(
+      'value' => array(1, 4),
+      'operator' => array('>', '<>'),
+    )));
+    $result = $handler->get('', $request);
+    $this->assertEqual($nodes['another abc'], $result[0]['id']);
+
+    $request = array('filter' => array('integer_single' => array(
+      'value' => array(1, 5),
+      'operator' => array('>', '<>'),
+    )));
+    $result = $handler->get('', $request);
+    $this->assertEqual($result, array());
+
+    $request = array('filter' => array('integer_multiple' => array(
+      'value' => array(3, 4),
+    )));
+    $result = $handler->get('', $request);
+    $this->assertEqual($nodes['another abc'], $result[0]['id']);
+
     // Test valid filter with filter params disabled.
     $handler->setPluginKey('url_params', array(
       'filter' => FALSE,


### PR DESCRIPTION
Allow things like getting all the articles created between 2 dates.

```
curl https://www.example.org/api/articles?filter[created][value][0]=12345&filter[created][operator][0]=">="&filter[created][value][1]=67890&filter[created][operator][1]="<="
```

Maybe the following is clearer.

``` php
$request['filter'] = array(
  'created' => array(
    'value' => array(12345, 67890),
    'operator' => array('>=', '<='),
    'conjuction' => 'AND',
  ),
);
```
