### PR TITLE
Fix missing entities returning HTTP 500 instead of a 4XX.

### DIFF
--- a/exceptions/RestfulUnprocessableEntityException.php
+++ b/exceptions/RestfulUnprocessableEntityException.php
@@ -5,7 +5,7 @@
  * Contains RestfulUnprocessableEntityException
  */
 
-class RestfulUnprocessableEntityException extends Exception {
+class RestfulUnprocessableEntityException extends RestfulException {
 
   /**
    * Defines the HTTP error code.

--- a/tests/RestfulExceptionHandleTestCase.test
+++ b/tests/RestfulExceptionHandleTestCase.test
@@ -5,7 +5,7 @@
  * Contains RestfulExceptionHandleTestCase
  */
 
-class RestfulExceptionHandleTestCase extends DrupalWebTestCase {
+class RestfulExceptionHandleTestCase extends RestfulCurlBaseTestCase {
 
   public static function getInfo() {
     return array(
@@ -36,6 +36,18 @@ class RestfulExceptionHandleTestCase extends DrupalWebTestCase {
     );
     $this->assertText(drupal_json_encode($expected_result), 'Exception was converted to JSON.');
     $this->assertResponse('400', 'Correct HTTP code.');
+  }
+
+  /**
+   * Test when an entity is not found that a 4XX is returned instead of 500.
+   */
+  function testEntityNotFoundDelivery() {
+    $url = 'api/v1.0/articles/1';
+    $result = $this->httpRequest($url);
+    $body = drupal_json_decode($result['body']);
+    $this->assertEqual($result['code'], '422', format_string('422 status code sent for @url url.', array('@url' => $url)));
+    $this->assertTrue(strpos($result['headers'], 'application/problem+json;'), '"application/problem+json" found in invalid request.');
+    $this->assertEqual($body['title'], 'The entity ID 1 for Articles does not exist.', 'Correct error message.');
   }
 
 }

--- a/tests/RestfulHookMenuTestCase.test
+++ b/tests/RestfulHookMenuTestCase.test
@@ -113,18 +113,6 @@ class RestfulHookMenuTestCase extends RestfulCurlBaseTestCase {
   }
 
   /**
-   * Test when an entity is not found that a 4XX is returned instead of 500.
-   */
-  function testEntityNotFoundDelivery() {
-    $url = 'api/v1.0/articles/1';
-    $result = $this->httpRequest($url);
-    $body = drupal_json_decode($result['body']);
-    $this->assertEqual($result['code'], '422', format_string('422 status code sent for @url url.', array('@url' => $url)));
-    $this->assertTrue(strpos($result['headers'], 'application/problem+json;'), '"application/problem+json" found in invalid request.');
-    $this->assertEqual($body['title'], 'The entity ID 1 for Articles does not exist.', 'Correct error message.');
-  }
-
-  /**
    * Test the version negotiation.
    */
   function testVersionNegotiation() {

--- a/tests/RestfulHookMenuTestCase.test
+++ b/tests/RestfulHookMenuTestCase.test
@@ -113,6 +113,18 @@ class RestfulHookMenuTestCase extends RestfulCurlBaseTestCase {
   }
 
   /**
+   * Test when an entity is not found that a 4XX is returned instead of 500.
+   */
+  function testEntityNotFoundDelivery() {
+    $url = 'api/v1.0/articles/1';
+    $result = $this->httpRequest($url);
+    $body = drupal_json_decode($result['body']);
+    $this->assertEqual($result['code'], '422', format_string('422 status code sent for @url url.', array('@url' => $url)));
+    $this->assertTrue(strpos($result['headers'], 'application/problem+json;'), '"application/problem+json" found in invalid request.');
+    $this->assertEqual($body['title'], 'The entity ID 1 for Articles does not exist.', 'Correct error message.');
+  }
+
+  /**
    * Test the version negotiation.
    */
   function testVersionNegotiation() {


### PR DESCRIPTION
This fixes missing entity GETs returning a 500, because the exception class wasn't extending RestfulException. I wasn't totally sure where to put the test, but this seemed like a good start.
