### PR TITLE
355 bad hal (remix)

### DIFF
--- a/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
+++ b/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
@@ -248,14 +248,14 @@ class RestfulFormatterHalJson extends \RestfulFormatterBase implements \RestfulF
     $rows = self::is_assoc($row[$public_field_name]) ? array($row[$public_field_name]) : $row[$public_field_name];
 
     foreach ($rows as $subindex => $subrow) {
-      $value_metadata = $values_metadata[$subindex];
+      $metadata = $values_metadata[$subindex];
 
+      // Loop through each value for the field.
       foreach ($subrow as $index => $resource_row) {
-        if (empty($value_metadata[$index])) {
+        if (empty($metadata[$index])) {
           // No metadata.
           continue;
         }
-        $metadata = $value_metadata;
 
         // If there is no resource name in the metadata for this particular value,
         // assume that we are referring to the first resource in the field

--- a/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
+++ b/plugins/formatter/hal_json/RestfulFormatterHalJson.class.php
@@ -77,7 +77,9 @@ class RestfulFormatterHalJson extends \RestfulFormatterBase implements \RestfulF
     }
     $request = $this->handler->getRequest();
 
-    $data['_links'] = array();
+    if (!isset($data['_links']) && is_array($data['_links'])) {
+      $data['_links'] = array();
+    }
 
     // Get self link.
     $data['_links']['self'] = array(


### PR DESCRIPTION
Fixes #355 
Closes #367 

This PR picks up on the awesome work that @adaddinsane did to help the hal_json formatter output _embedded resources for invidual items within list requests.  That PR #367 has been open since January 15th and I definitely would like to see the work make it to the main repo.

I've kept a lot of the work @adaddinsane including working with an embedded array within the prepareRow call and removing the final function (moveMetadataResource).

What i've done is tested for whether or not this call is a list request. That's what is going to either put embedded resources into the property level or allow them to float up the resource root in a single item request.

So for listings:

```
hal:thing [
    {
        property:"",
        _embedded {specific embeds for this thing},
       _links
    },
    {
        property:"",
        _embedded {specific embeds for this thing},
       _links
    }
],
_embedded {listing embedded probably empty},
_links
```

For Single Items:

```
hal:thing [
    {
        property:"",
    }
],
_embedded {specific embeds for this thing},
_links
```

There are a few code styling things from Drupal phpcs but nothing shocking there.
