### PR TITLE
2.x Enable Render cache feature

### DIFF
--- a/modules/restful_example/src/Plugin/resource/Articles__1_1.php
+++ b/modules/restful_example/src/Plugin/resource/Articles__1_1.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful_example\Plugin\resource\Articles__1_1.
+ */
+
+namespace Drupal\restful_example\Plugin\resource;
+
+use Drupal\restful\Http\RequestInterface;
+use Drupal\restful\Plugin\resource\ResourceEntity;
+use Drupal\restful\Plugin\resource\ResourceInterface;
+
+/**
+ * Class Articles
+ * @package Drupal\restful\Plugin\resource
+ *
+ * @Resource(
+ *   name = "articles:1.1",
+ *   resource = "articles",
+ *   label = "Articles",
+ *   description = "Export the article content type render cache.",
+ *   authenticationTypes = TRUE,
+ *   authenticationOptional = TRUE,
+ *   dataProvider = {
+ *     "entityType": "node",
+ *     "bundles": {
+ *       "article"
+ *     },
+ *   },
+ *   renderCache = {
+ *     "render": TRUE
+ *   },
+ *   majorVersion = 1,
+ *   minorVersion = 1
+ * )
+ */
+class Articles__1_1 extends ResourceEntity implements ResourceInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function publicFields() {
+    $public_fields = parent::publicFields();
+    $public_fields['tags'] = array(
+      'property' => 'field_tags',
+      'resource' => array(
+        'name' => 'tags',
+        'majorVersion' => 1,
+        'minorVersion' => 0,
+      ),
+    );
+    $public_fields['status'] = array(
+      'property' => 'status',
+      'methods' => array(RequestInterface::METHOD_GET),
+    );
+    $public_fields['body'] = array(
+      'property' => 'body',
+      'formatter' => array(
+        'type' => 'text_summary_or_trimmed',
+        'settings' => array(
+          'trim_length' => 100,
+        ),
+      ),
+    );
+
+    return $public_fields;
+  }
+
+  /**
+   * Helper function that adds a prefix.
+   *
+   * @param mixed $value
+   *   The input value to be prefixed.
+   * @param string $prefix
+   *   The prefix to add.
+   *
+   * @return string
+   *   The prefixed value.
+   */
+  public function addPrefix($value, $prefix) {
+    return $prefix . $value;
+  }
+
+}

--- a/restful.module
+++ b/restful.module
@@ -12,7 +12,10 @@ use Drupal\restful\Exception\RestfulException;
 use Drupal\restful\Exception\ServiceUnavailableException;
 use Drupal\restful\Http\HttpHeader;
 use Drupal\restful\Http\RequestInterface;
+use Drupal\restful\Plugin\resource\CachedResource;
+use Drupal\restful\Plugin\resource\RateLimitedResource;
 use Drupal\restful\Plugin\resource\ResourceInterface;
+use Drupal\restful\RateLimit\RateLimitManager;
 use Drupal\restful\RestfulManager;
 
 /**
@@ -559,5 +562,20 @@ function restful_date_time_format_element_validate($element, &$form_state) {
       '%name' => $element['#title'],
       '!link' => l(t('\DateInterval format'), 'http://php.net/manual/en/class.dateinterval.php'),
     )));
+  }
+}
+
+/**
+ * Implements hook_restful_resource_alter().
+ */
+function restful_restful_resource_alter(ResourceInterface &$resource) {
+  $plugin_definition = $resource->getPluginDefinition();
+  // Check for the rate limit configuration.
+  if (!empty($plugin_definition['rateLimit'])) {
+    $resource = new RateLimitedResource($resource);
+  }
+  // Check for the rate limit configuration.
+  if (!empty($plugin_definition['renderCache'])) {
+    $resource = new CachedResource($resource);
   }
 }

--- a/restful.module
+++ b/restful.module
@@ -566,6 +566,9 @@ function restful_date_time_format_element_validate($element, &$form_state) {
 
 /**
  * Implements hook_restful_resource_alter().
+ *
+ * Decorate an existing resource with other services (e.g. rate limit and render
+ * cache).
  */
 function restful_restful_resource_alter(ResourceInterface &$resource) {
   $plugin_definition = $resource->getPluginDefinition();
@@ -574,7 +577,7 @@ function restful_restful_resource_alter(ResourceInterface &$resource) {
     $resource = new RateLimitedResource($resource);
   }
   // Check for the rate limit configuration.
-  if (!empty($plugin_definition['renderCache']) && !empty($plugin_definition['renderCache']['render'])) {
+  if (!empty($plugin_definition['renderCache']['render'])) {
     $resource = new CachedResource($resource);
   }
 }

--- a/restful.module
+++ b/restful.module
@@ -262,7 +262,7 @@ function restful_menu_access_callback($resource_name, $version_string = NULL) {
 
   try {
     return $resource_manager
-      ->getPlugin($resource_name . PluginBase::DERIVATIVE_SEPARATOR . implode('.', $versions))
+      ->getPlugin($resource_name . PluginBase::DERIVATIVE_SEPARATOR . implode('.', $versions), restful()->getRequest())
       ->access();
   }
   catch (RestfulException $e) {
@@ -575,7 +575,7 @@ function restful_restful_resource_alter(ResourceInterface &$resource) {
     $resource = new RateLimitedResource($resource);
   }
   // Check for the rate limit configuration.
-  if (!empty($plugin_definition['renderCache'])) {
+  if (!empty($plugin_definition['renderCache']) && !empty($plugin_definition['renderCache']['render'])) {
     $resource = new CachedResource($resource);
   }
 }

--- a/restful.module
+++ b/restful.module
@@ -12,10 +12,9 @@ use Drupal\restful\Exception\RestfulException;
 use Drupal\restful\Exception\ServiceUnavailableException;
 use Drupal\restful\Http\HttpHeader;
 use Drupal\restful\Http\RequestInterface;
-use Drupal\restful\Plugin\resource\CachedResource;
-use Drupal\restful\Plugin\resource\RateLimitedResource;
+use Drupal\restful\Plugin\resource\Decorators\CachedResource;
+use Drupal\restful\Plugin\resource\Decorators\RateLimitedResource;
 use Drupal\restful\Plugin\resource\ResourceInterface;
-use Drupal\restful\RateLimit\RateLimitManager;
 use Drupal\restful\RestfulManager;
 
 /**

--- a/restful.module
+++ b/restful.module
@@ -125,9 +125,9 @@ function restful_menu() {
     }
     $item = array(
       'title' => $plugin_definition['name'],
-      'access callback' => 'restful_menu_access_callback',
+      'access callback' => RestfulManager::FRONT_CONTROLLER_ACCESS_CALLBACK,
       'access arguments' => array($plugin_definition['resource']),
-      'page callback' => 'restful_menu_process_callback',
+      'page callback' => RestfulManager::FRONT_CONTROLLER_CALLBACK,
       'page arguments' => array($plugin_definition['resource']),
       'delivery callback' => 'restful_formatted_delivery',
       'type' => MENU_CALLBACK,

--- a/src/Authentication/AuthenticationManager.php
+++ b/src/Authentication/AuthenticationManager.php
@@ -10,6 +10,7 @@ namespace Drupal\restful\Authentication;
 use Drupal\restful\Exception\UnauthorizedException;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\AuthenticationPluginManager;
+use Drupal\restful\RestfulManager;
 
 class AuthenticationManager implements AuthenticationManagerInterface {
 
@@ -103,7 +104,7 @@ class AuthenticationManager implements AuthenticationManagerInterface {
 
     if (!$account) {
 
-      if ($this->plugins->count() && !$this->getIsOptional()) {
+      if (RestfulManager::isRestfulPath($request) && $this->plugins->count() && !$this->getIsOptional()) {
         // User didn't authenticate against any provider, so we throw an error.
         throw new UnauthorizedException('Bad credentials');
       }

--- a/src/Plugin/authentication/CookieAuthentication.php
+++ b/src/Plugin/authentication/CookieAuthentication.php
@@ -10,6 +10,7 @@ use Drupal\restful\Exception\BadRequestException;
 use Drupal\restful\Exception\ForbiddenException;
 use Drupal\restful\Http\Request;
 use Drupal\restful\Http\RequestInterface;
+use Drupal\restful\RestfulManager;
 
 /**
  * Class CookieAuthentication
@@ -44,7 +45,7 @@ class CookieAuthentication extends Authentication {
       throw new BadRequestException('No CSRF token passed in the HTTP header.');
     }
 
-    if (!drupal_valid_token($request->getApplicationData('csrf_token'), Authentication::TOKEN_VALUE)) {
+    if (RestfulManager::isRestfulPath($request) && !drupal_valid_token($request->getApplicationData('csrf_token'), Authentication::TOKEN_VALUE)) {
       throw new ForbiddenException('CSRF token validation failed.');
     }
 

--- a/src/Plugin/resource/CachedResource.php
+++ b/src/Plugin/resource/CachedResource.php
@@ -337,4 +337,11 @@ class CachedResource extends PluginBase implements ResourceInterface {
     return $cache_info;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getResourceMachineName() {
+    return $this->subject->getResourceMachineName();
+  }
+
 }

--- a/src/Plugin/resource/CachedResource.php
+++ b/src/Plugin/resource/CachedResource.php
@@ -8,9 +8,10 @@
 namespace Drupal\restful\Plugin\resource;
 
 use Drupal\Component\Plugin\PluginBase;
-use Drupal\restful\Exception\NotImplementedException;
+use Drupal\restful\Http\HttpHeader;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
+use Drupal\restful\Resource\ResourceManager;
 
 class CachedResource extends PluginBase implements ResourceInterface {
 
@@ -47,6 +48,8 @@ class CachedResource extends PluginBase implements ResourceInterface {
     // TODO: Implement the ResourceManager factory to use the CachedResource.
     $this->subject = $subject;
     $this->cacheController = $cache_controller ? $cache_controller : $this->newCacheObject();
+    $cache_info = $this->defaultCacheInfo();
+    $this->pluginDefinition['renderCache'] = $cache_info;
   }
 
   /**
@@ -81,34 +84,27 @@ class CachedResource extends PluginBase implements ResourceInterface {
       return $cache_object;
     }
 
-    $plugin_definition = $this->subject->getPluginDefinition();
-    $cache_info = $plugin_definition['renderCache'];
-    $class = $cache_info['class'];
-    if (empty($class)) {
-      $class = variable_get('cache_class_' . $cache_info['bin']);
-      if (empty($class)) {
-        $class = variable_get('cache_default_class', 'DrupalDatabaseCache');
-      }
+    $cache_info = $this->defaultCacheInfo();
+    $class_name = empty($cache_info['class']) ? NULL : $cache_info['class'];
+
+    // If there is no class name in the plugin definition, try to get it from
+    // the variables.
+    if (empty($class_name)) {
+      $class_name = variable_get('cache_class_' . $cache_info['bin']);
     }
-    $cache_object = new $class($cache_info['bin']);
+    // If it is still empty, then default to drupal's default cache class.
+    if (empty($class_name)) {
+      $class_name = variable_get('cache_default_class', 'DrupalDatabaseCache');
+    }
+    $cache_object = new $class_name($cache_info['bin']);
     return $cache_object;
   }
 
   /**
-   * Data provider factory.
-   *
-   * @return DataProviderInterface
-   *   The data provider for this resource.
-   *
-   * @throws NotImplementedException
+   * {@inheritdoc}
    */
   public function dataProviderFactory() {
-    $data_provider = $this->subject->dataProviderFactory();
-    // TODO: See how this connects to the CachedDataProvider.
-    $data_provider->addOptions(array(
-      'renderCache' => $this->getPluginDefinition()['renderCache'],
-    ));
-    return $data_provider;
+    return $this->subject->dataProviderFactory();
   }
 
   /**
@@ -156,12 +152,23 @@ class CachedResource extends PluginBase implements ResourceInterface {
     if (isset($this->dataProvider)) {
       return $this->dataProvider;
     }
-    $data_provider = $this->subject->getDataProvider();
+    $data_provider = $this->dataProviderFactory();
     if ($data_provider instanceof DataProvider\CachedDataProvider) {
       $this->dataProvider = $data_provider;
       return $this->dataProvider;
     }
     $this->dataProvider = new DataProvider\CachedDataProvider($data_provider, $this->getCacheController());
+    $plugin_definition = $this->subject->getPluginDefinition();
+    $this->dataProvider->addOptions(array(
+      'renderCache' => $this->defaultCacheInfo(),
+      'resource' => array(
+        'version' => array(
+          'major' => $plugin_definition['majorVersion'],
+          'minor' => $plugin_definition['minorVersion'],
+        ),
+        'name' => $plugin_definition['resource'],
+      ),
+    ));
     return $this->dataProvider;
   }
 
@@ -176,7 +183,9 @@ class CachedResource extends PluginBase implements ResourceInterface {
    * {@inheritdoc}
    */
   public function process() {
-    return $this->subject->process();
+    $path = $this->getPath();
+
+    return ResourceManager::executeCallback($this->getControllerFromPath($path), array($path));
   }
 
   /**
@@ -197,14 +206,24 @@ class CachedResource extends PluginBase implements ResourceInterface {
    * {@inheritdoc}
    */
   public function index($path) {
-    return $this->subject->index($path);
+    return $this->getDataProvider()->index();
   }
 
   /**
    * {@inheritdoc}
    */
   public function view($path) {
-    return $this->subject->view($path);
+    // TODO: This is duplicating the code from Resource::view
+    $ids = explode(static::IDS_SEPARATOR, $path);
+
+    // REST requires a canonical URL for every resource.
+    $canonical_path = $this->getDataProvider()->canonicalPath($path);
+    $this
+      ->getRequest()
+      ->getHeaders()
+      ->add(HttpHeader::create('Link', $this->versionedUrl($canonical_path, array(), FALSE) . '; rel="canonical"'));
+
+    return $this->getDataProvider()->viewMultiple($ids);
   }
 
   /**
@@ -289,6 +308,33 @@ class CachedResource extends PluginBase implements ResourceInterface {
    */
   public function access() {
     return $this->subject->access();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getControllerFromPath($path = NULL, ResourceInterface $resource = NULL) {
+    return $this->subject->getControllerFromPath($path, $resource ?: $this);
+  }
+
+  /**
+   * Gets the default cache info.
+   *
+   * @return array
+   *   The cache info.
+   */
+  protected function defaultCacheInfo() {
+    $plugin_definition = $this->subject->getPluginDefinition();
+    $cache_info = empty($plugin_definition['renderCache']) ? array() : $plugin_definition['renderCache'];
+    $cache_info += array(
+      'render' => variable_get('restful_render_cache', FALSE),
+      'class' => NULL,
+      'bin' => 'cache_restful',
+      'expire' => CACHE_PERMANENT,
+      'simple_invalidate' => TRUE,
+      'granularity' => DRUPAL_CACHE_PER_USER,
+    );
+    return $cache_info;
   }
 
 }

--- a/src/Plugin/resource/CachedResource.php
+++ b/src/Plugin/resource/CachedResource.php
@@ -9,6 +9,7 @@ namespace Drupal\restful\Plugin\resource;
 
 use Drupal\Component\Plugin\PluginBase;
 use Drupal\restful\Exception\NotImplementedException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
 
 class CachedResource extends PluginBase implements ResourceInterface {
@@ -42,7 +43,7 @@ class CachedResource extends PluginBase implements ResourceInterface {
    * @param \DrupalCacheInterface $cache_controller
    *   Injected cache manager.
    */
-  public function __construct(ResourceInterface $subject, \DrupalCacheInterface $cache_controller) {
+  public function __construct(ResourceInterface $subject, \DrupalCacheInterface $cache_controller = NULL) {
     // TODO: Implement the ResourceManager factory to use the CachedResource.
     $this->subject = $subject;
     $this->cacheController = $cache_controller ? $cache_controller : $this->newCacheObject();
@@ -102,7 +103,12 @@ class CachedResource extends PluginBase implements ResourceInterface {
    * @throws NotImplementedException
    */
   public function dataProviderFactory() {
-    return $this->subject->dataProviderFactory();
+    $data_provider = $this->subject->dataProviderFactory();
+    // TODO: See how this connects to the CachedDataProvider.
+    $data_provider->addOptions(array(
+      'renderCache' => $this->getPluginDefinition()['renderCache'],
+    ));
+    return $data_provider;
   }
 
   /**
@@ -241,6 +247,48 @@ class CachedResource extends PluginBase implements ResourceInterface {
    */
   public function versionedUrl($path = '', $options = array(), $version_string = TRUE) {
     return $this->subject->versionedUrl($path, $options, $version_string);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfiguration() {
+    return $this->subject->getConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setConfiguration(array $configuration) {
+    $this->subject->setConfiguration($configuration);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return $this->subject->defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    return $this->subject->calculateDependencies();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->subject->setRequest($request);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access() {
+    return $this->subject->access();
   }
 
 }

--- a/src/Plugin/resource/DataProvider/CachedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CachedDataProvider.php
@@ -166,7 +166,7 @@ class CachedDataProvider implements DataProviderInterface {
    * {@inheritdoc}
    */
   public function canonicalPath($path) {
-    $this->subject->canonicalPath($path);
+    return $this->subject->canonicalPath($path);
   }
 
   /**

--- a/src/Plugin/resource/DataProvider/CachedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CachedDataProvider.php
@@ -145,6 +145,7 @@ class CachedDataProvider implements CachedDataProviderInterface {
    * {@inheritdoc}
    */
   public function update($identifier, $object, $replace = TRUE) {
+    $this->clearRenderedCache($this->getContext($identifier));
     return $this->subject->update($identifier, $object, $replace);
   }
 
@@ -181,10 +182,8 @@ class CachedDataProvider implements CachedDataProviderInterface {
    * @see DataProviderEntity::view()
    */
   protected function getRenderedCache(array $context = array()) {
-    $options = $this->getOptions();
-    $cache_info = $options['renderCache'];
-    if (!$cache_info['render']) {
-      return NULL;
+    if (!$this->isCacheEnabled()) {
+      return;
     }
 
     $cid = $this->generateCacheId($context);
@@ -333,17 +332,44 @@ class CachedDataProvider implements CachedDataProviderInterface {
    * @return array
    *   The rendered entity as returned by \RestfulEntityInterface::viewEntity().
    *
-   * @see \RestfulEntityInterface::viewEntity().
+   * @see static::view()
    */
   protected function setRenderedCache($data, array $context = array()) {
-    $options = $this->getOptions();
-    $cache_info = $options['renderCache'];
-    if (!$cache_info['render']) {
+    if (!$this->isCacheEnabled()) {
       return;
     }
 
     $cid = $this->generateCacheId($context);
-    $this->cacheController->set($cid, $data, $cache_info['expire']);
+    $this->cacheController->set($cid, $data, $this->getOptions()['renderCache']['expire']);
+  }
+
+  /**
+   * Clear an entry from the rendered cache.
+   *
+   * @param array $context
+   *   An associative array with additional information to build the cache ID.
+   *
+   * @see static::view()
+   */
+  protected function clearRenderedCache(array $context = array()) {
+    if (!$this->isCacheEnabled()) {
+      return;
+    }
+
+    $cid = $this->generateCacheId($context);
+    $this->cacheController->clear($cid);
+  }
+
+  /**
+   * Helper function that checks if cache is enabled.
+   *
+   * @return bool
+   *   TRUE if the resource has cache enabled.
+   */
+  protected function isCacheEnabled() {
+    $options = $this->getOptions();
+    $cache_info = $options['renderCache'];
+    return isset($cache_info['render']);
   }
 
 }

--- a/src/Plugin/resource/DataProvider/CachedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CachedDataProvider.php
@@ -265,6 +265,8 @@ class CachedDataProvider implements CachedDataProviderInterface {
 
   /**
    * {@inheritdoc}
+   *
+   * @see https://api.drupal.org/api/drupal/includes%21cache.inc/function/DrupalCacheInterface%3A%3Aclear/7
    */
   public function cacheInvalidate($cid) {
     $options = $this->getOptions();

--- a/src/Plugin/resource/DataProvider/CachedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CachedDataProvider.php
@@ -181,12 +181,6 @@ class CachedDataProvider implements DataProviderInterface {
    * @see DataProviderEntity::view()
    */
   protected function getRenderedCache(array $context = array()) {
-    // TODO: The render cache information will not be in the data provider
-    // options annotation. That means that it will not make it through to this
-    // class from the ResourceInterface object. We need to add
-    // $dataProvider->addOptions(array(
-    // 'renderCache' => Resource::getPluginDefinition()['renderCache']),
-    // ).
     $options = $this->getOptions();
     $cache_info = $options['renderCache'];
     if (!$cache_info['render']) {

--- a/src/Plugin/resource/DataProvider/CachedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CachedDataProvider.php
@@ -153,6 +153,7 @@ class CachedDataProvider implements CachedDataProviderInterface {
    * {@inheritdoc}
    */
   public function remove($identifier) {
+    $this->clearRenderedCache($this->getContext($identifier));
     $this->subject->remove($identifier);
   }
 
@@ -183,7 +184,7 @@ class CachedDataProvider implements CachedDataProviderInterface {
    */
   protected function getRenderedCache(array $context = array()) {
     if (!$this->isCacheEnabled()) {
-      return;
+      return NULL;
     }
 
     $cid = $this->generateCacheId($context);

--- a/src/Plugin/resource/DataProvider/CachedDataProviderInterface.php
+++ b/src/Plugin/resource/DataProvider/CachedDataProviderInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\restful\Plugin\resource\DataProvider\CachedDataProviderInterface.
+ */
+
+namespace Drupal\restful\Plugin\resource\DataProvider;
+
+
+interface CachedDataProviderInterface extends DataProviderInterface {
+
+  /**
+   * Invalidates cache for a certain entity.
+   *
+   * @param string $cid
+   *   The wildcard cache id to invalidate. Do not add * for the wildcard.
+   */
+  public function cacheInvalidate($cid);
+
+}

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -20,6 +20,7 @@ use Drupal\restful\Exception\BadRequestException;
 use Drupal\restful\Exception\UnprocessableEntityException;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldInterface;
 use Drupal\restful\Plugin\resource\Resource;
+use Drupal\restful\Plugin\resource\ResourceInterface;
 use Drupal\restful\Resource\ResourceManager;
 
 class DataProviderEntity extends DataProvider implements DataProviderEntityInterface {
@@ -128,6 +129,9 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
    * {@inheritdoc}
    */
   public function getContext($identifier) {
+    if (is_array($identifier)) {
+      $identifier = implode(ResourceInterface::IDS_SEPARATOR, $identifier);
+    }
     return array(
       'et' => $this->entityType,
       'ei' => $identifier,

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -130,6 +130,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
    */
   public function getContext($identifier) {
     if (is_array($identifier)) {
+      // Like in https://example.org/api/articles/1,2,3.
       $identifier = implode(ResourceInterface::IDS_SEPARATOR, $identifier);
     }
     return array(

--- a/src/Plugin/resource/Decorators/CachedResource.php
+++ b/src/Plugin/resource/Decorators/CachedResource.php
@@ -2,25 +2,19 @@
 
 /**
  * @file
- * Contains \Drupal\restful\Plugin\resource\CachedResource
+ * Contains \Drupal\restful\Plugin\resource\Decorators\CachedResource
  */
 
-namespace Drupal\restful\Plugin\resource;
+namespace Drupal\restful\Plugin\resource\Decorators;
 
-use Drupal\Component\Plugin\PluginBase;
 use Drupal\restful\Http\HttpHeader;
-use Drupal\restful\Http\RequestInterface;
+use Drupal\restful\Plugin\resource\DataProvider\CachedDataProvider;
+use Drupal\restful\Plugin\resource\DataProvider\CachedDataProviderInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
+use Drupal\restful\Plugin\resource\ResourceInterface;
 use Drupal\restful\Resource\ResourceManager;
 
-class CachedResource extends PluginBase implements ResourceInterface {
-
-  /**
-   * The decorated resource.
-   *
-   * @var ResourceInterface
-   */
-  protected $subject;
+class CachedResource extends ResourceDecoratorBase implements CachedResourceInterface {
 
   /**
    * Cache controller object.
@@ -53,10 +47,7 @@ class CachedResource extends PluginBase implements ResourceInterface {
   }
 
   /**
-   * Getter for $cacheController.
-   *
-   * @return \DrupalCacheInterface
-   *   The cache object.
+   * {@inheritdoc}
    */
   public function getCacheController() {
     return $this->cacheController;
@@ -103,61 +94,17 @@ class CachedResource extends PluginBase implements ResourceInterface {
   /**
    * {@inheritdoc}
    */
-  public function dataProviderFactory() {
-    return $this->subject->dataProviderFactory();
-  }
-
-  /**
-   * Proxy method to get the account from the rateLimitManager.
-   *
-   * {@inheritdoc}
-   */
-  public function getAccount($cache = TRUE) {
-    return $this->subject->getAccount();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getRequest() {
-    return $this->subject->getRequest();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getPath() {
-    return $this->subject->getPath();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setPath($path) {
-    $this->subject->setPath($path);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getFieldDefinitions() {
-    return $this->subject->getFieldDefinitions();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getDataProvider() {
     // Make sure that this returns a cached data provider.
     if (isset($this->dataProvider)) {
       return $this->dataProvider;
     }
     $data_provider = $this->dataProviderFactory();
-    if ($data_provider instanceof DataProvider\CachedDataProvider) {
+    if ($data_provider instanceof CachedDataProviderInterface) {
       $this->dataProvider = $data_provider;
       return $this->dataProvider;
     }
-    $this->dataProvider = new DataProvider\CachedDataProvider($data_provider, $this->getCacheController());
+    $this->dataProvider = new CachedDataProvider($data_provider, $this->getCacheController());
     $plugin_definition = $this->subject->getPluginDefinition();
     $this->dataProvider->addOptions(array(
       'renderCache' => $this->defaultCacheInfo(),
@@ -175,38 +122,10 @@ class CachedResource extends PluginBase implements ResourceInterface {
   /**
    * {@inheritdoc}
    */
-  public function getResourceName() {
-    return $this->subject->getResourceName();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function process() {
     $path = $this->getPath();
 
     return ResourceManager::executeCallback($this->getControllerFromPath($path), array($path));
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function controllersInfo() {
-    return $this->subject->controllersInfo();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getControllers() {
-    return $this->subject->getControllers();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function index($path) {
-    return $this->getDataProvider()->index();
   }
 
   /**
@@ -224,97 +143,6 @@ class CachedResource extends PluginBase implements ResourceInterface {
       ->add(HttpHeader::create('Link', $this->versionedUrl($canonical_path, array(), FALSE) . '; rel="canonical"'));
 
     return $this->getDataProvider()->viewMultiple($ids);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function create($path) {
-    return $this->subject->create($path);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function update($path) {
-    return $this->subject->update($path);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function replace($path) {
-    return $this->subject->replace($path);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function remove($path) {
-    $this->subject->remove($path);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getVersion() {
-    return $this->subject->getVersion();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function versionedUrl($path = '', $options = array(), $version_string = TRUE) {
-    return $this->subject->versionedUrl($path, $options, $version_string);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getConfiguration() {
-    return $this->subject->getConfiguration();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setConfiguration(array $configuration) {
-    $this->subject->setConfiguration($configuration);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function defaultConfiguration() {
-    return $this->subject->defaultConfiguration();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function calculateDependencies() {
-    return $this->subject->calculateDependencies();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setRequest(RequestInterface $request) {
-    $this->subject->setRequest($request);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function access() {
-    return $this->subject->access();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getControllerFromPath($path = NULL, ResourceInterface $resource = NULL) {
-    return $this->subject->getControllerFromPath($path, $resource ?: $this);
   }
 
   /**

--- a/src/Plugin/resource/Decorators/CachedResourceInterface.php
+++ b/src/Plugin/resource/Decorators/CachedResourceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Plugin\resource\Decorators\CachedResourceInterface.
+ */
+
+namespace Drupal\restful\Plugin\resource\Decorators;
+
+
+interface CachedResourceInterface extends ResourceDecoratorInterface {
+
+
+  /**
+   * Getter for $cacheController.
+   *
+   * @return \DrupalCacheInterface
+   *   The cache object.
+   */
+  public function getCacheController();
+
+}

--- a/src/Plugin/resource/Decorators/RateLimitedResource.php
+++ b/src/Plugin/resource/Decorators/RateLimitedResource.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Plugin\resource\Decorators\RateLimitedResource
+ */
+
+namespace Drupal\restful\Plugin\resource\Decorators;
+
+use Drupal\restful\Plugin\resource\ResourceInterface;
+use Drupal\restful\RateLimit\RateLimitManager;
+
+class RateLimitedResource extends ResourceDecoratorBase implements ResourceDecoratorInterface {
+
+  /**
+   * Authentication manager.
+   *
+   * @var RateLimitManager
+   */
+  protected $rateLimitManager;
+
+  /**
+   * Constructs a Drupal\Component\Plugin\PluginBase object.
+   *
+   * @param ResourceInterface $subject
+   *   The decorated object.
+   * @param RateLimitManager $rate_limit_manager
+   *   Injected rate limit manager.
+   */
+  public function __construct(ResourceInterface $subject, RateLimitManager $rate_limit_manager = NULL) {
+    $this->subject = $subject;
+    $plugin_definition = $subject->getPluginDefinition();
+    $this->rateLimitManager = $rate_limit_manager ? $rate_limit_manager : new RateLimitManager($this, $plugin_definition['rateLimit']);
+  }
+
+  /**
+   * Setter for $rateLimitManager.
+   *
+   * @param RateLimitManager $rate_limit_manager
+   *   The rate limit manager.
+   */
+  protected function setRateLimitManager(RateLimitManager $rate_limit_manager) {
+    $this->rateLimitManager = $rate_limit_manager;
+  }
+
+  /**
+   * Getter for $rate_limit_manager.
+   *
+   * @return RateLimitManager
+   *   The rate limit manager.
+   */
+  protected function getRateLimitManager() {
+    return $this->rateLimitManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process() {
+    // This will throw the appropriate exception if needed.
+    $this->getRateLimitManager()->checkRateLimit($this->getRequest());
+    return $this->subject->process();
+  }
+
+}

--- a/src/Plugin/resource/Decorators/ResourceDecoratorBase.php
+++ b/src/Plugin/resource/Decorators/ResourceDecoratorBase.php
@@ -2,22 +2,19 @@
 
 /**
  * @file
- * Contains \Drupal\restful\Plugin\resource\RateLimitedResource
+ * Contains \Drupal\restful\Plugin\resource\Decorators\ResourceDecoratorBase.
  */
 
-namespace Drupal\restful\Plugin\resource;
+namespace Drupal\restful\Plugin\resource\Decorators;
+
 
 use Drupal\Component\Plugin\PluginBase;
-use Drupal\restful\Exception\BadRequestException;
-use Drupal\restful\Exception\ForbiddenException;
-use Drupal\restful\Exception\GoneException;
-use Drupal\restful\Exception\ServerConfigurationException;
-use Drupal\restful\Http\RequestInterface;
-use Drupal\restful\RateLimit\RateLimitManager;
 use Drupal\restful\Exception\NotImplementedException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
+use Drupal\restful\Plugin\resource\ResourceInterface;
 
-class RateLimitedResource extends PluginBase implements ResourceInterface {
+abstract class ResourceDecoratorBase extends PluginBase implements ResourceDecoratorInterface {
 
   /**
    * The decorated resource.
@@ -27,44 +24,13 @@ class RateLimitedResource extends PluginBase implements ResourceInterface {
   protected $subject;
 
   /**
-   * Authentication manager.
+   * Gets the decorated resource.
    *
-   * @var RateLimitManager
+   * @return ResourceInterface
+   *   The underlying resource.
    */
-  protected $rateLimitManager;
-
-  /**
-   * Constructs a Drupal\Component\Plugin\PluginBase object.
-   *
-   * @param ResourceInterface $subject
-   *   The decorated object.
-   * @param RateLimitManager $rate_limit_manager
-   *   Injected rate limit manager.
-   */
-  public function __construct(ResourceInterface $subject, RateLimitManager $rate_limit_manager = NULL) {
-    $this->subject = $subject;
-    $plugin_definition = $subject->getPluginDefinition();
-    $this->rateLimitManager = $rate_limit_manager ? $rate_limit_manager : new RateLimitManager($this, $plugin_definition['rateLimit']);
-  }
-
-  /**
-   * Setter for $rateLimitManager.
-   *
-   * @param RateLimitManager $rate_limit_manager
-   *   The rate limit manager.
-   */
-  protected function setRateLimitManager(RateLimitManager $rate_limit_manager) {
-    $this->rateLimitManager = $rate_limit_manager;
-  }
-
-  /**
-   * Getter for $rate_limit_manager.
-   *
-   * @return RateLimitManager
-   *   The rate limit manager.
-   */
-  protected function getRateLimitManager() {
-    return $this->rateLimitManager;
+  public function getDecoratedResource() {
+    return $this->subject;
   }
 
   /**
@@ -134,8 +100,6 @@ class RateLimitedResource extends PluginBase implements ResourceInterface {
    * {@inheritdoc}
    */
   public function process() {
-    // This will throw the appropriate exception if needed.
-    $this->getRateLimitManager()->checkRateLimit($this->getRequest());
     return $this->subject->process();
   }
 
@@ -255,7 +219,7 @@ class RateLimitedResource extends PluginBase implements ResourceInterface {
    * {@inheritdoc}
    */
   public function getControllerFromPath($path = NULL, ResourceInterface $resource = NULL) {
-    return $this->subject->getControllerFromPath($resource ?: $this);
+    return $this->subject->getControllerFromPath($path, $resource ?: $this);
   }
 
   /**

--- a/src/Plugin/resource/Decorators/ResourceDecoratorBase.php
+++ b/src/Plugin/resource/Decorators/ResourceDecoratorBase.php
@@ -24,13 +24,21 @@ abstract class ResourceDecoratorBase extends PluginBase implements ResourceDecor
   protected $subject;
 
   /**
-   * Gets the decorated resource.
-   *
-   * @return ResourceInterface
-   *   The underlying resource.
+   * {@inheritdoc}
    */
   public function getDecoratedResource() {
     return $this->subject;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPrimaryResource() {
+    $resource = $this->getDecoratedResource();
+    while ($resource instanceof ResourceDecoratorInterface) {
+      $resource = $resource->getDecoratedResource();
+    }
+    return $resource;
   }
 
   /**

--- a/src/Plugin/resource/Decorators/ResourceDecoratorInterface.php
+++ b/src/Plugin/resource/Decorators/ResourceDecoratorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Plugin\resource\Decorators\ResourceDecoratorInterface.
+ */
+
+namespace Drupal\restful\Plugin\resource\Decorators;
+
+
+use Drupal\restful\Plugin\resource\ResourceInterface;
+
+interface ResourceDecoratorInterface extends ResourceInterface {
+
+  /**
+   * Gets the decorated resource.
+   *
+   * @return ResourceInterface
+   *   The underlying resource.
+   */
+  public function getDecoratedResource();
+
+}

--- a/src/Plugin/resource/Decorators/ResourceDecoratorInterface.php
+++ b/src/Plugin/resource/Decorators/ResourceDecoratorInterface.php
@@ -20,4 +20,12 @@ interface ResourceDecoratorInterface extends ResourceInterface {
    */
   public function getDecoratedResource();
 
+  /**
+   * Gets the primary resource, the one that is not a decorator.
+   *
+   * @return ResourceInterface
+   *   The resource.
+   */
+  public function getPrimaryResource();
+
 }

--- a/src/Plugin/resource/FilesUpload__1_0.php
+++ b/src/Plugin/resource/FilesUpload__1_0.php
@@ -10,6 +10,7 @@ namespace Drupal\restful\Plugin\resource;
 use Drupal\restful\Exception\NotImplementedException;
 use Drupal\restful\Exception\UnauthorizedException;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
+use Drupal\restful\Plugin\resource\Field\ResourceFieldEntityInterface;
 
 /**
  * Class FilesUpload__1_0

--- a/src/Plugin/resource/RateLimitedResource.php
+++ b/src/Plugin/resource/RateLimitedResource.php
@@ -8,6 +8,10 @@
 namespace Drupal\restful\Plugin\resource;
 
 use Drupal\Component\Plugin\PluginBase;
+use Drupal\restful\Exception\BadRequestException;
+use Drupal\restful\Exception\ForbiddenException;
+use Drupal\restful\Exception\GoneException;
+use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\RateLimit\RateLimitManager;
 use Drupal\restful\Exception\NotImplementedException;
@@ -245,6 +249,13 @@ class RateLimitedResource extends PluginBase implements ResourceInterface {
    */
   public function access() {
     return $this->subject->access();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getControllerFromPath($path = NULL, ResourceInterface $resource = NULL) {
+    return $this->subject->getControllerFromPath($resource ?: $this);
   }
 
 }

--- a/src/Plugin/resource/RateLimitedResource.php
+++ b/src/Plugin/resource/RateLimitedResource.php
@@ -258,4 +258,11 @@ class RateLimitedResource extends PluginBase implements ResourceInterface {
     return $this->subject->getControllerFromPath($resource ?: $this);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getResourceMachineName() {
+    return $this->subject->getResourceMachineName();
+  }
+
 }

--- a/src/Plugin/resource/RateLimitedResource.php
+++ b/src/Plugin/resource/RateLimitedResource.php
@@ -8,6 +8,7 @@
 namespace Drupal\restful\Plugin\resource;
 
 use Drupal\Component\Plugin\PluginBase;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\RateLimit\RateLimitManager;
 use Drupal\restful\Exception\NotImplementedException;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
@@ -36,9 +37,10 @@ class RateLimitedResource extends PluginBase implements ResourceInterface {
    * @param RateLimitManager $rate_limit_manager
    *   Injected rate limit manager.
    */
-  public function __construct(ResourceInterface $subject, RateLimitManager $rate_limit_manager) {
+  public function __construct(ResourceInterface $subject, RateLimitManager $rate_limit_manager = NULL) {
     $this->subject = $subject;
-    $this->rateLimitManager = $rate_limit_manager;
+    $plugin_definition = $subject->getPluginDefinition();
+    $this->rateLimitManager = $rate_limit_manager ? $rate_limit_manager : new RateLimitManager($this, $plugin_definition['rateLimit']);
   }
 
   /**
@@ -194,6 +196,55 @@ class RateLimitedResource extends PluginBase implements ResourceInterface {
    */
   public function getVersion() {
     return $this->subject->getVersion();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function versionedUrl($path = '', $options = array(), $version_string = TRUE) {
+    return $this->subject->versionedUrl($path, $options, $version_string);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfiguration() {
+    return $this->subject->getConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setConfiguration(array $configuration) {
+    $this->subject->setConfiguration($configuration);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return $this->subject->defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    return $this->subject->calculateDependencies();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->subject->setRequest($request);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access() {
+    return $this->subject->access();
   }
 
 }

--- a/src/Plugin/resource/Resource.php
+++ b/src/Plugin/resource/Resource.php
@@ -172,11 +172,6 @@ abstract class Resource extends PluginBase implements ResourceInterface {
 
   /**
    * {@inheritdoc}
-   *
-   * Provide sensible defaults for the HTTP methods. These methods (index,
-   * create, view, update and delete) are not implemented in this layer but
-   * they are guaranteed to exist because we are enforcing that all restful
-   * resources are an instance of \RestfulDataProviderInterface.
    */
   public function controllersInfo() {
     return array(

--- a/src/Plugin/resource/Resource.php
+++ b/src/Plugin/resource/Resource.php
@@ -150,6 +150,14 @@ abstract class Resource extends PluginBase implements ResourceInterface {
   /**
    * {@inheritdoc}
    */
+  public function getResourceMachineName() {
+    $definition = $this->getPluginDefinition();
+    return $definition['resource'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function defaultConfiguration() {
     return array(
       'request' => restful()->getRequest(),

--- a/src/Plugin/resource/ResourceInterface.php
+++ b/src/Plugin/resource/ResourceInterface.php
@@ -272,7 +272,7 @@ interface ResourceInterface extends PluginInspectionInterface, ConfigurablePlugi
   public function access();
 
   /**
-   * Return the controller from a given path.
+   * Return the controller for a given path.
    *
    * @param string $path
    *   (optional) The path to use. If none is provided the path from the

--- a/src/Plugin/resource/ResourceInterface.php
+++ b/src/Plugin/resource/ResourceInterface.php
@@ -114,6 +114,14 @@ interface ResourceInterface extends PluginInspectionInterface, ConfigurablePlugi
   public function getResourceName();
 
   /**
+   * Gets the resource machine name.
+   *
+   * @return string
+   *   The machine name.
+   */
+  public function getResourceMachineName();
+
+  /**
    * Controller function that passes the data along and executes right action.
    *
    * @return array

--- a/src/Plugin/resource/ResourceInterface.php
+++ b/src/Plugin/resource/ResourceInterface.php
@@ -9,12 +9,22 @@ namespace Drupal\restful\Plugin\resource;
 
 use Drupal\Component\Plugin\ConfigurablePluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\restful\Exception\BadRequestException;
+use Drupal\restful\Exception\ForbiddenException;
+use Drupal\restful\Exception\GoneException;
 use Drupal\restful\Exception\NotImplementedException;
+use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldCollectionInterface;
+use Drupal\restful\Resource\ResourceManager;
 
 interface ResourceInterface extends PluginInspectionInterface, ConfigurablePluginInterface {
+
+  /**
+   * The string that separates multiple ids.
+   */
+  const IDS_SEPARATOR = ',';
 
   /**
    * Data provider factory.
@@ -252,5 +262,28 @@ interface ResourceInterface extends PluginInspectionInterface, ConfigurablePlugi
    *   otherwise.
    */
   public function access();
+
+  /**
+   * Return the controller from a given path.
+   *
+   * @param string $path
+   *   (optional) The path to use. If none is provided the path from the
+   *   resource will be used.
+   * @param ResourceInterface $resource
+   *   (optional) Use the passed in resource instead of $this. This is mainly
+   *   used by decorator resources.
+   *
+   * @return callable
+   *   A callable as expected by ResourceManager::executeCallback.
+   *
+   * @throws BadRequestException
+   * @throws ForbiddenException
+   * @throws GoneException
+   * @throws NotImplementedException
+   * @throws ServerConfigurationException
+   *
+   * @see ResourceManager::executeCallback()
+   */
+  public function getControllerFromPath($path = NULL, ResourceInterface $resource = NULL);
 
 }

--- a/src/RateLimit/RateLimitManager.php
+++ b/src/RateLimit/RateLimitManager.php
@@ -12,6 +12,7 @@ use Drupal\restful\Exception\FloodException;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\RateLimitPluginManager;
 use Drupal\restful\Plugin\rate_limit\RateLimit;
+use Drupal\restful\Plugin\resource\ResourceInterface;
 
 class RateLimitManager implements RateLimitManagerInterface {
 
@@ -60,7 +61,7 @@ class RateLimitManager implements RateLimitManagerInterface {
   /**
    * Constructor for RateLimitManager.
    *
-   * @param \RestfulBase $resource
+   * @param ResourceInterface $resource
    *   Resource being checked.
    * @param array $plugin_options
    *   Array of options keyed by plugin id.
@@ -69,7 +70,7 @@ class RateLimitManager implements RateLimitManagerInterface {
    * @param RateLimitPluginManager $manager
    *   The plugin manager.
    */
-  public function __construct(\RestfulBase $resource, $plugin_options, $account = NULL, RateLimitPluginManager $manager = NULL) {
+  public function __construct(ResourceInterface $resource, array $plugin_options, $account = NULL, RateLimitPluginManager $manager = NULL) {
     $this->resource = $resource;
     $this->account = $account ? $account : drupal_anonymous_user();
     $manager = $manager ?: RateLimitPluginManager::create();

--- a/src/Resource/ResourceManager.php
+++ b/src/Resource/ResourceManager.php
@@ -69,9 +69,6 @@ class ResourceManager implements ResourceManagerInterface {
   public function getPlugin($instance_id) {
     /** @var ResourceInterface $plugin */
     $plugin = $this->plugins->get($instance_id);
-    $plugin->setConfiguration(array(
-      'request' => $this->request,
-    ));
     return $plugin;
   }
 

--- a/src/Resource/ResourceManager.php
+++ b/src/Resource/ResourceManager.php
@@ -66,9 +66,12 @@ class ResourceManager implements ResourceManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getPlugin($instance_id) {
+  public function getPlugin($instance_id, RequestInterface $request = NULL) {
     /** @var ResourceInterface $plugin */
     $plugin = $this->plugins->get($instance_id);
+    if ($request) {
+      $plugin->setRequest($request);
+    }
     return $plugin;
   }
 

--- a/src/Resource/ResourceManager.php
+++ b/src/Resource/ResourceManager.php
@@ -183,6 +183,14 @@ class ResourceManager implements ResourceManagerInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public static function getPageCallback($path = NULL) {
+    $router_item = static::getMenuItem($path);
+    return isset($router_item['page_callback']) ? $router_item['page_callback'] : NULL;
+  }
+
+  /**
    * Parses the version string.
    *
    * @param string $version
@@ -224,7 +232,7 @@ class ResourceManager implements ResourceManagerInterface {
    * @return array
    *   The page arguments.
    *
-   * @see menu_get_item().
+   * @see menu_get_item()
    */
   protected static function getMenuItem($path = NULL) {
     $router_items = &drupal_static(__METHOD__);

--- a/src/Resource/ResourceManagerInterface.php
+++ b/src/Resource/ResourceManagerInterface.php
@@ -111,4 +111,15 @@ interface ResourceManagerInterface {
    */
   public function getResourceLastVersion($resource_name, $major_version = NULL);
 
+  /**
+   * Get the menu item callback.
+   *
+   * @param string $path
+   *   The path to match the router item. Leave it empty to use the current one.
+   *
+   * @return string
+   *   The callback function to be executed.
+   */
+  public static function getPageCallback($path = NULL);
+
 }

--- a/src/Resource/ResourceManagerInterface.php
+++ b/src/Resource/ResourceManagerInterface.php
@@ -9,6 +9,7 @@ namespace Drupal\restful\Resource;
 
 use \Drupal\restful\Exception\RestfulException;
 use \Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Http\RequestInterface;
 use \Drupal\restful\Plugin\ResourcePluginManager;
 use \Drupal\restful\Plugin\resource\ResourceInterface;
 use \Drupal\Component\Plugin\Exception\PluginNotFoundException;
@@ -28,6 +29,8 @@ interface ResourceManagerInterface {
    *
    * @param string $instance_id
    *   The instance ID.
+   * @param RequestInterface $request
+   *   The request object.
    *
    * @return ResourceInterface
    *   The plugin.
@@ -35,7 +38,7 @@ interface ResourceManagerInterface {
    * @throws PluginNotFoundException
    *   If the plugin instance cannot be found.
    */
-  public function getPlugin($instance_id);
+  public function getPlugin($instance_id, RequestInterface $request = NULL);
 
   /**
    * Gets the major and minor version for the current request.

--- a/src/Resource/ResourcePluginCollection.php
+++ b/src/Resource/ResourcePluginCollection.php
@@ -7,7 +7,9 @@
 
 namespace Drupal\restful\Resource;
 
+use Drupal\Component\Plugin\PluginManagerInterface;
 use Drupal\Core\Plugin\DefaultLazyPluginCollection;
+use Drupal\restful\Http\RequestInterface;
 
 class ResourcePluginCollection extends DefaultLazyPluginCollection {
 
@@ -17,5 +19,44 @@ class ResourcePluginCollection extends DefaultLazyPluginCollection {
    * @var string
    */
   protected $pluginKey = 'name';
+
+  /**
+   * The request object.
+   *
+   * @var RequestInterface
+   */
+  protected $request;
+
+  /**
+   * Constructs a ResourcePluginCollection object.
+   *
+   * @param \Drupal\Component\Plugin\PluginManagerInterface $manager
+   *   The manager to be used for instantiating plugins.
+   * @param array $configurations
+   *   (optional) An associative array containing the initial configuration for
+   *   each plugin in the collection, keyed by plugin instance ID.
+   * @param RequestInterface $request
+   *   (optional) The request object.
+   */
+  public function __construct(PluginManagerInterface $manager, array $configurations = array(), RequestInterface $request = NULL) {
+    parent::__construct($manager, $configurations);
+    $this->request = $request;
+  }
+
+
+  /**
+   * Overwrites LazyPluginCollection::get().
+   */
+  public function &get($instance_id) {
+    /** @var \Drupal\restful\Plugin\resource\ResourceInterface $resource */
+    $resource = parent::get($instance_id);
+    $resource->setConfiguration(array(
+      'request' => $this->request,
+    ));
+    // Allow altering the resource, this way we can read the resource's
+    // definition to return a different class that is using composition.
+    drupal_alter('restful_resource', $resource);
+    return $resource;
+  }
 
 }

--- a/src/RestfulManager.php
+++ b/src/RestfulManager.php
@@ -168,4 +168,16 @@ class RestfulManager {
     return $this->response;
   }
 
+  /**
+   * Checks if the passed in request belongs to RESTful.
+   *
+   * @param RequestInterface $request
+   *   The path to check.
+   *
+   * @return bool
+   *   TRUE if the path belongs to RESTful.
+   */
+  public static function isRestfulPath(RequestInterface $request) {
+    return strpos($request->getPath(), variable_get('restful_hook_menu_base_path', 'api')) === 0;
+  }
 }

--- a/src/RestfulManager.php
+++ b/src/RestfulManager.php
@@ -19,6 +19,16 @@ use Drupal\restful\Resource\ResourceManagerInterface;
 class RestfulManager {
 
   /**
+   * The front controller callback function.
+   */
+  const FRONT_CONTROLLER_CALLBACK = 'restful_menu_process_callback';
+
+  /**
+   * The front controller access callback function.
+   */
+  const FRONT_CONTROLLER_ACCESS_CALLBACK = 'restful_menu_access_callback';
+
+  /**
    * The request object.
    *
    * @var RequestInterface
@@ -47,9 +57,10 @@ class RestfulManager {
   protected $formatterManager;
 
   /**
-   * Accessor for the request.ç
+   * Accessor for the request.
    *
    * @return RequestInterface
+   *   The request object.
    */
   public function getRequest() {
     return $this->request;
@@ -59,6 +70,7 @@ class RestfulManager {
    * Mutator for the request.
    *
    * @param RequestInterface $request
+   *   The request object.
    */
   public function setRequest(RequestInterface $request) {
     $this->request = $request;
@@ -68,6 +80,7 @@ class RestfulManager {
    * Accessor for the response.
    *
    * @return ResponseInterface
+   *   The response object.
    */
   public function getResponse() {
     return $this->response;
@@ -77,6 +90,7 @@ class RestfulManager {
    * Mutator for the response.
    *
    * @param ResponseInterface $response
+   *   The response object.
    */
   public function setResponse(ResponseInterface $response) {
     $this->response = $response;
@@ -178,6 +192,7 @@ class RestfulManager {
    *   TRUE if the path belongs to RESTful.
    */
   public static function isRestfulPath(RequestInterface $request) {
-    return strpos($request->getPath(), variable_get('restful_hook_menu_base_path', 'api')) === 0;
+    return ResourceManager::getPageCallback($request->getPath(FALSE)) == static::FRONT_CONTROLLER_CALLBACK;
   }
+
 }


### PR DESCRIPTION
This PR will make sure that we can decorate resources to stack functionality to a resource. For now there are 2 decorators:
- `CachedResource`: adds caching capabilities.
- `RateLimitedResource`: adds rate limit capabilities.

That is specially good because it allows other modules to add new decorators and cherry pick the decorators to use (via the annotation configuration). Yes! (this was one of the big points of the re-architecture).

Also, this PR fixes render cache. With the increased complexity, that comes from the greater flexibility, the render cache is even more important. See a basic benchmark below.
