### PR TITLE
in entity update / delete hooks don’t invalidate the cache for user

### DIFF
--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -35,18 +35,40 @@ function restful_entity_info() {
  * Implements hook_entity_update().
  */
 function restful_entity_update($entity, $type) {
-  list($entity_id) = entity_extract_ids($type, $entity);
-  $cid = 'paet:' . $type . '::ei:' . $entity_id;
-  \RestfulManager::invalidateEntityCache($cid);
+  if(restful_entity_good_for_invalidation($type)) {
+    list($entity_id) = entity_extract_ids($type, $entity);
+    $cid = 'paet:' . $type . '::ei:' . $entity_id;
+    \RestfulManager::invalidateEntityCache($cid);
+  }
 }
 
 /**
  * Implements hook_entity_delete().
  */
 function restful_entity_delete($entity, $type) {
-  list($entity_id) = entity_extract_ids($type, $entity);
-  $cid = 'paet:' . $type . '::ei:' . $entity_id;
-  \RestfulManager::invalidateEntityCache($cid);
+  if(restful_entity_good_for_invalidation($type)) {
+    list($entity_id) = entity_extract_ids($type, $entity);
+    $cid = 'paet:' . $type . '::ei:' . $entity_id;
+    \RestfulManager::invalidateEntityCache($cid);
+  }
+}
+
+/**
+ * Helper function, used in the entity hooks to determine whether entities are supposed to be cached or not.
+ * 
+ * @param $type entity type - string
+ * @return bool 
+ */
+
+function restful_entity_good_for_invalidation($type) {
+  $skip_types = array(
+    // Saves to the configuration entity dont necesarrily need to be cached & invalidated.   
+      'rate_limit',
+    // User is being delt with separately.
+    'user'
+  );
+  $skip_types = array_merge($skip_types, variable_get('restful_entities_to_skip',array()));
+  return ! in_array($type, $skip_types);
 }
 
 /**

--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -35,7 +35,7 @@ function restful_entity_info() {
  * Implements hook_entity_update().
  */
 function restful_entity_update($entity, $type) {
-  if(restful_entity_good_for_invalidation($type)) {
+  if (restful_entity_determine_invalidation_by_type($type)) {
     list($entity_id) = entity_extract_ids($type, $entity);
     $cid = 'paet:' . $type . '::ei:' . $entity_id;
     \RestfulManager::invalidateEntityCache($cid);
@@ -46,7 +46,7 @@ function restful_entity_update($entity, $type) {
  * Implements hook_entity_delete().
  */
 function restful_entity_delete($entity, $type) {
-  if(restful_entity_good_for_invalidation($type)) {
+  if (restful_entity_determine_invalidation_by_type($type)) {
     list($entity_id) = entity_extract_ids($type, $entity);
     $cid = 'paet:' . $type . '::ei:' . $entity_id;
     \RestfulManager::invalidateEntityCache($cid);
@@ -54,21 +54,28 @@ function restful_entity_delete($entity, $type) {
 }
 
 /**
- * Helper function, used in the entity hooks to determine whether entities are supposed to be cached or not.
+ * Helper function, used in the entity hooks.
+ * 
+ * To determine whether entities are supposed to be cached or not.
  * 
  * @param $type entity type - string
+ * Entity type to be tested.
  * @return bool 
  */
 
-function restful_entity_good_for_invalidation($type) {
+function restful_entity_determine_invalidation_by_type($type) {
   $skip_types = array(
-    // Saves to the configuration entity dont necesarrily need to be cached & invalidated.   
-      'rate_limit',
-    // User is being delt with separately.
+    // Saves to the configuration entity don't necessarily need to be
+    // cached & invalidated.   
+    'rate_limit',
+    // User is being dealt with separately.
     'user'
   );
-  $skip_types = array_merge($skip_types, variable_get('restful_entities_to_skip',array()));
-  return ! in_array($type, $skip_types);
+  $skip_types = array_merge(
+    $skip_types, 
+    variable_get('restful_entities_to_skip', array())
+  );
+  return !in_array($type, $skip_types);
 }
 
 /**

--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -58,12 +58,12 @@ function restful_entity_delete($entity, $type) {
  * 
  * To determine whether entities are supposed to be cached or not.
  * 
- * @param $type entity type - string
+ * @param string $entity_type
  *   Entity type to be tested.
  * @return bool 
  */
 
-function restful_entity_determine_invalidation_by_type($type) {
+function restful_entity_determine_invalidation_by_type($entity_type) {
   $skip_types = array(
     // Saves to the configuration entity don't necessarily need to be
     // cached & invalidated.   
@@ -75,7 +75,7 @@ function restful_entity_determine_invalidation_by_type($type) {
     $skip_types, 
     variable_get('restful_entities_to_skip', array())
   );
-  return !in_array($type, $skip_types);
+  return !in_array($entity_type, $skip_types);
 }
 
 /**

--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -59,7 +59,7 @@ function restful_entity_delete($entity, $type) {
  * To determine whether entities are supposed to be cached or not.
  * 
  * @param $type entity type - string
- * Entity type to be tested.
+ *   Entity type to be tested.
  * @return bool 
  */
 


### PR DESCRIPTION
... and other entities #515

As it is, user is invalidated twice - in the entity hook as well as in the user hook. This is an attempt to invalidate the user only once.
Also, a site may contain many entity types, where restful and its cache (and cache invalidation) is not going to be used at all. Probably the fastest is to allow the developer to set those in a variable, instead of going to the plugin definitions.
