### PR TITLE
Add support for LIKE and STARTS_WITH operators

### DIFF
--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -1057,14 +1057,12 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
       '!=',
       'IN',
       'BETWEEN',
-      'LIKE',
-      'STARTS_WITH',
     );
 
     foreach ($operators as $operator) {
       if (!in_array($operator, $allowed_operators)) {
         throw new \RestfulBadRequestException(format_string('Operator "@operator" is not allowed for filtering on this resource. Allowed operators are: !allowed', array(
-          '@operator' => $operators,
+          '@operator' => $operator,
           '!allowed' => implode(', ', $allowed_operators),
         )));
       }

--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -1057,6 +1057,8 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
       '!=',
       'IN',
       'BETWEEN',
+      'LIKE',
+      'STARTS_WITH',
     );
 
     foreach ($operators as $operator) {

--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -175,6 +175,10 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
           $query->fieldCondition($public_fields[$filter['public_field']]['property'], $public_fields[$filter['public_field']]['column'], $filter['value'], $filter['operator'][0]);
           continue;
         }
+        if (in_array(strtoupper($filter['operator'][0]), array('LIKE', 'STARTS_WITH'))) {
+          $query->fieldCondition($public_fields[$filter['public_field']]['property'], $public_fields[$filter['public_field']]['column'], $filter['value'][0], $filter['operator'][0]);
+          continue;
+        }
         for ($index = 0; $index < count($filter['value']); $index++) {
           $query->fieldCondition($public_fields[$filter['public_field']]['property'], $public_fields[$filter['public_field']]['column'], $filter['value'][$index], $filter['operator'][$index]);
         }

--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -175,10 +175,6 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
           $query->fieldCondition($public_fields[$filter['public_field']]['property'], $public_fields[$filter['public_field']]['column'], $filter['value'], $filter['operator'][0]);
           continue;
         }
-        if (in_array(strtoupper($filter['operator'][0]), array('LIKE', 'STARTS_WITH'))) {
-          $query->fieldCondition($public_fields[$filter['public_field']]['property'], $public_fields[$filter['public_field']]['column'], $filter['value'][0], $filter['operator'][0]);
-          continue;
-        }
         for ($index = 0; $index < count($filter['value']); $index++) {
           $query->fieldCondition($public_fields[$filter['public_field']]['property'], $public_fields[$filter['public_field']]['column'], $filter['value'][$index], $filter['operator'][$index]);
         }

--- a/plugins/restful/RestfulDataProviderEFQ.php
+++ b/plugins/restful/RestfulDataProviderEFQ.php
@@ -209,6 +209,34 @@ abstract class RestfulDataProviderEFQ extends \RestfulBase implements \RestfulDa
   }
 
   /**
+   * Overrides \RestfulBase::isValidOperatorsForFilter().
+   */
+  protected static function isValidOperatorsForFilter(array $operators) {
+    $allowed_operators = array(
+      '=',
+      '>',
+      '<',
+      '>=',
+      '<=',
+      '<>',
+      '!=',
+      'IN',
+      'BETWEEN',
+      'LIKE',
+      'STARTS_WITH',
+    );
+
+    foreach ($operators as $operator) {
+      if (!in_array($operator, $allowed_operators)) {
+        throw new \RestfulBadRequestException(format_string('Operator "@operator" is not allowed for filtering on this resource. Allowed operators are: !allowed', array(
+          '@operator' => $operator,
+          '!allowed' => implode(', ', $allowed_operators),
+        )));
+      }
+    }
+  }
+
+  /**
    * Overrides \RestfulBase::isValidConjuctionForFilter().
    */
   protected static function isValidConjunctionForFilter($conjunction) {

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -356,6 +356,26 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
     $request['filter'] = array('integer_single' => '1');
     $result = $handler->get('', $request);
     $this->assertEqual($result[0]['id'], $nodes['abc'], 'Filter list by Single value field.');
+    
+    // LIKE operator.
+    $request['filter'] = array(
+      'label' => array(
+        'value' => '%nothe%',
+        'operator' => 'LIKE',
+      ),
+    );
+    $result = $handler->get('', $request);
+    $this->assertEqual($result[0]['id'], $nodes['another abc'], 'Filter list using LIKE operator.');
+
+    // STARTS_WITH operator.
+    $request['filter'] = array(
+      'label' => array(
+        'value' => 'las',
+        'operator' => 'STARTS_WITH',
+      ),
+    );
+    $result = $handler->get('', $request);
+    $this->assertEqual($result[0]['id'], $nodes['last'], 'Filter list using STARTS_WITH operator.');
 
     // Multiple value field.
     $request['filter'] = array(


### PR DESCRIPTION
This PR adds support for use of the LIKE and STARTS_WITH operators when adding a field condition to a query.
