### PR TITLE
Allow overriding entity cache parameters

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -350,7 +350,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
       $values[$public_field_name] = $value;
     }
 
-    $this->setRenderedCache($values, array($this->entityCacheTags());
+    $this->setRenderedCache($values, $this->entityCacheTags());
     return $values;
   }
   

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -281,7 +281,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     $entity_id = $this->getEntityIdByFieldId($id);
     $request = $this->getRequest();
 
-    $cached_data = $this->getRenderedCache($this->entityCacheTags());
+    $cached_data = $this->getRenderedCache($this->entityCacheTags($entity_id));
     if (!empty($cached_data->data)) {
       return $cached_data->data;
     }
@@ -350,18 +350,21 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
       $values[$public_field_name] = $value;
     }
 
-    $this->setRenderedCache($values, $this->entityCacheTags());
+    $this->setRenderedCache($values, $this->entityCacheTags($entity_id));
     return $values;
   }
   
   /**
    * The array of parameters by which entities should be cached.
    *
+   * @param mixed
+   *   The entity ID of the entity to be cached.
+   * 
    * @return array
    *   An array of parameter keys and values which should be added
    *   to the cache key for each entity.
    */
-  public function entityCacheTags() {
+  public function entityCacheTags($entity_id) {
     return array(
       'et' => $this->getEntityType(),
       'ei' => $entity_id,

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -281,10 +281,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     $entity_id = $this->getEntityIdByFieldId($id);
     $request = $this->getRequest();
 
-    $cached_data = $this->getRenderedCache(array(
-      'et' => $this->getEntityType(),
-      'ei' => $entity_id,
-    ));
+    $cached_data = $this->getRenderedCache($this->entityCacheTags());
     if (!empty($cached_data->data)) {
       return $cached_data->data;
     }
@@ -353,11 +350,22 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
       $values[$public_field_name] = $value;
     }
 
-    $this->setRenderedCache($values, array(
+    $this->setRenderedCache($values, array($this->entityCacheTags());
+    return $values;
+  }
+  
+  /**
+   * The array of parameters by which entities should be cached.
+   *
+   * @return array
+   *   An array of parameter keys and values which should be added
+   *   to the cache key for each entity.
+   */
+  public function entityCacheTags() {
+    return array(
       'et' => $this->getEntityType(),
       'ei' => $entity_id,
-    ));
-    return $values;
+    );
   }
 
   /**


### PR DESCRIPTION
We're putting together a site where the language negotiation is done via an HTTP `Accept-Language:` header, but this resulted in cache conflicts since there were no parameters in the URL on which the differing language values could be cached. Unfortunately, with the way `viewEntity()` is structured we had to copy/paste the entire function just to change the cache tagging -- it seems better to allow this to be overridden at the plugin layer so I did a small re-factoring to support this.
