### PR TITLE
defaultSort fails with custom resource properties returns SQL error

### DIFF
--- a/docs/api_drupal.md
+++ b/docs/api_drupal.md
@@ -23,6 +23,10 @@ properties.  List every property in a comma-separated string, in the order that
 you want to sort by.  Prefixing the property name with a dash (``-``) will sort
  by that property in a descending order; the default is ascending.
 
+Bear in mind that for entity based resources, only those fields with a
+`'property'` (matching to an entity property or a Field API field) can be used
+for sorting.
+
 If no sorting is specified the default sorting is by the entity ID.
 
 ```php
@@ -60,6 +64,10 @@ $handler = restful_get_restful_handler('articles');
 $request['filter'] = array('label' => 'abc');
 $result = $handler->get('', $request);
 ```
+
+Bear in mind that for entity based resources, only those fields with a
+`'property'` (matching to an entity property or a Field API field) can be used
+for filtering.
 
 Additionally you can provide multiple filters for the same field. That is
 specially useful when filtering on multiple value fields. The following example

--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -84,6 +84,10 @@ Returns:
 ## Applying a query filter
 RESTful allows applying filters to the database query used to generate the list.
 
+Bear in mind that for entity based resources, only those fields with a
+`'property'` (matching to an entity property or a Field API field) can be used
+for filtering.
+
 ```php
 # Handler v1.0
 curl https://example.com/api/v1/articles?filter[label]=abc

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -113,7 +113,9 @@ You can also define default sort fields in your plugin, by overriding
 
 This method should return an associative array, with each element having a key
 that matches a field from `publicFieldsInfo()`, and a value of either 'ASC' or
-'DESC'.
+'DESC'. Bear in mind that for entity based resources, only those fields with a
+`'property'` (matching to an entity property or a Field API field) can be used
+for sorting.
 
 This default sort will be ignored if the request URL contains a sort query.
 

--- a/modules/restful_example/plugins/restful/node/articles/1.5/RestfulExampleArticlesResource__1_5.class.php
+++ b/modules/restful_example/plugins/restful/node/articles/1.5/RestfulExampleArticlesResource__1_5.class.php
@@ -58,6 +58,11 @@ class RestfulExampleArticlesResource__1_5 extends RestfulEntityBaseNode {
       ),
     );
 
+    $public_fields['static'] = array(
+      'callback' => array(
+        array($this, 'randomNumber'),
+      ),
+    );
 
     return $public_fields;
   }
@@ -89,4 +94,18 @@ class RestfulExampleArticlesResource__1_5 extends RestfulEntityBaseNode {
       'styles' => $value['image_styles'],
     );
   }
+
+  /**
+   * Callback, Generate a random number.
+   *
+   * @param \EntityMetadataWrapper $wrapper
+   *   The EMW.
+   *
+   * @return int
+   *   A random integer.
+   */
+  public function randomNumber($wrapper) {
+    return mt_rand();
+  }
+
 }

--- a/modules/restful_example/plugins/restful/node/articles/1.5/RestfulExampleArticlesResource__1_5.class.php
+++ b/modules/restful_example/plugins/restful/node/articles/1.5/RestfulExampleArticlesResource__1_5.class.php
@@ -59,9 +59,7 @@ class RestfulExampleArticlesResource__1_5 extends RestfulEntityBaseNode {
     );
 
     $public_fields['static'] = array(
-      'callback' => array(
-        array($this, 'randomNumber'),
-      ),
+      'callback' => 'static::randomNumber',
     );
 
     return $public_fields;
@@ -104,7 +102,7 @@ class RestfulExampleArticlesResource__1_5 extends RestfulEntityBaseNode {
    * @return int
    *   A random integer.
    */
-  public function randomNumber($wrapper) {
+  public static function randomNumber($wrapper) {
     return mt_rand();
   }
 

--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -140,7 +140,9 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
 
     foreach ($sorts as $public_field_name => $direction) {
       // Determine if sorting is by field or property.
-      $property_name = $public_fields[$public_field_name]['property'];
+      if (!$property_name = $public_fields[$public_field_name]['property']) {
+        throw new \RestfulBadRequestException('The current sort selection does not map to any entity property or Field API field.');
+      }
       if (field_info_field($property_name)) {
         $query->fieldOrderBy($public_fields[$public_field_name]['property'], $public_fields[$public_field_name]['column'], $direction);
       }
@@ -165,7 +167,9 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
     $public_fields = $this->getPublicFields();
     foreach ($this->parseRequestForListFilter() as $filter) {
       // Determine if filtering is by field or property.
-      $property_name = $public_fields[$filter['public_field']]['property'];
+      if (!$property_name = $public_fields[$filter['public_field']]['property']) {
+        throw new \RestfulBadRequestException('The current filter selection does not map to any entity property or Field API field.');
+      }
       if (field_info_field($property_name)) {
         if (in_array(strtoupper($filter['operator'][0]), array('IN', 'BETWEEN'))) {
           $query->fieldCondition($public_fields[$filter['public_field']]['property'], $public_fields[$filter['public_field']]['column'], $filter['value'], $filter['operator'][0]);

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -436,6 +436,19 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
 
     $result = $handler->get('', $request);
     $this->assertEqual(count($result), 2, 'List filtered by the "author" entity metadata wrapper property, which maps to the "uid" DB column name.');
+
+    $request = array('filter' => array(
+      'static' => array(
+        'value' => 0,
+      )
+    ));
+    try {
+      $handler->get('', $request);
+      $this->fail('Exception not thrown for invalid filter.');
+    }
+    catch (\RestfulBadRequestException $e) {
+      $this->pass('Exception thrown for invalid filter.');
+    }
   }
 
   /**

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -270,6 +270,15 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
     $request = array('sort' => '-user',);
     $result = $handler->get('', $request);
     $this->assertEqual($result[0]['user']['id'], 3, 'List sorted by the "author" entity metadata wrapper property, which maps to the "uid" DB column name.');
+
+    $request = array('sort' => 'static');
+    try {
+      $handler->get('', $request);
+      $this->fail('Exception not thrown for invalid sort.');
+    }
+    catch (\RestfulBadRequestException $e) {
+      $this->pass('Exception thrown for invalid sort.');
+    }
   }
 
   /**
@@ -591,4 +600,5 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
       $this->fail('Exception of wrong type was thrown for un-accessible node for specific IDs list.');
     }
   }
+
 }


### PR DESCRIPTION
I have a custom property added to a custom resource that extends `RestfulEntityBaseNode` like so:

```
<?php

class Example extends RestfulEntityBaseNode {

  public function publicFieldsInfo() {
    $public_fields = parent::publicFieldsInfo();

    $public_fields['weight'] = array(
      'callback' => array($this, 'customWeightCallback'),
    );
  }

  public function defaultSortInfo() {
    return array(
      'weight' => 'ASC',
    );
  }

  protected function customWeightCallback($entity) {
    return 0; // Could return anything
  }
}

```

According to the documentation this should be supported, from plugin.md:

> ## Defining a default sort
> 
>    You can also define default sort fields in your plugin, by overriding `defaultSortInfo()` in your class definition.
> 
> This method should return an associative array, with each element having a key that matches a field from `publicFieldsInfo()`, and a value of either 'ASC' or 'DESC'.

But what happens is that this throws an error:

```
{"type":"http:\/\/www.w3.org\/Protocols\/rfc2616\/rfc2616-sec10.html#sec10.5.1",
"title":"SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \u0027ASC\nLIMIT 50 OFFSET 0\u0027 at line 2","status":500}
```

It appears that the current sort functionality perhaps only allow things that are actually queried out of the database, not calculated properties

Are custom properties supported as a sort parameter?
