### PR TITLE
Filtering nodes as anonymous user

### DIFF
--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -252,10 +252,10 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
       $query->entityCondition('entity_id', $ids, 'IN');
     }
 
+    $this->queryForListFilter($query);
+
     $this->addExtraInfoToQuery($query);
     $query->addTag('restful_count');
-
-    $this->queryForListFilter($query);
 
     return $query->count();
   }
@@ -278,9 +278,13 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
   protected function addExtraInfoToQuery($query) {
     parent::addExtraInfoToQuery($query);
     $entity_type = $this->getEntityType();
-    // Add a generic entity access tag to the query.
-    $query->addTag($entity_type . '_access');
-    $query->addMetaData('restful_handler', $this);
+    // The only time you need to add the access tags to a EFQ is when you don't
+    // have fieldConditions.
+    if (empty($query->fieldConditions)) {
+      // Add a generic entity access tag to the query.
+      $query->addTag($entity_type . '_access');
+      $query->addMetaData('restful_handler', $this);
+    }
   }
 
   /**

--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -283,8 +283,8 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
     if (empty($query->fieldConditions)) {
       // Add a generic entity access tag to the query.
       $query->addTag($entity_type . '_access');
-      $query->addMetaData('restful_handler', $this);
     }
+    $query->addMetaData('restful_handler', $this);
   }
 
   /**


### PR DESCRIPTION
Hi,

For some weird reason, when I do a query with filters on my API which uses the restful module, I get the following error:

<code>SQLSTATE[42703]: Undefined column: 7 ERROR: column field_data_field_operation_type0.nid does not exist LINE 11: ....realm = 'all') ))AND (na.grant_view >= '1') AND (field_data... ^</code>

I've found out that the issue comes from the <a href="https://api.drupal.org/api/drupal/modules!node!node.module/function/_node_query_node_access_alter/7">_node_query_node_access_alter</a> function, which, when not logged in as an admin, overrides the EntityFieldQuery.

I haven't found any way to fix this issue yet, but was wondering if someone had run into it at some point...
