### PR TITLE
generate access token and refresh token for correct users

### DIFF
--- a/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
+++ b/modules/restful_token_auth/plugins/authentication/RestfulAuthenticationToken.class.php
@@ -30,6 +30,7 @@ class RestfulAuthenticationToken extends \RestfulAuthenticationBase {
     $query = new EntityFieldQuery();
     $result = $query
       ->entityCondition('entity_type', 'restful_token_auth')
+      ->entityCondition('bundle', 'access_token')
       ->propertyCondition('token', $token)
       ->range(0, 1)
       ->execute();

--- a/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/refresh_token/1.0/RestfulRefreshTokenAuthentication.class.php
+++ b/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/refresh_token/1.0/RestfulRefreshTokenAuthentication.class.php
@@ -31,7 +31,6 @@ class RestfulRefreshTokenAuthentication extends \RestfulTokenAuthenticationBase 
    *   The new access token.
    */
   public function refreshToken($token) {
-    $account = $this->getAccount();
     // Check if there is a token that did not expire yet.
     $query = new EntityFieldQuery();
     $results = $query
@@ -47,11 +46,12 @@ class RestfulRefreshTokenAuthentication extends \RestfulTokenAuthenticationBase 
 
     // Remove the refresh token once used.
     $refresh_token = entity_load_single('restful_token_auth', key($results['restful_token_auth']));
+    $uid = $refresh_token->uid;
     $refresh_token->delete();
 
     // Create the new access token and return it.
     $controller = entity_get_controller($this->getEntityType());
-    $token = $controller->generateAccessToken($account->uid);
+    $token = $controller->generateAccessToken($uid);
     return $this->viewEntity($token->id);
   }
 

--- a/modules/restful_token_auth/tests/RestfulTokenAuthenticationTestCase.test
+++ b/modules/restful_token_auth/tests/RestfulTokenAuthenticationTestCase.test
@@ -74,6 +74,30 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
       $this->fail('Exception different from "Unauthorized" exception was thrown.');
     }
 
+    // Get a "protected" resource with refresh token as access token.
+    try {
+      $handler->get($id, array('access_token' => $refresh_token));
+      $this->fail('"Unauthorized" exception not thrown.');
+    }
+    catch (\RestfulUnauthorizedException $e) {
+      $this->pass('"Unauthorized" exception was thrown.');
+    }
+    catch (\Exception $e) {
+      $this->fail('Exception different from "Unauthorized" exception was thrown.');
+    }
+
+    // Get a "protected" resource with refresh token.
+    try {
+      $handler->get($id, array('refresh_token' => $refresh_token));
+      $this->fail('"Unauthorized" exception not thrown.');
+    }
+    catch (\RestfulUnauthorizedException $e) {
+      $this->pass('"Unauthorized" exception was thrown.');
+    }
+    catch (\Exception $e) {
+      $this->fail('Exception different from "Unauthorized" exception was thrown.');
+    }
+
     // Get a "protected" resource with the access token.
     $response = $handler->get(1, array('access_token' => $access_token));
     $result = $response[0];
@@ -83,8 +107,8 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
     $query = new \EntityFieldQuery();
     $results = $query
       ->entityCondition('entity_type', 'restful_token_auth')
-      ->entityCondition('bundle', 'refresh_token')
-      ->propertyCondition('token', $refresh_token)
+      ->entityCondition('bundle', 'access_token')
+      ->propertyCondition('token', $access_token)
       ->execute();
 
     if (empty($results['restful_token_auth'])) {
@@ -103,7 +127,7 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
     $query = new \EntityFieldQuery();
     $result = $query
       ->entityCondition('entity_type', 'restful_token_auth')
-      ->entityCondition('bundle', 'refresh_token')
+      ->entityCondition('bundle', 'access_token')
       ->propertyCondition('token', $access_token)
       ->execute();
 

--- a/modules/restful_token_auth/tests/RestfulTokenAuthenticationTestCase.test
+++ b/modules/restful_token_auth/tests/RestfulTokenAuthenticationTestCase.test
@@ -58,9 +58,6 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
     catch (\RestfulUnauthorizedException $e) {
       $this->pass('"Unauthorized" exception was thrown.');
     }
-    catch (\Exception $e) {
-      $this->fail('Exception different from "Unauthorized" exception was thrown.');
-    }
 
     // Get a "protected" resource with invalid access token.
     try {
@@ -69,9 +66,6 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
     }
     catch (\RestfulUnauthorizedException $e) {
       $this->pass('"Unauthorized" exception was thrown.');
-    }
-    catch (\Exception $e) {
-      $this->fail('Exception different from "Unauthorized" exception was thrown.');
     }
 
     // Get a "protected" resource with refresh token as access token.
@@ -82,9 +76,6 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
     catch (\RestfulUnauthorizedException $e) {
       $this->pass('"Unauthorized" exception was thrown.');
     }
-    catch (\Exception $e) {
-      $this->fail('Exception different from "Unauthorized" exception was thrown.');
-    }
 
     // Get a "protected" resource with refresh token.
     try {
@@ -94,36 +85,13 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
     catch (\RestfulUnauthorizedException $e) {
       $this->pass('"Unauthorized" exception was thrown.');
     }
-    catch (\Exception $e) {
-      $this->fail('Exception different from "Unauthorized" exception was thrown.');
-    }
 
     // Get a "protected" resource with the access token.
-    $response = $handler->get(1, array('access_token' => $access_token));
+    $response = $handler->get($id, array('access_token' => $access_token));
     $result = $response[0];
     $this->assertEqual($result['label'], $title1, 'Article resource can be accessed with valid access token.');
 
     // Set the expiration token to the past.
-    $query = new \EntityFieldQuery();
-    $results = $query
-      ->entityCondition('entity_type', 'restful_token_auth')
-      ->entityCondition('bundle', 'access_token')
-      ->propertyCondition('token', $access_token)
-      ->execute();
-
-    if (empty($results['restful_token_auth'])) {
-      $this->fail('No token was found.');
-    }
-
-    // Load the token.
-    $token = entity_load_single('restful_token_auth', key($results['restful_token_auth']));
-    $token->expire = time() - 1;
-    $token->save();
-
-    // Make a GET request to trigger a deletion of the token.
-    $handler->get($id, array('access_token' => $access_token));
-
-    // Make sure the token was deleted.
     $query = new \EntityFieldQuery();
     $result = $query
       ->entityCondition('entity_type', 'restful_token_auth')
@@ -131,7 +99,40 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
       ->propertyCondition('token', $access_token)
       ->execute();
 
-    $this->assertTrue(empty($result['restful_token_auth']), 'The token was deleted.');
+    if (empty($result['restful_token_auth'])) {
+      $this->fail('No token was found.');
+    }
+
+    // Load the token.
+    $access_id = key($result['restful_token_auth']);
+    $token = entity_load_single('restful_token_auth', $access_id);
+    $token->expire = REQUEST_TIME - 60 * 24;
+    $token->save();
+
+    // Clear the restful handler, to make sure the user set by RESTful is
+    // cleared.
+    drupal_static_reset('restful_get_restful_handler');
+    // Make a GET request to trigger a deletion of the token.
+    $handler = restful_get_restful_handler('articles', 1, 3);
+
+    try {
+      $handler->get($id, array('access_token' => $access_token));
+      $this->fail('"Unauthorized" exception not thrown for expired token.');
+    }
+    catch (\RestfulUnauthorizedException $e) {
+      $this->pass('"Unauthorized" exception was thrown for expired token.');
+    }
+
+    // Make sure the token was deleted.
+    $query = new \EntityFieldQuery();
+    $count = $query
+      ->entityCondition('entity_type', 'restful_token_auth')
+      ->entityCondition('bundle', 'access_token')
+      ->propertyCondition('token', $access_token)
+      ->count()
+      ->execute();
+
+    $this->assertFalse($count, 'The token was deleted.');
 
     // Test the refresh capabilities.
     $handler = restful_get_restful_handler('refresh_token');
@@ -148,9 +149,5 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
     catch (\RestfulBadRequestException $e) {
       $this->pass('"Bad Request" exception was thrown.');
     }
-    catch (\Exception $e) {
-      $this->fail('Exception different from "Bad Request" exception was thrown.');
-    }
   }
-
 }


### PR DESCRIPTION
the resulting uid of both access token and refresh token is 0, when trying to refresh token (e.g. make a call to http://www.example.com/api/refresh-token/89LcfdhOWptEEcjcoDpuLGZVKUX_Agpp_IL2VwohN1Q).
