### PR TITLE
Allow files to be uploaded directly through PUT method. 

### DIFF
--- a/restful.module
+++ b/restful.module
@@ -573,6 +573,7 @@ function restful_parse_request() {
   }
   elseif ($method == \RestfulInterface::POST) {
     $request = $_POST;
+    watchdog('debug', 'parsed request : ' . print_r($request, 1));
   }
   elseif ($method == \RestfulInterface::HEAD) {
     $request = array();

--- a/restful.module
+++ b/restful.module
@@ -610,7 +610,7 @@ function restful_parse_request() {
         if (!$request) {
           parse_str(_restful_get_query_string_from_php_input(), $request);
         }
-
+        break;
       default:
         // this is some kind of file, a direct upload
         // copy it into the temporary directory then pass the URI to the handler for it to deal with

--- a/restful.module
+++ b/restful.module
@@ -577,14 +577,14 @@ function restful_parse_request() {
     watchdog('debug', 'php://input is : ' . _restful_get_query_string_from_php_input());
   }
   elseif ($method == \RestfulInterface::HEAD) {
-    $request = array();
+    $request = TRUE;
   }
   elseif ($method == \RestfulInterface::DELETE) {
-    $request = array();
+    $request = TRUE;
   }
 
   // if we get this far, then we need to do special processing on php://input to get the data
-  if (is_null($request)) {
+  if ($request) {
     $temp = explode(';', $_SERVER['CONTENT_TYPE']);
     $contentType = $temp[0];
     // CHARSET=<Something> will be in $temp[1], if it's ever needed

--- a/restful.module
+++ b/restful.module
@@ -574,6 +574,9 @@ function restful_parse_request() {
   elseif ($method == \RestfulInterface::POST) {
     $request = $_POST;
   }
+  elseif ($method == \RestfulInterface::HEAD) {
+    $request = array();
+  }
   else {
     $temp = explode(';', $_SERVER['CONTENT_TYPE']);
     $contentType = $temp[0];

--- a/restful.module
+++ b/restful.module
@@ -584,8 +584,8 @@ function restful_parse_request() {
   }
 
   // if we get this far, then we need to do special processing on php://input to get the data
-  if ($request && !empty($_SERVER['CONTENT_TYPE'])) {
-    $temp = explode(';', $_SERVER['CONTENT_TYPE']);
+  if (!$request) {
+    $temp = explode(';', isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : 'unknown');
     $contentType = $temp[0];
     // CHARSET=<Something> will be in $temp[1], if it's ever needed
     switch ($contentType) {
@@ -604,6 +604,13 @@ function restful_parse_request() {
         // There's nothing we can do to get this data
         throw new RestfulBadRequestException('Cannot use multipart/form-data with HTTP Method ' . $method . '.');
         break;
+      case 'unknown':
+        // if content type is undefined, we try a couple things and if they don't work, oh well
+        $request = drupal_json_decode(_restful_get_query_string_from_php_input());
+        if (!$request) {
+          parse_str(_restful_get_query_string_from_php_input(), $request);
+        }
+
       default:
         // this is some kind of file, a direct upload
         // copy it into the temporary directory then pass the URI to the handler for it to deal with

--- a/restful.module
+++ b/restful.module
@@ -612,9 +612,18 @@ function restful_parse_request() {
           }
         }
 
-        // this file never exists on the server already, as it is temporary
-        // save processing time by not checking if it already exists
-        $request['file'] = file_uri_to_object($uri, FALSE);
+        // construct a file object based on the file we just received.
+        $uri = file_stream_wrapper_uri_normalize($uri);
+        $file = new stdClass();
+        $file->uid = $GLOBALS['user']->uid;
+        $file->filename = basename($uri);
+        $file->uri = $uri;
+        $file->filemime = file_get_mimetype($uri);
+        // This is gagged because some uris will not support it.
+        $file->filesize = @filesize($uri);
+        $file->timestamp = REQUEST_TIME;
+
+        $request['file'] = $file;
         $request['file']->filemime = $contentType;
         $request['file']->type = file_get_type($request['file']);
         fclose($input);

--- a/restful.module
+++ b/restful.module
@@ -573,6 +573,9 @@ function restful_parse_request() {
   }
   elseif ($method == \RestfulInterface::POST) {
     $request = $_POST;
+    if ($_FILES) {
+      $request['file_upload'] = true;
+    }
     watchdog('debug', 'parsed request : ' . print_r($request, 1));
     watchdog('debug', 'php://input is : ' . _restful_get_query_string_from_php_input());
   }

--- a/restful.module
+++ b/restful.module
@@ -556,15 +556,52 @@ function restful_parse_request() {
     $request = $_POST;
   }
 
-  if (!$request && $query_string = _restful_get_query_string_from_php_input()) {
-    // When trying to POST using curl on simpleTest it doesn't reach
-    // $_POST, so we try to re-grab it here.
-    // Also, sometimes the client might send the input still encoded.
-    if ($decoded_json = drupal_json_decode($query_string)) {
-      $request = $decoded_json;
-    }
-    else {
-      parse_str($query_string, $request);
+  $temp = explode(';', $_SERVER['CONTENT_TYPE']);
+  $contentType = $temp[0];
+  // CHARSET=<Something> will be in $temp[1], if it's ever needed
+
+  if (!$request) {
+    switch ($contentType) {
+      case 'application/json':
+        $request = drupal_json_decode(_restful_get_query_string_from_php_input());
+        break;
+      case 'application/x-www-form-encoded':
+        parse_str(_restful_get_query_string_from_php_input(), $request);
+        break;
+      case 'multipart/form-data':
+        // php://input is an empty string when the content-type is multipart/form-data
+        // There's nothing we can do to get this data
+        throw new RestfulBadRequestException('Cannot use multipart/form-data with HTTP Method ' . $method . '.');
+        break;
+      default:
+        // this is some kind of file, a direct upload
+        // copy it into the temporary directory then pass the URI to the handler for it to deal with
+        // handlers are expected to copy this file somewhere else
+        $uri = drupal_tempnam('temporary://', 'restFile_');
+        $input = fopen('php://input', 'rb');
+        $dest = fopen($uri, 'wb');
+
+        $size = $_SERVER['CONTENT_LENGTH'];
+        $pos = 0;
+        $chunk = 1024;
+        while ($pos < $size) {
+          if ($writ = stream_copy_to_stream($input, $dest, $chunk)) {
+            $pos += $writ;
+          } else {
+            fclose($input);
+            fclose($dest);
+            throw new RestfulUnprocessableEntityException('Unable to copy file.');
+          }
+        }
+
+        // this file never exists on the server already, as it is temporary
+        // save processing time by not checking if it already exists
+        $request['file'] = file_uri_to_object($uri, FALSE);
+        $request['file']->filemime = $contentType;
+        $request['file']->type = file_get_type($request['file']);
+        fclose($input);
+        fclose($dest);
+        break;
     }
   }
 

--- a/restful.module
+++ b/restful.module
@@ -591,9 +591,11 @@ function restful_parse_request() {
         $request = drupal_json_decode(_restful_get_query_string_from_php_input());
         break;
       case 'application/x-www-form-encoded':
-        watchdog('debug', 'raw request : ' . _restful_get_query_string_from_php_input());
         parse_str(_restful_get_query_string_from_php_input(), $request);
-        watchdog('debug', 'parsed request : ' . print_r($request, 1));
+        if ($methods == \RestfulInterface::POST) {
+          watchdog('debug', 'raw request : ' . _restful_get_query_string_from_php_input());
+          watchdog('debug', 'parsed request : ' . print_r($request, 1));
+        }
         break;
       case 'multipart/form-data':
         // php://input is an empty string when the content-type is multipart/form-data

--- a/restful.module
+++ b/restful.module
@@ -583,7 +583,7 @@ function restful_parse_request() {
     $temp = explode(';', $_SERVER['CONTENT_TYPE']);
     $contentType = $temp[0];
     // CHARSET=<Something> will be in $temp[1], if it's ever needed
-
+    watchdog('debug', 'ContentType header is : ' . $contentType);
     switch ($contentType) {
       case 'application/json':
         $request = drupal_json_decode(_restful_get_query_string_from_php_input());

--- a/restful.module
+++ b/restful.module
@@ -574,12 +574,11 @@ function restful_parse_request() {
   elseif ($method == \RestfulInterface::POST) {
     $request = $_POST;
   }
+  else {
+    $temp = explode(';', $_SERVER['CONTENT_TYPE']);
+    $contentType = $temp[0];
+    // CHARSET=<Something> will be in $temp[1], if it's ever needed
 
-  $temp = explode(';', $_SERVER['CONTENT_TYPE']);
-  $contentType = $temp[0];
-  // CHARSET=<Something> will be in $temp[1], if it's ever needed
-
-  if (!$request) {
     switch ($contentType) {
       case 'application/json':
         $request = drupal_json_decode(_restful_get_query_string_from_php_input());

--- a/restful.module
+++ b/restful.module
@@ -574,6 +574,7 @@ function restful_parse_request() {
   elseif ($method == \RestfulInterface::POST) {
     $request = $_POST;
     watchdog('debug', 'parsed request : ' . print_r($request, 1));
+    watchdog('debug', 'php://input is : ' . _restful_get_query_string_from_php_input());
   }
   elseif ($method == \RestfulInterface::HEAD) {
     $request = array();

--- a/restful.module
+++ b/restful.module
@@ -625,7 +625,6 @@ function restful_parse_request() {
 
         $request['file'] = $file;
         $request['file']->filemime = $contentType;
-        $request['file']->type = file_get_type($request['file']);
         fclose($input);
         fclose($dest);
         break;

--- a/restful.module
+++ b/restful.module
@@ -631,13 +631,12 @@ function restful_parse_request() {
         $file->uid = $GLOBALS['user']->uid;
         $file->filename = basename($uri);
         $file->uri = $uri;
-        $file->filemime = file_get_mimetype($uri);
+        $file->filemime = $contentType;
         // This is gagged because some uris will not support it.
         $file->filesize = @filesize($uri);
         $file->timestamp = REQUEST_TIME;
 
         $request['file'] = $file;
-        $request['file']->filemime = $contentType;
         fclose($input);
         fclose($dest);
         break;

--- a/restful.module
+++ b/restful.module
@@ -586,8 +586,8 @@ function restful_parse_request() {
     watchdog('debug', 'ContentType header is : ' . $contentType);
     switch ($contentType) {
       case 'application/json':
+        watchdog('debug', 'raw request is : ' . _restful_get_query_string_from_php_input());
         $request = drupal_json_decode(_restful_get_query_string_from_php_input());
-        watchdog('debug', 'request is : ' . print_r($request, 1));
         break;
       case 'application/x-www-form-encoded':
         parse_str(_restful_get_query_string_from_php_input(), $request);

--- a/restful.module
+++ b/restful.module
@@ -577,16 +577,17 @@ function restful_parse_request() {
   elseif ($method == \RestfulInterface::HEAD) {
     $request = array();
   }
+  elseif ($method == \RestfulInterface::DELETE) {
+    $request = array();
+  }
 
   // if we get this far, then we need to do special processing on php://input to get the data
   if (is_null($request)) {
     $temp = explode(';', $_SERVER['CONTENT_TYPE']);
     $contentType = $temp[0];
     // CHARSET=<Something> will be in $temp[1], if it's ever needed
-    watchdog('debug', 'ContentType header is : ' . $contentType);
     switch ($contentType) {
       case 'application/json':
-        watchdog('debug', 'raw request is : ' . _restful_get_query_string_from_php_input());
         $request = drupal_json_decode(_restful_get_query_string_from_php_input());
         break;
       case 'application/x-www-form-encoded':

--- a/restful.module
+++ b/restful.module
@@ -577,10 +577,10 @@ function restful_parse_request() {
     watchdog('debug', 'php://input is : ' . _restful_get_query_string_from_php_input());
   }
   elseif ($method == \RestfulInterface::HEAD) {
-    $request = TRUE;
+    $request = array('method' => $method);
   }
   elseif ($method == \RestfulInterface::DELETE) {
-    $request = TRUE;
+    $request = array('method' => $method);
   }
 
   // if we get this far, then we need to do special processing on php://input to get the data

--- a/restful.module
+++ b/restful.module
@@ -587,6 +587,7 @@ function restful_parse_request() {
     switch ($contentType) {
       case 'application/json':
         $request = drupal_json_decode(_restful_get_query_string_from_php_input());
+        watchdog('debug', 'request is : ' . print_r($request, 1));
         break;
       case 'application/x-www-form-encoded':
         parse_str(_restful_get_query_string_from_php_input(), $request);

--- a/restful.module
+++ b/restful.module
@@ -591,7 +591,9 @@ function restful_parse_request() {
         $request = drupal_json_decode(_restful_get_query_string_from_php_input());
         break;
       case 'application/x-www-form-encoded':
+        watchdog('debug', 'raw request : ' . _restful_get_query_string_from_php_input());
         parse_str(_restful_get_query_string_from_php_input(), $request);
+        watchdog('debug', 'parsed request : ' . print_r($request, 1));
         break;
       case 'multipart/form-data':
         // php://input is an empty string when the content-type is multipart/form-data

--- a/restful.module
+++ b/restful.module
@@ -592,7 +592,7 @@ function restful_parse_request() {
         break;
       case 'application/x-www-form-encoded':
         parse_str(_restful_get_query_string_from_php_input(), $request);
-        if ($methods == \RestfulInterface::POST) {
+        if ($method == \RestfulInterface::POST) {
           watchdog('debug', 'raw request : ' . _restful_get_query_string_from_php_input());
           watchdog('debug', 'parsed request : ' . print_r($request, 1));
         }

--- a/restful.module
+++ b/restful.module
@@ -584,7 +584,7 @@ function restful_parse_request() {
   }
 
   // if we get this far, then we need to do special processing on php://input to get the data
-  if ($request) {
+  if ($request && !empty($_SERVER['CONTENT_TYPE'])) {
     $temp = explode(';', $_SERVER['CONTENT_TYPE']);
     $contentType = $temp[0];
     // CHARSET=<Something> will be in $temp[1], if it's ever needed

--- a/restful.module
+++ b/restful.module
@@ -576,8 +576,7 @@ function restful_parse_request() {
     if ($_FILES) {
       $request['file_upload'] = true;
     }
-    watchdog('debug', 'parsed request : ' . print_r($request, 1));
-    watchdog('debug', 'php://input is : ' . _restful_get_query_string_from_php_input());
+    watchdog('debug', 'files : ' . print_r($_FILES));
   }
   elseif ($method == \RestfulInterface::HEAD) {
     $request = array('method' => $method);
@@ -597,10 +596,6 @@ function restful_parse_request() {
         break;
       case 'application/x-www-form-encoded':
         parse_str(_restful_get_query_string_from_php_input(), $request);
-        if ($method == \RestfulInterface::POST) {
-          watchdog('debug', 'raw request : ' . _restful_get_query_string_from_php_input());
-          watchdog('debug', 'parsed request : ' . print_r($request, 1));
-        }
         break;
       case 'multipart/form-data':
         // php://input is an empty string when the content-type is multipart/form-data

--- a/restful.module
+++ b/restful.module
@@ -576,7 +576,7 @@ function restful_parse_request() {
     if ($_FILES) {
       $request['file_upload'] = true;
     }
-    watchdog('debug', 'files : ' . print_r($_FILES));
+    watchdog('debug', 'files : ' . print_r($_FILES, 1));
   }
   elseif ($method == \RestfulInterface::HEAD) {
     $request = array('method' => $method);

--- a/restful.module
+++ b/restful.module
@@ -577,7 +577,9 @@ function restful_parse_request() {
   elseif ($method == \RestfulInterface::HEAD) {
     $request = array();
   }
-  else {
+
+  // if we get this far, then we need to do special processing on php://input to get the data
+  if (is_null($request)) {
     $temp = explode(';', $_SERVER['CONTENT_TYPE']);
     $contentType = $temp[0];
     // CHARSET=<Something> will be in $temp[1], if it's ever needed

--- a/tests/RestfulCurlBaseTestCase.test
+++ b/tests/RestfulCurlBaseTestCase.test
@@ -27,7 +27,7 @@ class RestfulCurlBaseTestCase extends DrupalWebTestCase {
    *   Array keyed with the "code", "headers", and "body" of the response.
    */
   protected function httpRequest($url, $method = \RestfulInterface::GET, $body = NULL, $headers = array(), $use_token = TRUE) {
-    $format = 'json';
+    $format = 'x-www-form-encoded';
 
     switch ($method) {
       case \RestfulInterface::GET:


### PR DESCRIPTION
From #483.

If the Content-Type header is not a known value, we assume it's a direct file upload. The file is copied to a temporary location, made into a Drupal File entity, and then put into the request array to be passed to the handler. At this point, it's up to the handler to move the file into a permanent location or process it.
