### PR TITLE
Allow plugins to be sorted by weight.

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -146,8 +146,20 @@ $plugin = array(
 );
 ```
 
+
 ## Setting the default range
 The range can be specified by setting `$this->range` in your plugin definition.
+
+
+## Setting plugin precedence
+Plugins can be sorted relative to each other by specifying a weight. This is useful, for example, in the case of formatters where the first formatter matching the Accept request header is used.
+
+```php
+$plugin = array(
+  ...
+  'weight' => -1,
+);
+```
 
 
 ### Disabling the range parameter

--- a/modules/restful_example/plugins/formatter/hal_xml.inc
+++ b/modules/restful_example/plugins/formatter/hal_xml.inc
@@ -5,4 +5,5 @@ $plugin = array(
   'description' => t('Output in using the HAL conventions and XML format.'),
   'name' => 'hal_xml',
   'class' => 'RestfulFormatterHalXml',
+  'weight' => -1,
 );

--- a/restful.info
+++ b/restful.info
@@ -79,6 +79,7 @@ files[] = tests/RestfulHookMenuTestCase.test
 files[] = tests/RestfulListEntityMultipleBundlesTestCase.test
 files[] = tests/RestfulListTestCase.test
 files[] = tests/RestfulPassThroughTestCase.test
+files[] = tests/RestfulPluginPrecedenceTestCase.test
 files[] = tests/RestfulRateLimitTestCase.test
 files[] = tests/RestfulReferenceTestCase.test
 files[] = tests/RestfulRenderCacheTestCase.test

--- a/restful.module
+++ b/restful.module
@@ -44,6 +44,22 @@ function restful_ctools_plugin_type() {
   return $plugins;
 }
 
+/**
+ * Include Ctools plugins and get plugins of the given type.
+ *
+ * @param string $type
+ *   The type of plugin to retrieve.
+ *
+ * @return array
+ *   All plugins of the given type.
+ */
+function restful_get_plugins_by_type($type) {
+  ctools_include('plugins');
+  $plugins = ctools_get_plugins('restful', $type);
+  uasort($plugins, 'drupal_sort_weight');
+  return $plugins;
+}
+
 
 /**
  * Include CTools plugins and get all restful plugins.
@@ -52,8 +68,7 @@ function restful_ctools_plugin_type() {
  *   All plugins for restful resources.
  */
 function restful_get_restful_plugins() {
-  ctools_include('plugins');
-  return ctools_get_plugins('restful', 'restful');
+  return restful_get_plugins_by_type('restful');
 }
 
 /**
@@ -63,8 +78,7 @@ function restful_get_restful_plugins() {
  *   All plugins for restful authentication.
  */
 function restful_get_authentication_plugins() {
-  ctools_include('plugins');
-  return ctools_get_plugins('restful', 'authentication');
+  return restful_get_plugins_by_type('authentication');
 }
 
 /**
@@ -74,8 +88,7 @@ function restful_get_authentication_plugins() {
  *   All the restful rate_limit plugins.
  */
 function restful_get_rate_limit_plugins() {
-  ctools_include('plugins');
-  return ctools_get_plugins('restful', 'rate_limit');
+  return restful_get_plugins_by_type('rate_limit');
 }
 
 /**
@@ -85,8 +98,7 @@ function restful_get_rate_limit_plugins() {
  *   All the restful formatter plugins.
  */
 function restful_get_formatter_plugins() {
-  ctools_include('plugins');
-  return ctools_get_plugins('restful', 'formatter');
+  return restful_get_plugins_by_type('formatter');
 }
 
 /**

--- a/tests/RestfulPluginPrecedenceTestCase.test
+++ b/tests/RestfulPluginPrecedenceTestCase.test
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulPluginPrecedenceTestCase
+ */
+
+class RestfulPluginPrecedenceTestCase extends DrupalWebTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Plugin Precedence',
+      'description' => 'Test the ordering of plugins by weight.',
+      'group' => 'RESTful',
+    );
+  }
+
+  function setUp() {
+    parent::setUp('restful_example');
+  }
+
+  /**
+   * Test plugin precedence.
+   */
+  function testPluginPrecedence() {
+    // Test that the hal_xml formatter plugin is first.
+    $plugins = restful_get_formatter_plugins();
+    $this->assertTrue(key($plugins) === 'hal_xml' && $plugins['hal_xml']['weight'] === -1, 'The hal_xml formatter plugin has a weight of -1 and is first in the retrieved array of formatter plugins.');
+  }
+
+}


### PR DESCRIPTION
The use case for this:
We have extended RestfulFormatterHalJson with our own class and utilized it in a custom formatter plugin. However, if the request comes through with an Accept header of 'application/hal+json' the regular hal+json formatter is always used. This is because outputFormat() bails as soon as it finds a matching formatter and the regular hal+json formatter always comes first in the array. This pull request allows us to specify that our custom hal+json formatter should come first.

I also created an additional helper function to prevent from repeating myself in each of the others.
