### PR TITLE
2.x advanced read

### DIFF
--- a/modules/restful_example/src/Plugin/resource/Articles__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/Articles__1_0.php
@@ -49,6 +49,14 @@ class Articles__1_0 extends ResourceEntity implements ResourceInterface {
       'self' => array(
         'callback' => array($this, 'getEntitySelf'),
       ),
+      'tags' => array(
+        'property' => 'field_tags',
+        'resource' => array(
+          'name' => 'tags',
+          'majorVersion' => 1,
+          'minorVersion' => 0,
+        ),
+      ),
     );
   }
 

--- a/modules/restful_example/src/Plugin/resource/Articles__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/Articles__1_0.php
@@ -64,6 +64,15 @@ class Articles__1_0 extends ResourceEntity implements ResourceInterface {
         'property' => 'status',
         'methods' => array(Request::METHOD_POST, Request::METHOD_PUT),
       ),
+      'body' => array(
+        'property' => 'body',
+        'formatter' => array(
+          'type' => 'text_summary_or_trimmed',
+          'settings' => array(
+            'trim_length' => 100,
+          ),
+        ),
+      ),
     );
   }
 

--- a/modules/restful_example/src/Plugin/resource/Articles__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/Articles__1_0.php
@@ -7,6 +7,9 @@
 
 namespace Drupal\restful_example\Plugin\resource;
 
+use Drupal\restful\Http\Request;
+use Drupal\restful\Plugin\resource\Field\ResourceFieldBase;
+use Drupal\restful\Plugin\resource\Resource;
 use Drupal\restful\Plugin\resource\ResourceEntity;
 use Drupal\restful\Plugin\resource\ResourceInterface;
 
@@ -44,6 +47,9 @@ class Articles__1_0 extends ResourceEntity implements ResourceInterface {
       'label' => array(
         'wrapper_method' => 'label',
         'wrapper_method_on_entity' => TRUE,
+        'process_callbacks' => array(
+          array(array($this, 'addPrefix'), array('Label: ')),
+        ),
       ),
       'self' => array(
         'callback' => array($this, 'getEntitySelf'),
@@ -60,6 +66,21 @@ class Articles__1_0 extends ResourceEntity implements ResourceInterface {
         'property' => 'status',
       ),
     );
+  }
+
+  /**
+   * Helper function that adds a prefix.
+   *
+   * @param mixed $value
+   *   The input value to be prefixed.
+   * @param string $prefix
+   *   The prefix to add.
+   *
+   * @return string
+   *   The prefixed value.
+   */
+  public function addPrefix($value, $prefix) {
+    return $prefix . $value;
   }
 
 }

--- a/modules/restful_example/src/Plugin/resource/Articles__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/Articles__1_0.php
@@ -8,8 +8,6 @@
 namespace Drupal\restful_example\Plugin\resource;
 
 use Drupal\restful\Http\Request;
-use Drupal\restful\Plugin\resource\Field\ResourceFieldBase;
-use Drupal\restful\Plugin\resource\Resource;
 use Drupal\restful\Plugin\resource\ResourceEntity;
 use Drupal\restful\Plugin\resource\ResourceInterface;
 
@@ -64,6 +62,7 @@ class Articles__1_0 extends ResourceEntity implements ResourceInterface {
       ),
       'status' => array(
         'property' => 'status',
+        'methods' => array(Request::METHOD_POST, Request::METHOD_PUT),
       ),
     );
   }

--- a/modules/restful_example/src/Plugin/resource/Articles__2_0.php
+++ b/modules/restful_example/src/Plugin/resource/Articles__2_0.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful_example\Plugin\resource\Articles__1_0.
+ */
+
+namespace Drupal\restful_example\Plugin\resource;
+
+use Drupal\restful\Plugin\resource\ResourceEntity;
+use Drupal\restful\Plugin\resource\ResourceInterface;
+
+/**
+ * Class Articles
+ * @package Drupal\restful\Plugin\resource
+ *
+ * @Resource(
+ *   name = "articles:2.0",
+ *   resource = "articles",
+ *   label = "Articles",
+ *   description = "Export the article content type with cookie authentication.",
+ *   authenticationTypes = TRUE,
+ *   authenticationOptional = TRUE,
+ *   dataProvider = {
+ *     "entityType": "node",
+ *     "bundles": {
+ *       "article"
+ *     },
+ *     "viewMode": {
+ *       "name": "default",
+ *       "fieldMap": {
+ *         "body": "body",
+ *         "field_tags": "tags",
+ *         "field_image": "image",
+ *       }
+ *     }
+ *   },
+ *   majorVersion = 2,
+ *   minorVersion = 0
+ * )
+ */
+class Articles__2_0 extends ResourceEntity implements ResourceInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function publicFields() {
+    return array();
+  }
+
+}

--- a/modules/restful_example/src/Plugin/resource/Tags__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/Tags__1_0.php
@@ -7,6 +7,9 @@
 
 namespace Drupal\restful_example\Plugin\resource;
 
+use Drupal\restful\Http\Request;
+use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
+use Drupal\restful\Plugin\resource\Field\ResourceFieldInterface;
 use Drupal\restful\Plugin\resource\ResourceEntity;
 use Drupal\restful\Plugin\resource\ResourceInterface;
 
@@ -48,8 +51,29 @@ class Tags__1_0 extends ResourceEntity implements ResourceInterface {
       ),
       'self' => array(
         'callback' => array($this, 'getEntitySelf'),
+        'access_callbacks' => array(
+          array($this, 'evenAccess'),
+        ),
       ),
     );
   }
 
+  /**
+   * Access callback example.
+   *
+   * @param string $op
+   *   Operation being performed.
+   * @param ResourceFieldInterface $resource_field
+   *   The resource field definition object.
+   * @param DataInterpreterInterface $interpreter
+   *   The data interpreter.
+   *
+   * @return bool
+   *   TRUE for access granted.
+   */
+  public function evenAccess($op, ResourceFieldInterface $resource_field, DataInterpreterInterface $interpreter) {
+    $account = $interpreter->getAccount();
+    $value = $interpreter->getWrapper()->getIdentifier() + $account->uid;
+    return $value % 2;
+  }
 }

--- a/modules/restful_example/src/Plugin/resource/Tags__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/Tags__1_0.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\restful_example\Plugin\resource\Articles__1_0.
+ * Contains \Drupal\restful_example\Plugin\resource\Tags__1_0.
  */
 
 namespace Drupal\restful_example\Plugin\resource;
@@ -11,27 +11,27 @@ use Drupal\restful\Plugin\resource\ResourceEntity;
 use Drupal\restful\Plugin\resource\ResourceInterface;
 
 /**
- * Class Articles
+ * Class Tags
  * @package Drupal\restful\Plugin\resource
  *
  * @Resource(
- *   name = "articles:1.0",
- *   resource = "articles",
- *   label = "Articles",
- *   description = "Export the article content type with cookie authentication.",
+ *   name = "tags:1.0",
+ *   resource = "tags",
+ *   label = "Tags",
+ *   description = "Export the tags taxonomy term.",
  *   authenticationTypes = TRUE,
  *   authenticationOptional = TRUE,
  *   dataProvider = {
- *     "entityType": "node",
+ *     "entityType": "taxonomy_term",
  *     "bundles": {
- *       "article"
+ *       "tags"
  *     },
  *   },
  *   majorVersion = 1,
  *   minorVersion = 0
  * )
  */
-class Articles__1_0 extends ResourceEntity implements ResourceInterface {
+class Tags__1_0 extends ResourceEntity implements ResourceInterface {
 
   /**
    * {@inheritdoc}
@@ -39,7 +39,8 @@ class Articles__1_0 extends ResourceEntity implements ResourceInterface {
   protected function publicFields() {
     return array(
       'id' => array(
-        'property' => 'nid',
+        'wrapper_method' => 'getIdentifier',
+        'wrapper_method_on_entity' => TRUE,
       ),
       'label' => array(
         'wrapper_method' => 'label',
@@ -47,17 +48,6 @@ class Articles__1_0 extends ResourceEntity implements ResourceInterface {
       ),
       'self' => array(
         'callback' => array($this, 'getEntitySelf'),
-      ),
-      'tags' => array(
-        'property' => 'field_tags',
-        'resource' => array(
-          'name' => 'tags',
-          'majorVersion' => 1,
-          'minorVersion' => 0,
-        ),
-      ),
-      'status' => array(
-        'property' => 'status',
       ),
     );
   }

--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -5,6 +5,8 @@
  * Contains entity related code.
  */
 
+use Drupal\restful\Plugin\resource\DataProvider\CachedDataProvider;
+
 /**
  * Implements hook_entity_info().
  */
@@ -37,7 +39,7 @@ function restful_entity_info() {
 function restful_entity_update($entity, $type) {
   list($entity_id) = entity_extract_ids($type, $entity);
   $cid = 'paet:' . $type . '::ei:' . $entity_id;
-  \RestfulManager::invalidateEntityCache($cid);
+  CachedDataProvider::invalidateEntityCache($cid);
 }
 
 /**
@@ -46,7 +48,7 @@ function restful_entity_update($entity, $type) {
 function restful_entity_delete($entity, $type) {
   list($entity_id) = entity_extract_ids($type, $entity);
   $cid = 'paet:' . $type . '::ei:' . $entity_id;
-  \RestfulManager::invalidateEntityCache($cid);
+  CachedDataProvider::invalidateEntityCache($cid);
 }
 
 /**
@@ -55,7 +57,7 @@ function restful_entity_delete($entity, $type) {
 function restful_user_update(&$edit, $account, $category) {
   // Due to the limitations for cid matching on clearing caches, we need to
   // clear all the bin. We cannot do $cid = '%::uu' . $account->uid . '::pa';
-  \RestfulManager::invalidateEntityCache('*');
+  CachedDataProvider::invalidateEntityCache('*');
 }
 
 /**
@@ -64,5 +66,5 @@ function restful_user_update(&$edit, $account, $category) {
 function restful_user_delete($account) {
   // Due to the limitations for cid matching on clearing caches, we need to
   // clear all the bin. We cannot do $cid = '%::uu' . $account->uid . '::pa';
-  \RestfulManager::invalidateEntityCache('*');
+  CachedDataProvider::invalidateEntityCache('*');
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -171,7 +171,7 @@ class Request implements RequestInterface {
    */
   public static function create($path, array $query = array(), $method = 'GET', HttpHeaderBag $headers = NULL, $via_router = FALSE, $csrf_token = NULL, array $cookies = array(), array $files = array(), array $server = array()) {
     if (!$headers) {
-      $headers = HttpHeaderNull::create(NULL, NULL);
+      $headers = new HttpHeaderBag();
     }
     if ($method == static::METHOD_POST && $headers->get('x-http-method-override')->getValueString()) {
       $method = $headers->get('x-http-method-override')->getValueString();

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -237,11 +237,11 @@ class Request implements RequestInterface {
   /**
    * {@inheritdoc}
    */
-  public function isListRequest() {
+  public function isListRequest($resource_path) {
     if ($this->method != static::METHOD_GET) {
       return FALSE;
     }
-    return empty($this->path) || strpos($this->path, ',') !== FALSE;
+    return empty($resource_path) || strpos($resource_path, ',') !== FALSE;
   }
 
   /**
@@ -260,12 +260,20 @@ class Request implements RequestInterface {
    * {@inheritdoc}
    */
   public function getParsedInput() {
-    if ($this->parsedInput) {
+    if (isset($this->parsedInput)) {
       return $this->parsedInput;
     }
     // Get the input data provided via URL.
     $this->parsedInput = static::parseInput($this->method);
+    unset($this->parsedInput['q']);
     return $this->parsedInput;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setParsedInput(array $input) {
+    $this->parsedInput = $input;
   }
 
   /**

--- a/src/Http/RequestInterface.php
+++ b/src/Http/RequestInterface.php
@@ -81,15 +81,19 @@ interface RequestInterface {
   /**
    * Helper method to know if the current request is for a list.
    *
+   * @param string $resource_path
+   *   The resource path without any prefixes.
+   *
    * @return boolean
    *   TRUE if the request is for a list. FALSE otherwise.
    */
-  public function isListRequest();
+  public function isListRequest($resource_path);
 
   /**
    * Parses the body string.
    *
    * @return array
+   *   The parsed body.
    */
   public function getParsedBody();
 
@@ -97,8 +101,17 @@ interface RequestInterface {
    * Parses the input data provided via URL params.
    *
    * @return array
+   *   The parsed input.
    */
   public function getParsedInput();
+
+  /**
+   * Parses the input data provided via URL params.
+   *
+   * @param array $input
+   *   The input to set.
+   */
+  public function setParsedInput(array $input);
 
   /**
    * Gets the request path.

--- a/src/Plugin/formatter/FormatterHalJson.php
+++ b/src/Plugin/formatter/FormatterHalJson.php
@@ -55,7 +55,7 @@ class FormatterHalJson extends Formatter implements FormatterInterface {
       if (
         method_exists($this->resource, 'getTotalCount') &&
         method_exists($this->resource, 'isListRequest') &&
-        $this->resource->isListRequest()
+        $this->resource->isListRequest($this->resource->getPath())
       ) {
         // Get the total number of items for the current request without pagination.
         $output['count'] = $this->resource->getTotalCount();

--- a/src/Plugin/formatter/FormatterJson.php
+++ b/src/Plugin/formatter/FormatterJson.php
@@ -43,7 +43,7 @@ class FormatterJson extends Formatter implements FormatterInterface {
       if (
         method_exists($this->resource, 'getTotalCount') &&
         method_exists($this->resource, 'isListRequest') &&
-        $this->resource->isListRequest()
+        $this->resource->isListRequest($this->resource->getPath())
       ) {
         // Get the total number of items for the current request without pagination.
         $output['count'] = $this->resource->getTotalCount();

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -531,7 +531,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       if (!$property_name = $resource_field->getProperty()) {
         throw new BadRequestException('The current sort selection does not map to any entity property or Field API field.');
       }
-      if (ResourceFieldEntityInterface::propertyIsField($property_name)) {
+      if (ResourceFieldEntity::propertyIsField($property_name)) {
         $query->fieldOrderBy($property_name, $resource_field->getColumn(), $direction);
       }
       else {

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -197,12 +197,12 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
 
       $value = NULL;
 
-      if (!$this->methodAccess($resource_field)) {
-        // The field does not apply to the current method.
+      $interpreter = new DataInterpreterEMW($this->getAccount(), $wrapper);
+      if (!$this->methodAccess($resource_field) || !$resource_field->access('view', $interpreter)) {
+        // The field does not apply to the current method or has denied access.
         continue;
       }
 
-      $interpreter = new DataInterpreterEMW($this->getAccount(), $wrapper);
       $value = $resource_field->value($interpreter);
 
       $value = $this->processCallbacks($value, $resource_field);

--- a/src/Plugin/resource/DataProvider/DataProviderResource.php
+++ b/src/Plugin/resource/DataProvider/DataProviderResource.php
@@ -54,6 +54,7 @@ class DataProviderResource extends DataProvider implements DataProviderResourceI
    */
   public function __construct(RequestInterface $request, ResourceFieldCollectionInterface $field_definitions, $account, array $options, $langcode = NULL, ResourceInterface $resource = NULL) {
     $this->resource = $resource;
+    $resource->setRequest($request);
     $this->referencedDataProvider = $resource->getDataProvider();
     parent::__construct($request, $field_definitions, $account, $options, $langcode);
   }

--- a/src/Plugin/resource/Field/ResourceField.php
+++ b/src/Plugin/resource/Field/ResourceField.php
@@ -30,8 +30,9 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
     $this->property = isset($field['property']) ? $field['property'] : $this->property;
     // $this->column = isset($field['column']) ? $field['column'] : $this->column;
     $this->callback = isset($field['callback']) ? $field['callback'] : $this->callback;
-    $this->processCallbacks = isset($field['processCallbacks']) ? $field['processCallbacks'] : $this->processCallbacks;
+    $this->processCallbacks = isset($field['process_callbacks']) ? $field['process_callbacks'] : $this->processCallbacks;
     $this->resource = isset($field['resource']) ? $field['resource'] : $this->resource;
+    $this->methods = isset($field['methods']) ? $field['methods'] : $this->methods;
   }
 
   /**
@@ -52,10 +53,6 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
    * {@inheritdoc}
    */
   public function value(DataInterpreterInterface $interpreter) {
-    if (!$this->access('view', $interpreter)) {
-      // If there is no access to the property, return NULL.
-      return NULL;
-    }
     if ($callback = $this->getCallback()) {
       return ResourceManager::executeCallback($callback, array($interpreter));
     }

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -146,8 +146,10 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
    * {@inheritdoc}
    */
   public function value(DataInterpreterInterface $interpreter) {
-    if ($callback = $this->getCallback()) {
-      throw new IncompatibleFieldDefinitionException('You cannot have a callback with entity specific field descriptions.');
+    $value = $this->decorated->value($interpreter);
+    if (isset($value)) {
+      // Let the decorated resolve callbacks.
+      return $value;
     }
 
     // Check user has access to the property.

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -201,6 +201,8 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
         return $embedded_identifier;
       }
       $request = Request::create('', array(), Request::METHOD_GET);
+      // Remove the $_GET options for the sub-request.
+      $request->setParsedInput(array());
       // TODO: Get version automatically to avoid setting it in the plugin definition. Ideally we would fill this when processing the plugin definition defaults.
       $resource_data_provider = DataProviderResource::init($request, $resource['name'], array(
         $resource['majorVersion'],

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -196,7 +196,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
         // the embedded identifier.
         $embedded_identifier = $this->fieldValue($property_wrapper);
       }
-      if ($resource['full_view' === FALSE]) {
+      if (isset($resource['full_view']) && $resource['full_view'] === FALSE) {
         return $embedded_identifier;
       }
       $request = Request::create('', array(), Request::METHOD_GET);
@@ -204,7 +204,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
         $resource['majorVersion'],
         $resource['minorVersion'],
       ));
-      // FIXME: $embedded_identifier needs to be fetched first!!!
+
       return $resource_data_provider->view($embedded_identifier);
     }
 

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\restful\Plugin\resource\Field\ResourceFieldEntity
+* Contains \Drupal\restful\Plugin\resource\Field\ResourceFieldEntity
  */
 
 namespace Drupal\restful\Plugin\resource\Field;
@@ -200,6 +200,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
         return $embedded_identifier;
       }
       $request = Request::create('', array(), Request::METHOD_GET);
+      // TODO: Get version automatically to avoid setting it in the plugin definition. Ideally we would fill this when processing the plugin definition defaults.
       $resource_data_provider = DataProviderResource::init($request, $resource['name'], array(
         $resource['majorVersion'],
         $resource['minorVersion'],
@@ -560,6 +561,10 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
    *   was found.
    */
   protected static function fieldClassName(array $field_definition) {
+    if (!empty($field_definition['class']) && $field_definition['class'] != '\Drupal\restful\Plugin\resource\Field\ResourceFieldEntity') {
+      // If there is a class that is not the current, return it.
+      return $field_definition['class'];
+    }
     // If there is an extending class for the particular field use that class
     // instead.
     if (empty($field_definition['property']) || !$field_info = field_info_field($field_definition['property'])) {

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -7,7 +7,6 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
-use Drupal\restful\Exception\IncompatibleFieldDefinitionException;
 use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Http\Request;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderResource;

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -7,14 +7,10 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
-use Drupal\restful\Exception\IncompatibleFieldDefinitionException;
 use Drupal\restful\Http\HttpHeaderBag;
 use Drupal\restful\Http\Request;
-use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderResource;
-use Drupal\restful\Plugin\resource\DataSource\DataSourceEMW;
-use Drupal\restful\Plugin\resource\DataSource\DataSourceInterface;
 
 class ResourceFieldEntityReference extends ResourceFieldEntity implements ResourceFieldEntityReferenceInterface {
 

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -157,8 +157,10 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
    * {@inheritdoc}
    */
   public function value(DataInterpreterInterface $interpreter) {
-    if ($callback = $this->getCallback()) {
-      throw new IncompatibleFieldDefinitionException('You cannot have a callback with entity specific field descriptions.');
+    $value = $this->decorated->value($interpreter);
+    if (isset($value)) {
+      // Let the decorated resolve callbacks.
+      return $value;
     }
 
     // Check user has access to the property.

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -11,6 +11,8 @@ use Drupal\restful\Http\HttpHeaderBag;
 use Drupal\restful\Http\Request;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderResource;
+use Drupal\restful\Plugin\resource\DataSource\DataSourceEMW;
+use Drupal\restful\Plugin\resource\DataSource\DataSourceInterface;
 
 class ResourceFieldEntityReference extends ResourceFieldEntity implements ResourceFieldEntityReferenceInterface {
 
@@ -137,7 +139,7 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
   }
 
   /**
-   * Get the ID of the resource this sub-request is for.
+   * Get the ID of the resource this write sub-request is for.
    *
    * @param array $value
    *   The array of values provided for this sub-request.
@@ -147,6 +149,47 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
    */
   protected static function subRequestId(array $value) {
     return $value['id'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function value(DataSourceInterface $source) {
+    // Return if this field is a callback.
+    $value = $this->decorated->value($source);
+    if (isset($value)) {
+      return $value;
+    }
+
+    // Check user has access to the property.
+    if (!$this->access('view', $source)) {
+      return NULL;
+    }
+
+    $resource = $this->getResource();
+    // If the field definition does not contain a resource, or it is set
+    // explicitly to full_view FALSE, then return only the entity ID.
+    if ($resource || (!empty($resource) && $resource['full_view'] !== FALSE)) {
+      // Let the resource embedding to the parent class.
+      return parent::value($source);
+    }
+
+    // Since this is a reference field (a field that points to other entities,
+    // we can know for sure that the property wrappers are instances of
+    // \EntityDrupalWrapper or lists of them.
+    $property_wrapper = $this->propertyWrapper($source);
+
+    // If this is a multivalue field, then call recursively on the items.
+    if ($property_wrapper instanceof \EntityListWrapper) {
+      $values = array();
+      foreach ($property_wrapper->getIterator() as $item_wrapper) {
+        /** @var $item_wrapper \EntityDrupalWrapper */
+        $values[] = $item_wrapper->getIdentifier();
+      }
+      return $values;
+    }
+    /** @var $property_wrapper \EntityDrupalWrapper */
+    return $property_wrapper->getIdentifier();
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -167,7 +167,11 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
     $resource = $this->getResource();
     // If the field definition does not contain a resource, or it is set
     // explicitly to full_view FALSE, then return only the entity ID.
-    if ($resource || (!empty($resource) && $resource['full_view'] !== FALSE)) {
+    if (
+      $resource ||
+      (!empty($resource) && $resource['full_view'] !== FALSE) ||
+      $this->getFormatter()
+    ) {
       // Let the resource embedding to the parent class.
       return parent::value($interpreter);
     }

--- a/src/Plugin/resource/Resource.php
+++ b/src/Plugin/resource/Resource.php
@@ -71,7 +71,7 @@ abstract class Resource extends PluginBase implements ResourceInterface {
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->fieldDefinitions = ResourceFieldCollection::factory($this->publicFields());
+    $this->fieldDefinitions = ResourceFieldCollection::factory($this->processedPublicFields());
   }
 
   /**
@@ -388,5 +388,16 @@ abstract class Resource extends PluginBase implements ResourceInterface {
    *   The field definition array.
    */
   abstract protected function publicFields();
+
+  /**
+   * Get the public fields with the default values applied to them.
+   *
+   * @return array
+   *   The field definition array.
+   */
+  protected function processedPublicFields() {
+    // By default do not do any special processing.
+    return $this->publicFields();
+  }
 
 }

--- a/src/Plugin/resource/Resource.php
+++ b/src/Plugin/resource/Resource.php
@@ -71,7 +71,7 @@ abstract class Resource extends PluginBase implements ResourceInterface {
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->fieldDefinitions = ResourceFieldCollection::factory($this->processedPublicFields());
+    $this->fieldDefinitions = ResourceFieldCollection::factory($this->processPublicFields($this->publicFields()));
   }
 
   /**
@@ -93,6 +93,13 @@ abstract class Resource extends PluginBase implements ResourceInterface {
       throw new ServerConfigurationException('Request object is not available for the Resource plugin.');
     }
     return $this->request;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->request = $request;
   }
 
   /**
@@ -392,12 +399,15 @@ abstract class Resource extends PluginBase implements ResourceInterface {
   /**
    * Get the public fields with the default values applied to them.
    *
+   * @param array $field_definitions
+   *   The field definitions to process.
+   *
    * @return array
    *   The field definition array.
    */
-  protected function processedPublicFields() {
+  protected function processPublicFields(array $field_definitions) {
     // By default do not do any special processing.
-    return $this->publicFields();
+    return $field_definitions;
   }
 
 }

--- a/src/Plugin/resource/ResourceEntity.php
+++ b/src/Plugin/resource/ResourceEntity.php
@@ -10,7 +10,6 @@ namespace Drupal\restful\Plugin\resource;
 use Drupal\restful\Exception\InternalServerErrorException;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderEntity;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
-use Drupal\restful\Plugin\resource\Field\ResourceFieldCollectionInterface;
 
 abstract class ResourceEntity extends Resource {
 
@@ -81,6 +80,21 @@ abstract class ResourceEntity extends Resource {
    */
   public function getEntitySelf(DataInterpreterInterface $interpreter) {
     return $this->versionedUrl($interpreter->getWrapper()->getIdentifier());
+  }
+
+  /**
+   * Get the public fields with the default values applied to them.
+   *
+   * @return array
+   *   The field definition array.
+   */
+  protected function processedPublicFields() {
+    // The fields that only contain a property need to be set to be
+    // ResourceFieldEntity. Otherwise they will be considered regular
+    // ResourceField.
+    return array_map(function ($field_definition) {
+      return $field_definition + array('class' => '\Drupal\restful\Plugin\resource\Field\ResourceFieldEntity');
+    },$this->publicFields());
   }
 
 }

--- a/src/Plugin/resource/ResourceInterface.php
+++ b/src/Plugin/resource/ResourceInterface.php
@@ -10,6 +10,7 @@ namespace Drupal\restful\Plugin\resource;
 use Drupal\Component\Plugin\ConfigurablePluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\restful\Exception\NotImplementedException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldCollectionInterface;
 
@@ -41,12 +42,20 @@ interface ResourceInterface extends PluginInspectionInterface, ConfigurablePlugi
   /**
    * Get the request object.
    *
-   * @return \Drupal\restful\Http\RequestInterface
+   * @return RequestInterface
    *   The request object.
    *
    * @throws \Drupal\restful\Exception\ServerConfigurationException
    */
   public function getRequest();
+
+  /**
+   * Sets the request object.
+   *
+   * @param RequestInterface $request
+   *   The request object.
+   */
+  public function setRequest(RequestInterface $request);
 
   /**
    * Gets the path of the resource.

--- a/src/Resource/ResourceManagerInterface.php
+++ b/src/Resource/ResourceManagerInterface.php
@@ -18,7 +18,8 @@ interface ResourceManagerInterface {
   /**
    * Gets the plugin collection for this plugin manager.
    *
-   * @return ResourcePluginManager
+   * @return ResourcePluginCollection
+   *   The plugin collection.
    */
   public function getPlugins();
 


### PR DESCRIPTION
All this should be working now!
- [x] Listing Field API fields.
- [x] Listing entity properties.
- [x] Listing embedded resources.
- [x] Listing reference fields with their ID (either by not using `'resource'` or using it with `'full_view' = FALSE`.
- [x] Using process callbacks.
- [x] Using field access callbacks.
- [x] Using method based field access (disabling fields for the GET method). This is the new alternative for `create_or_update_passthrough`.
- [x] Filtering by property/field.
- [x] Hiding fields from output via url.
- [x] Sorting  by property/field.
- [x] Disabling url params.
- [x] Showing fields by using a field formatter.
- [x] Showing an entity with a view mode.

Basically, making sure that we can read from an entity based endpoint with full features.

@amitaibu I feel that the _Gizra Army_ can start adapting the read related tests. The version negotiation and menu tests should also be ready to test.

What a break through in these last 4 (long) days! I'm excited to see this taking shape.

As a side note, I re-implemented the view mode rendering. Now it's better (it re-uses the formatter rendering) and it only took a few lines of code to write! I have the impression that we have moved towards the correct direction, but let's evaluate when the dust settles.
