### PR TITLE
Use the resource path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,9 @@ script:
   - drush --yes pm-enable simpletest restful restful_token_auth
   # Run the tests
   - cd $TRAVIS_BUILD_DIR/../drupal
-  - php ./scripts/run-tests.sh --php $(which php) --verbose --color --concurrency 4 --url http://localhost RESTful | tee /tmp/simpletest-result.txt
+  - php ./scripts/run-tests.sh --php $(which php) --verbose --color --concurrency 4 --url http://localhost --class RestfulEntityUserAccessTestCase,RestfulAuthenticationTestCase | tee /tmp/simpletest-result.txt
+  - echo '####### RESULTS #######'
+  - cat /tmp/simpletest-result.txt
+  - echo '#######################'
   - egrep -i "([1-9]+ fail)|(Fatal error)|([1-9]+ exception)" /tmp/simpletest-result.txt && exit 1
   - exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,6 @@ script:
   - drush --yes pm-enable simpletest restful restful_token_auth
   # Run the tests
   - cd $TRAVIS_BUILD_DIR/../drupal
-  - php ./scripts/run-tests.sh --php $(which php) --verbose --color --concurrency 4 --url http://localhost --class RestfulEntityUserAccessTestCase,RestfulAuthenticationTestCase | tee /tmp/simpletest-result.txt
-  - echo '####### RESULTS #######'
-  - cat /tmp/simpletest-result.txt
-  - echo '#######################'
+  - php ./scripts/run-tests.sh --php $(which php) --verbose --color --concurrency 4 --url http://localhost RESTful | tee /tmp/simpletest-result.txt
   - egrep -i "([1-9]+ fail)|(Fatal error)|([1-9]+ exception)" /tmp/simpletest-result.txt && exit 1
   - exit 0

--- a/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
@@ -431,4 +431,18 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface 
     $this->subject->setOptions($options);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function setResourcePath($resource_path) {
+    $this->subject->setResourcePath($resource_path);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResourcePath() {
+    return $this->subject->getResourcePath();
+  }
+
 }

--- a/src/Plugin/resource/DataProvider/DataProvider.php
+++ b/src/Plugin/resource/DataProvider/DataProvider.php
@@ -448,4 +448,18 @@ abstract class DataProvider implements DataProviderInterface {
       ->add(HttpHeader::create($name, $value));
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function setResourcePath($resource_path) {
+    $this->resourcePath = $resource_path;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResourcePath() {
+    return $this->resourcePath;
+  }
+
 }

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -702,7 +702,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
 
     if ($this->checkEntityAccess($op, $entity_type, $entity) === FALSE) {
 
-      if ($op == 'view' && !$this->request->getPath()) {
+      if ($op == 'view' && !$this->resourcePath) {
         // Just return FALSE, without an exception, for example when a list of
         // entities is requested, and we don't want to fail all the list because
         // of a single item without access.

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -102,7 +102,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
         $value->setBundles($this->bundles);
       }
     }
-    $this->resourcePath = $resource_path;
+    $this->setResourcePath($resource_path);
     if (empty($this->options['urlParams'])) {
       $this->options['urlParams'] = array(
         'filter' => TRUE,
@@ -702,7 +702,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
 
     if ($this->checkEntityAccess($op, $entity_type, $entity) === FALSE) {
 
-      if ($op == 'view' && !$this->resourcePath) {
+      if ($op == 'view' && !$this->getResourcePath()) {
         // Just return FALSE, without an exception, for example when a list of
         // entities is requested, and we don't want to fail all the list because
         // of a single item without access.

--- a/src/Plugin/resource/DataProvider/DataProviderInterface.php
+++ b/src/Plugin/resource/DataProvider/DataProviderInterface.php
@@ -139,4 +139,20 @@ interface DataProviderInterface extends CrudInterface {
    */
   public function getIndexIds();
 
+  /**
+   * Set the resource path.
+   *
+   * @param string $resource_path
+   *   The resource path.
+   */
+  public function setResourcePath($resource_path);
+
+  /**
+   * Get the resource path.
+   *
+   * @return string
+   *   The resource path.
+   */
+  public function getResourcePath();
+
 }

--- a/src/Plugin/resource/Resource.php
+++ b/src/Plugin/resource/Resource.php
@@ -162,6 +162,7 @@ abstract class Resource extends PluginBase implements ResourceInterface {
    */
   public function setPath($path) {
     $this->path = $path;
+    $this->getDataProvider()->setResourcePath($path);
   }
 
   /**

--- a/tests/RestfulAuthenticationTestCase.test
+++ b/tests/RestfulAuthenticationTestCase.test
@@ -135,13 +135,12 @@ class RestfulAuthenticationTestCase extends RestfulCurlBaseTestCase {
     $handler->setRequest(Request::create('api/v1.0/users'));
     $handler->setPath('');
     $handler->setAccount(NULL);
-    try {
-      restful()->getFormatterManager()->format($handler->process(), 'json');
-      $this->fail('Anonymous user did not get 403 when trying to access the "users" resource.');
-    }
-    catch (\Drupal\restful\Exception\ForbiddenException $e) {
-      $this->pass('Anonymous user got 403 when trying to access the "users" resource.');
-    }
+    $result = drupal_json_decode(restful()
+      ->getFormatterManager()
+      ->format($handler->process(), 'json'));
+    $result = $result['data'];
+    $this->assertEqual($result[0]['self'], 'http://restful.local/api/v1.0/users/0');
+    $this->assertEqual(count($result), 1, 'The anonymous users can only see themselves.');
 
     // To assert permissions control access to the resource, we change the
     // permission for anonymous to access other user's profile.

--- a/tests/RestfulAuthenticationTestCase.test
+++ b/tests/RestfulAuthenticationTestCase.test
@@ -139,7 +139,7 @@ class RestfulAuthenticationTestCase extends RestfulCurlBaseTestCase {
       ->getFormatterManager()
       ->format($handler->process(), 'json'));
     $result = $result['data'];
-    $this->assertEqual($result[0]['self'], 'http://restful.local/api/v1.0/users/0');
+    $this->assertEqual($result[0]['self'], url('api/v1.0/users/0', array('absolute' => TRUE)));
     $this->assertEqual(count($result), 1, 'The anonymous users can only see themselves.');
 
     // To assert permissions control access to the resource, we change the

--- a/tests/RestfulEntityUserAccessTestCase.test
+++ b/tests/RestfulEntityUserAccessTestCase.test
@@ -54,8 +54,8 @@ class RestfulEntityUserAccessTestCase extends DrupalWebTestCase {
       ->getFormatterManager()
       ->format($handler->process(), 'json'));
     $result = $result['data'];
-    $this->assertEqual($result[0]['self'], 'http://restful.local/api/v1.0/users/0');
-    $this->assertEqual($result[1]['self'], 'http://restful.local/api/v1.0/users/2');
+    $this->assertEqual($result[0]['self'], url('api/v1.0/users/0', array('absolute' => TRUE)));
+    $this->assertEqual($result[1]['self'], url('api/v1.0/users/2', array('absolute' => TRUE)));
     $this->assertEqual(count($result), 2, 'Unprivileged users can only see themselves and the anonymous user.');
 
     // View own user account.

--- a/tests/RestfulEntityUserAccessTestCase.test
+++ b/tests/RestfulEntityUserAccessTestCase.test
@@ -56,7 +56,7 @@ class RestfulEntityUserAccessTestCase extends DrupalWebTestCase {
     $result = $result['data'];
     $this->assertEqual($result[0]['self'], 'http://restful.local/api/v1.0/users/0');
     $this->assertEqual($result[1]['self'], 'http://restful.local/api/v1.0/users/2');
-    $this->assertEqual(count($result), 2, 'The current user can only see themselves and the anonymous user.');
+    $this->assertEqual(count($result), 2, 'Unprivileged users can only see themselves and the anonymous user.');
 
     // View own user account.
     $handler->setRequest(Request::create('api/v1.0/users/' . $user1->uid));

--- a/tests/RestfulEntityUserAccessTestCase.test
+++ b/tests/RestfulEntityUserAccessTestCase.test
@@ -37,7 +37,7 @@ class RestfulEntityUserAccessTestCase extends DrupalWebTestCase {
     try {
       $handler->setRequest(Request::create('api/v1.0/users/' . $user2->uid));
       $handler->setPath($user2->uid);
-      restful()->getFormatterManager()->format($handler->process(), 'json');
+      $handler->process();
       $this->fail('Non-privileged user can view another user.');
     }
     catch (ForbiddenException $e) {
@@ -48,18 +48,15 @@ class RestfulEntityUserAccessTestCase extends DrupalWebTestCase {
     }
 
     // Listing of users.
-    try {
-      $handler->setRequest(Request::create('api/v1.0/users'));
-      $handler->setPath('');
-      restful()->getFormatterManager()->format($handler->process(), 'json');
-      $this->fail('Non-privileged user can view listing of users.');
-    }
-    catch (ForbiddenException $e) {
-      $this->pass('Non-privileged user cannot view listing of users.');
-    }
-    catch (\Exception $e) {
-      $this->fail('Incorrect exception thrown for non-privileged user accessing listing of users.');
-    }
+    $handler->setRequest(Request::create('api/v1.0/users'));
+    $handler->setPath('');
+    $result = drupal_json_decode(restful()
+      ->getFormatterManager()
+      ->format($handler->process(), 'json'));
+    $result = $result['data'];
+    $this->assertEqual($result[0]['self'], 'http://restful.local/api/v1.0/users/0');
+    $this->assertEqual($result[1]['self'], 'http://restful.local/api/v1.0/users/2');
+    $this->assertEqual(count($result), 2, 'The current user can only see themselves and the anonymous user.');
 
     // View own user account.
     $handler->setRequest(Request::create('api/v1.0/users/' . $user1->uid));

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -735,7 +735,8 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
     $handler = $resource_manager->getPlugin('articles:1.0');
     $handler->setAccount($user1);
 
-    $handler->setRequest(Request::create(''));
+    $handler->setRequest(Request::create('api/articles/v1.0'));
+    $handler->setPath('');
     $result = drupal_json_decode(restful()
       ->getFormatterManager()
       ->format($handler->process(), 'json'));
@@ -749,7 +750,8 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
       $node2->nid,
       $node3->nid,
     );
-    $handler->setRequest(Request::create(implode(',', $ids)));
+    $handler->setRequest(Request::create('api/articles/v1.0' . implode(',', $ids)));
+    $handler->setPath(implode(',', $ids));
     try {
       restful()->getFormatterManager()->format($handler->process(), 'json');
       $this->fail('Exception was not thrown for un-accessible node for specific IDs list.');


### PR DESCRIPTION
@amitaibu the request path contains `v1.0/resource-name`, so we need to use the resource path to check that it's a listing.

I added a follow up to add testing for this case.
