### PR TITLE
Fix RestfulDataProviderVariable file docblock

### DIFF
--- a/plugins/restful/RestfulDataProviderVariable.php
+++ b/plugins/restful/RestfulDataProviderVariable.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \RestfulDataProviderDbQuery
+ * Contains \RestfulDataProviderVariable
  */
 
 use Drupal\restful\Exception\BadRequestException;


### PR DESCRIPTION
Incorrect class name was used in the docblock for this file.
