### PR TITLE
Bug fixes to RestfulDataProviderDbQuery

### DIFF
--- a/plugins/restful/RestfulDataProviderDbQuery.php
+++ b/plugins/restful/RestfulDataProviderDbQuery.php
@@ -360,8 +360,8 @@ abstract class RestfulDataProviderDbQuery extends \RestfulBase implements \Restf
   /**
    * {@inheritdoc}
    */
-  public function view($id) {
-    return $this->viewMultiple(array($id));
+  public function view($ids) {
+    return $this->viewMultiple(explode(',', $ids);
   }
 
   /**

--- a/plugins/restful/RestfulDataProviderDbQuery.php
+++ b/plugins/restful/RestfulDataProviderDbQuery.php
@@ -361,34 +361,7 @@ abstract class RestfulDataProviderDbQuery extends \RestfulBase implements \Restf
    * {@inheritdoc}
    */
   public function view($id) {
-    $cache_id = array(
-      'tb' => $this->getTableName(),
-      'cl' => implode(',', $this->getIdColumn()),
-      'id' => $id,
-    );
-    $cached_data = $this->getRenderedCache($cache_id);
-    if (!empty($cached_data->data)) {
-      return $cached_data->data;
-    }
-
-    $table = $this->getTableName();
-    $query = db_select($table)
-      ->fields($table);
-    foreach ($this->getIdColumn() as $index => $column) {
-      $query->condition($this->getTableName() . '.' . $column, current($this->getColumnFromIds(array($id), $index)));
-    }
-    $this->addExtraInfoToQuery($query);
-    $results = $query->execute();
-
-
-    $return = array();
-
-    foreach ($results as $result) {
-      $return[] = $this->mapDbRowToPublicFields($result);
-    }
-
-    $this->setRenderedCache($return, $cache_id);
-    return $return;
+    return viewMultiple(array($id));
   }
 
   /**

--- a/plugins/restful/RestfulDataProviderDbQuery.php
+++ b/plugins/restful/RestfulDataProviderDbQuery.php
@@ -361,7 +361,7 @@ abstract class RestfulDataProviderDbQuery extends \RestfulBase implements \Restf
    * {@inheritdoc}
    */
   public function view($ids) {
-    return $this->viewMultiple(explode(',', $ids);
+    return $this->viewMultiple(explode(',', $ids));
   }
 
   /**

--- a/plugins/restful/RestfulDataProviderDbQuery.php
+++ b/plugins/restful/RestfulDataProviderDbQuery.php
@@ -554,7 +554,7 @@ abstract class RestfulDataProviderDbQuery extends \RestfulBase implements \Restf
       }
 
       // Execute the process callbacks.
-      if ($value && $info['process_callbacks']) {
+      if ($info['process_callbacks']) {
         foreach ($info['process_callbacks'] as $process_callback) {
           $value = static::executeCallback($process_callback, array($value));
         }

--- a/plugins/restful/RestfulDataProviderDbQuery.php
+++ b/plugins/restful/RestfulDataProviderDbQuery.php
@@ -554,7 +554,7 @@ abstract class RestfulDataProviderDbQuery extends \RestfulBase implements \Restf
       }
 
       // Execute the process callbacks.
-      if ($info['process_callbacks']) {
+      if (isset($value) && $info['process_callbacks']) {
         foreach ($info['process_callbacks'] as $process_callback) {
           $value = static::executeCallback($process_callback, array($value));
         }

--- a/plugins/restful/RestfulDataProviderDbQuery.php
+++ b/plugins/restful/RestfulDataProviderDbQuery.php
@@ -361,7 +361,7 @@ abstract class RestfulDataProviderDbQuery extends \RestfulBase implements \Restf
    * {@inheritdoc}
    */
   public function view($id) {
-    return viewMultiple(array($id));
+    return $this->viewMultiple(array($id));
   }
 
   /**


### PR DESCRIPTION
As the view function was not calling getQuery, it would not include properties from joins that someone may do. If changes were made, it would be exactly the same as viewMultiple other than one accepts arrays, so I just called viewMultiple.

As a value was required to be not falsy for process_callbacks to be called, it would not allow processing falsy values. For example, certain tables in Drupal appear to use "1" and "0" for true and false values. Someone may want to convert those "1" and "0" to true and false before returning the data, but "0" is falsy and process_callback could not be called.
