### PR TITLE
Wrong count on un-accessible nodes

### DIFF
--- a/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
+++ b/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
@@ -38,7 +38,8 @@ class RestfulFormatterHalJson extends \RestfulFormatterBase implements \RestfulF
       if (
         method_exists($this->handler, 'getTotalCount') &&
         method_exists($this->handler, 'isListRequest') &&
-        $this->handler->isListRequest()
+        $this->handler->isListRequest() && 
+        !empty($data)
       ) {
         // Get the total number of items for the current request without pagination.
         $output['count'] = $this->handler->getTotalCount();

--- a/plugins/formatter/json/RestfulFormatterJson.class.php
+++ b/plugins/formatter/json/RestfulFormatterJson.class.php
@@ -31,7 +31,8 @@ class RestfulFormatterJson extends \RestfulFormatterBase implements \RestfulForm
       if (
         method_exists($this->handler, 'getTotalCount') &&
         method_exists($this->handler, 'isListRequest') &&
-        $this->handler->isListRequest()
+        $this->handler->isListRequest() && 
+        !empty($data)
       ) {
         // Get the total number of items for the current request without pagination.
         $output['count'] = $this->handler->getTotalCount();


### PR DESCRIPTION
#411

Fix by judging the returned $data. I don't think it's necessary to run a checkEntityAccess again at formatter. Better to have the checkEntityAccess result passed into formatter, then we don't rely on $data.
