### PR TITLE
Removing typecasting on the argument of viewMultiple

### DIFF
--- a/plugins/restful/RestfulDataProviderInterface.php
+++ b/plugins/restful/RestfulDataProviderInterface.php
@@ -24,13 +24,13 @@ interface RestfulDataProviderInterface {
   /**
    * View a collection of items.
    *
-   * @param array $ids
+   * @param mixed $ids
    *   An array of items to view.
    *
    * @return array
    *   The structured array ready to be rendered.
    */
-  public function viewMultiple(array $ids);
+  public function viewMultiple($ids);
 
   /**
    * View an item from the data source.


### PR DESCRIPTION
RestfulBase->process() passes the path into the controller as an argument. Typecasting the argument as an array will result in an error when a controller is defined as the following.

```
  public static function controllersInfo() {
    return array(
      '^.*$' => array(
        \RestfulInterface::GET => 'viewMultiple',
      ),
    );
  }
```

Error:

```
Recoverable fatal error: Argument 1 passed to RestfulDataProviderSample::viewMultiple() must be of the type array, string given
```

This PR is not ready as RestfulDataProviderEFQ, RestfulDataProviderDbQuery and RestfulBase are still implementing RestfulDataProviderInterface, but I wanted to throw something up to see if there is something I am missing.
