### PR TITLE
414 check to see if additional hateoas function has set _links before declaring array()

### DIFF
--- a/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
+++ b/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
@@ -77,7 +77,9 @@ class RestfulFormatterHalJson extends \RestfulFormatterBase implements \RestfulF
     }
     $request = $this->handler->getRequest();
 
-    $data['_links'] = array();
+    if (!isset($data['_links']) && is_array($data['_links'])) {
+      $data['_links'] = array();
+    }
 
     // Get self link.
     $data['_links']['self'] = array(

--- a/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
+++ b/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
@@ -77,7 +77,7 @@ class RestfulFormatterHalJson extends \RestfulFormatterBase implements \RestfulF
     }
     $request = $this->handler->getRequest();
 
-    if (!isset($data['_links']) && is_array($data['_links'])) {
+    if (!isset($data['_links'])) {
       $data['_links'] = array();
     }
 


### PR DESCRIPTION
This PR adds code to check to see if $data['_links'] has already been set by the additionalHateoas function in the JSON formatter.

closes #414 
- checks to see if $data['_links'] has been set
- checks to see that previously set $data['_links'] is the type we expect
- allows addtionalHateoas function defined at the handler level to contribute _links
