### PR TITLE
only access_token is allowed when authenticating a user

### DIFF
--- a/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
+++ b/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
@@ -30,6 +30,7 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
     $query = new EntityFieldQuery();
     $result = $query
       ->entityCondition('entity_type', 'restful_token_auth')
+      ->entityCondition('bundle', 'access_token')
       ->propertyCondition('token', $token)
       ->range(0, 1)
       ->execute();


### PR DESCRIPTION
at the moment, users can be authenticated using both access_token and refresh_token, the refresh_token should be disallowed
