### PR TITLE
[FEATURE] (Entity) Allow a different ID field

### DIFF
--- a/modules/restful_example/src/Plugin/resource/node/article/v2/Articles__2_1.php
+++ b/modules/restful_example/src/Plugin/resource/node/article/v2/Articles__2_1.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\restful_example\Plugin\resource\node\article\v2\Articles__2_0.
+ * Contains \Drupal\restful_example\Plugin\resource\node\article\v2\Articles__2_1.
  */
 
 namespace Drupal\restful_example\Plugin\resource\node\article\v2;
@@ -15,7 +15,7 @@ use Drupal\restful\Plugin\resource\ResourceNode;
  * @package Drupal\restful\Plugin\resource
  *
  * @Resource(
- *   name = "articles:2.0",
+ *   name = "articles:2.1",
  *   resource = "articles",
  *   label = "Articles",
  *   description = "Export the article content type.",
@@ -25,9 +25,29 @@ use Drupal\restful\Plugin\resource\ResourceNode;
  *     "bundles": {
  *       "article"
  *     },
+ *     "idField": "custom-uuid"
  *   },
+ *   formatter = "json_api",
  *   majorVersion = 2,
- *   minorVersion = 0
+ *   minorVersion = 1
  * )
  */
-class Articles__2_0 extends ResourceNode implements ResourceInterface {}
+class Articles__2_1 extends ResourceNode implements ResourceInterface {
+
+  // TODO: Document the use of the idField.
+  /**
+   * {@inheritdoc}
+   */
+  protected function publicFields() {
+    $fields = parent::publicFields();
+
+    $fields['custom-uuid'] = array(
+      'methods' => array(),
+      'property' => 'uuid',
+    );
+
+    return $fields;
+  }
+
+
+}

--- a/modules/restful_token_auth/src/Plugin/resource/TokenAuthenticationBase.php
+++ b/modules/restful_token_auth/src/Plugin/resource/TokenAuthenticationBase.php
@@ -18,6 +18,10 @@ abstract class TokenAuthenticationBase extends ResourceEntity implements Resourc
    * @see http://tools.ietf.org/html/rfc6750#section-4
    */
   public function publicFields() {
+    $public_fields = parent::publicFields();
+    unset($public_fields['label']);
+    unset($public_fields['self']);
+    $public_fields['id']['methods'] = array();
     $public_fields['access_token'] = array(
       'property' => 'token',
     );

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -114,7 +114,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
       }
       if ($resource = $this->getResource()) {
         $output['type'] = $resource->getResourceMachineName();
-        $output['id'] = (string) $data->getInterpreter()->getWrapper()->getIdentifier();
+        $output['id'] = (string) $data->getIdField()->value($data->getInterpreter());
       }
       $interpreter = $data->getInterpreter();
       $value = $resource_field->render($interpreter);
@@ -125,7 +125,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
         $resource_field instanceof ResourceFieldResourceInterface
       ) {
         $value = $this->extractFieldValues($value, $included);
-        $ids = $resource_field->getResourceId($interpreter);
+        $ids = $resource_field->compoundDocumentId($interpreter);
         $cardinality = $resource_field->cardinality();
         if ($cardinality == 1) {
           $value = array($value);

--- a/src/Plugin/resource/DataProvider/DataProviderResource.php
+++ b/src/Plugin/resource/DataProvider/DataProviderResource.php
@@ -64,11 +64,12 @@ class DataProviderResource extends DataProvider implements DataProviderResourceI
   /**
    * {@inheritdoc}
    */
-  public static function init(RequestInterface $request, $resource_name, array $version) {
+  public static function init(RequestInterface $request, $resource_name, array $version, $resource_path = NULL) {
     $plugin_manager = ResourcePluginManager::create('cache', $request);
     /* @var ResourceInterface $resource */
     $resource = $plugin_manager->createInstance($resource_name . PluginBase::DERIVATIVE_SEPARATOR . $version[0] . '.' . $version[1]);
     $plugin_definition = $resource->getPluginDefinition();
+    $resource->setPath($resource_path);
     return new static($request, $resource->getFieldDefinitions(), $resource->getAccount(), $resource->getPath(), $plugin_definition['dataProvider'], static::getLanguage(), $resource);
   }
 

--- a/src/Plugin/resource/Field/ResourceFieldCollection.php
+++ b/src/Plugin/resource/Field/ResourceFieldCollection.php
@@ -28,6 +28,13 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
   protected $interpreter;
 
   /**
+   * Contains the resource field representing the ID.
+   *
+   * @var ResourceFieldInterface $idField;
+   */
+  protected $idField;
+
+  /**
    * Constructor.
    *
    * Creates the collection and each one of the field resource fields in it
@@ -105,6 +112,7 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
       }
       $this->fields[$resource_field->id()] = $resource_field;
     }
+    $this->idField = empty($fields['id']) ? NULL : $this->get('id');
   }
 
   /**
@@ -198,6 +206,20 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
    */
   public function setInterpreter($interpreter) {
     $this->interpreter = $interpreter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIdField() {
+    return $this->idField;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setIdField($id_field) {
+    $this->idField = $id_field;
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldCollectionInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldCollectionInterface.php
@@ -84,4 +84,20 @@ interface ResourceFieldCollectionInterface extends \Iterator, \Countable {
    */
   public function getInterpreter();
 
+  /**
+   * Get the resource field that will return the ID.
+   *
+   * @return ResourceFieldInterface
+   *   The field.
+   */
+  public function getIdField();
+
+  /**
+   * Set the resource field that will return the ID.
+   *
+   * @param ResourceFieldInterface $id_field
+   *   The field to set.
+   */
+  public function setIdField($id_field);
+
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -206,7 +206,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
       $identifier = $property_wrapper->getIdentifier() ?: NULL;
       $resource = $this->getResource();
       // TODO: Make sure we still want to support full_view.
-      if (!$resource || !$identifier || $resource['full_view'] === FALSE) {
+      if (!$resource || !$identifier || (isset($resource['full_view']) && $resource['full_view'] === FALSE)) {
         return $identifier;
       }
       // If there is a resource that we are pointing to, we need to use the id

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -205,7 +205,8 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
       // ID.
       $identifier = $property_wrapper->getIdentifier() ?: NULL;
       $resource = $this->getResource();
-      if (!$resource || !$identifier) {
+      // TODO: Make sure we still want to support full_view.
+      if (!$resource || !$identifier || $resource['full_view'] === FALSE) {
         return $identifier;
       }
       // If there is a resource that we are pointing to, we need to use the id

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -15,6 +15,30 @@ use Drupal\restful\Plugin\resource\DataProvider\DataProviderResource;
 class ResourceFieldEntityReference extends ResourceFieldEntity implements ResourceFieldEntityReferenceInterface {
 
   /**
+   * Property where the ID should be retrieved from.
+   *
+   * If empty, the entity ID will be used. It's either the property or Field API
+   * field name.
+   *
+   * @var string
+   */
+  protected $referencedIdProperty;
+
+  /**
+   * Constructs a ResourceFieldEntityReference.
+   *
+   * @param array $field
+   *   Contains the field values.
+   */
+  public function __construct(array $field) {
+    parent::__construct($field);
+    if (!empty($field['referencedIdProperty'])) {
+      $this->referencedIdProperty = $field['referencedIdProperty'];
+    }
+    // TODO: Document referencedIdProperty.
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function preprocess($value) {
@@ -219,12 +243,29 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
       $values = array();
       foreach ($property_wrapper->getIterator() as $item_wrapper) {
         /* @var $item_wrapper \EntityDrupalWrapper */
-        $values[] = $item_wrapper->getIdentifier();
+        $values[] = $this->referencedId($item_wrapper);
       }
       return $values;
     }
     /* @var $property_wrapper \EntityDrupalWrapper */
-    return $property_wrapper->getIdentifier();
+    return $this->referencedId($property_wrapper);
+  }
+
+  /**
+   * Helper function to get the referenced entity ID.
+   *
+   * @param \EntityDrupalWrapper $property_wrapper
+   *   The wrapper for the referenced entity.
+   *
+   * @return mixed
+   *   The ID.
+   */
+  protected function referencedId(\EntityDrupalWrapper $property_wrapper) {
+    $identifier = $property_wrapper->getIdentifier();
+    if (!$this->referencedIdProperty) {
+      return $identifier;
+    }
+    return $identifier ? $property_wrapper->{$this->referencedIdProperty}->value() : NULL;
   }
 
 }

--- a/src/Plugin/resource/LoginCookie__1_0.php
+++ b/src/Plugin/resource/LoginCookie__1_0.php
@@ -108,4 +108,25 @@ class LoginCookie__1_0 extends ResourceEntity implements ResourceInterface {
     user_login_finalize($login_array);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function processPublicFields(array $field_definitions) {
+    // The fields that only contain a property need to be set to be
+    // ResourceFieldEntity. Otherwise they will be considered regular
+    // ResourceField.
+    $field_definitions = array_map(function ($field_definition) {
+      return $field_definition + array('class' => '\Drupal\restful\Plugin\resource\Field\ResourceFieldEntity');
+    }, $field_definitions);
+
+    // If there is an alternate id field, use it instead of the entity id.
+    $plugin_definition = $this->getPluginDefinition();
+    if (!empty($plugin_definition['dataProvider']['idField'])) {
+      // Remove the 'id' field.
+      unset($field_definitions['id']);
+    }
+
+    return $field_definitions;
+  }
+
 }

--- a/src/Plugin/resource/LoginCookie__1_0.php
+++ b/src/Plugin/resource/LoginCookie__1_0.php
@@ -58,7 +58,11 @@ class LoginCookie__1_0 extends ResourceEntity implements ResourceInterface {
    * {@inheritdoc}
    */
   public function publicFields() {
-    return array();
+    $public_fields = parent::publicFields();
+    $public_fields['id']['methods'] = array();
+
+    // Just return the hidden ID.
+    return array('id' => $public_fields['id']);
   }
 
   /**
@@ -106,27 +110,6 @@ class LoginCookie__1_0 extends ResourceEntity implements ResourceInterface {
 
     $login_array = array('name' => $account->name);
     user_login_finalize($login_array);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function processPublicFields(array $field_definitions) {
-    // The fields that only contain a property need to be set to be
-    // ResourceFieldEntity. Otherwise they will be considered regular
-    // ResourceField.
-    $field_definitions = array_map(function ($field_definition) {
-      return $field_definition + array('class' => '\Drupal\restful\Plugin\resource\Field\ResourceFieldEntity');
-    }, $field_definitions);
-
-    // If there is an alternate id field, use it instead of the entity id.
-    $plugin_definition = $this->getPluginDefinition();
-    if (!empty($plugin_definition['dataProvider']['idField'])) {
-      // Remove the 'id' field.
-      unset($field_definitions['id']);
-    }
-
-    return $field_definitions;
   }
 
 }

--- a/src/Plugin/resource/ResourceEntity.php
+++ b/src/Plugin/resource/ResourceEntity.php
@@ -176,6 +176,9 @@ abstract class ResourceEntity extends Resource {
    * @param array $field_definitions
    *   The field definitions to process.
    *
+   * @throws \Drupal\restful\Exception\ServerConfigurationException
+   *   For resources without ID field.
+   *
    * @return array
    *   The field definition array.
    */

--- a/tests/RestfulHookMenuTestCase.test
+++ b/tests/RestfulHookMenuTestCase.test
@@ -158,7 +158,7 @@ class RestfulHookMenuTestCase extends RestfulCurlBaseTestCase {
       array(
         'path' => 'api/articles',
         'version_header' => NULL,
-        'expected_version' => array(2, 0),
+        'expected_version' => array(2, 1),
       ),
     );
 


### PR DESCRIPTION
This pull request allows you to specify a field to be used as the
primary ID. That means that all of the entity based resources need
to have the `id` field present. The `id` field is inherited from
the abstract base class ResourceEntity, but it can be swapped by
another one. If you don't want the `id` field present in your
resource input & output you can use the `'methods' => array()`
trick in the field definition. If you specify an `idField` in the
resource annotation, that field will be
used as the loadByIdField by default. This allows you to stop using
entity ids as your API ids and use UUIDs (maybe generated by the
uuid Drupal module).
