### PR TITLE
Support autocomplete when bundle plugin property is ommitted

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -205,7 +205,8 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     $info = $this->getEntityInfo();
     // When a bundle key wasn't defined return false in order to make the
     // autocomplete support entities without bundle key. i.e: user, vocabulary.
-    return !empty($info['entity keys']['bundle']) ? array($this->getBundle()) : FALSE;
+    $bundle = $this->getBundle();
+    return !empty($bundle) && !empty($info['entity keys']['bundle']) ? array($bundle) : FALSE;
   }
 
   /**


### PR DESCRIPTION
This allows autocomplete on plugins that are intentionally including all bundles by excluding the bundle property. Otherwise getBundlesForAutocomplete() would return array(0) since the entity type has bundles but getBundle() returns 0.
