### PR TITLE
[FEATURE] Allow files to be references

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -339,9 +339,11 @@ class Request implements RequestInterface {
     // fieldsets. fields=active,image.category.name,image.description becomes
     // fields=active,image,image.category,image.category.name,image.description
     foreach (array('fields', 'include') as $key_name) {
-      $keys = empty($input[$key_name]) ? array() : explode(',', $input[$key_name]);
+      if (empty($input[$key_name])) {
+        continue;
+      }
       $added_keys = array();
-      foreach ($keys as $key) {
+      foreach (explode(',', $input[$key_name]) as $key) {
         $parts = explode('.', $key);
         for ($index = 0; $index < count($parts); $index++) {
           $path = implode('.', array_slice($parts, 0, $index + 1));

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -137,7 +137,8 @@ class Request implements RequestInterface {
    */
   public function __construct($path, array $query, $method = 'GET', HttpHeaderBag $headers, $via_router = FALSE, $csrf_token = NULL, array $cookies = array(), array $files = array(), array $server = array(), $parsed_body = NULL) {
     $this->path = $path;
-    $this->query = !isset($query) ? static::parseInput($method) : $query;
+    $this->query = !isset($query) ? static::parseInput() : $query;
+    $this->query = $this->fixQueryFields($this->query);
     // If the method is empty, fall back to GET.
     $this->method = $method ?: static::METHOD_GET;
     $this->headers = $headers;
@@ -320,10 +321,38 @@ class Request implements RequestInterface {
    * @return array
    *   The parsed input.
    */
-  protected static function parseInput($method) {
+  protected static function parseInput() {
     return $_GET;
   }
 
+  /**
+   * Helps fixing the fields to ensure that dot-notation makes sense.
+   *
+   * @param array $input
+   *   The parsed input to fix.
+   *
+   * @return array
+   *   The parsed input array.
+   */
+  protected function fixQueryFields(array $input) {
+    // Make sure to add all of the parents for the dot-notation sparse
+    // fieldsets. fields=active,image.category.name,image.description becomes
+    // fields=active,image,image.category,image.category.name,image.description
+    foreach (array('fields', 'include') as $key_name) {
+      $keys = empty($input[$key_name]) ? array() : explode(',', $input[$key_name]);
+      $added_keys = array();
+      foreach ($keys as $key) {
+        $parts = explode('.', $key);
+        for ($index = 0; $index < count($parts); $index++) {
+          $path = implode('.', array_slice($parts, 0, $index + 1));
+          $added_keys[$path] = TRUE;
+        }
+      }
+      $input[$key_name] = implode(',', array_keys(array_filter($added_keys))) ?: NULL;
+    }
+
+    return $input;
+  }
   /**
    * Parses the header names and values from globals.
    *

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -46,21 +46,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
 
     $included = array();
     $output = array('data' => $this->extractFieldValues($data, $included));
-    // Loop through the included resource entities and add them to the output if
-    // they are included from the request.
-    $input = $this->getRequest()->getParsedInput();
-    $requested_includes = empty($input['include']) ? array() : explode(',', $input['include']);
-    // Keep track of everything that has been included.
-    $include_keys = array();
-    foreach ($requested_includes as $requested_include) {
-      foreach ($included[$requested_include] as $include_key => $included_item) {
-        if (in_array($include_key, $include_keys)) {
-          continue;
-        }
-        $output['included'][] = $included_item;
-        $include_keys[] = $include_key;
-      }
-    }
+    $this->moveEmbedsToIncluded($output, $included);
 
     if ($resource = $this->getResource()) {
       $request = $resource->getRequest();
@@ -99,14 +85,15 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
    *
    * @throws InternalServerErrorException
    */
-  protected function extractFieldValues($data, &$included) {
+  protected function extractFieldValues($data, &$included, array $parents = array()) {
     $output = array();
     foreach ($data as $public_field_name => $resource_field) {
       if (!$resource_field instanceof ResourceFieldInterface) {
         // If $resource_field is not a ResourceFieldInterface it means that we
         // are dealing with a nested structure of some sort. If it is an array
         // we process it as a set of rows, if not then use the value directly.
-        $output[$public_field_name] = static::isIterable($resource_field) ? $this->extractFieldValues($resource_field, $included) : $resource_field;
+        $parents[] = $public_field_name;
+        $output[$public_field_name] = static::isIterable($resource_field) ? $this->extractFieldValues($resource_field, $included, $parents) : $resource_field;
         continue;
       }
       if (!$data instanceof ResourceFieldCollectionInterface) {
@@ -124,7 +111,9 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
         static::isIterable($value) &&
         $resource_field instanceof ResourceFieldResourceInterface
       ) {
-        $value = $this->extractFieldValues($value, $included);
+        $new_parents = $parents;
+        $new_parents[] = $public_field_name;
+        $value = $this->extractFieldValues($value, $included, $new_parents);
         $ids = $resource_field->compoundDocumentId($interpreter);
         $cardinality = $resource_field->cardinality();
         if ($cardinality == 1) {
@@ -153,7 +142,18 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
           $resource_plugin = $resource_field->getResourcePlugin();
           $this->addHateoas($included_item, $resource_plugin, $id);
 
-          $included[$public_field_name][$included_item['type'] . $included_item['id']] = $included_item;
+          // We want to be able to include only the images in articles.images,
+          //but not articles.related.images. That's why we need the path
+          //including the parents.
+
+          // Remove numeric parents since those only indicate that the field was
+          // multivalue, not a parent.
+          $array_path = $parents;
+          array_push($array_path, $public_field_name);
+          $include_path = implode('.', array_filter($array_path, function ($item) {
+            return !is_numeric($item);
+          }));
+          $included[$include_path][$included_item['type'] . $included_item['id']] = $included_item;
         }
         if ($cardinality == 1) {
           // Make them single items.
@@ -249,6 +249,34 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
       return $resource->getRequest();
     }
     return restful()->getRequest();
+  }
+
+  /**
+   * Move the embedded resources to the included key.
+   *
+   * @param array $output
+   *   The output array to modify to include the compounded documents.
+   * @param array $included
+   *   Pool of documents to compound.
+   *
+   * @throws \Drupal\restful\Exception\InternalServerErrorException
+   */
+  protected function moveEmbedsToIncluded(array &$output, array $included) {
+    // Loop through the included resource entities and add them to the output if
+    // they are included from the request.
+    $input = $this->getRequest()->getParsedInput();
+    $requested_includes = empty($input['include']) ? array() : explode(',', $input['include']);
+    // Keep track of everything that has been included.
+    $include_keys = array();
+    foreach ($requested_includes as $requested_include) {
+      foreach ($included[$requested_include] as $include_key => $included_item) {
+        if (in_array($include_key, $include_keys)) {
+          continue;
+        }
+        $output['included'][] = $included_item;
+        $include_keys[] = $include_key;
+      }
+    }
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Plugin\resource\Field\ResourceFieldFileEntityReference.
+ */
+
+namespace Drupal\restful\Plugin\resource\Field;
+
+use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
+
+class ResourceFieldFileEntityReference extends ResourceFieldEntityReference implements ResourceFieldEntityReferenceInterface {
+
+  // TODO: Add testing to this!
+  /**
+   * Get the wrapper for the property associated to the current field.
+   *
+   * @param DataInterpreterInterface $interpreter
+   *   The data source.
+   *
+   * @return \EntityMetadataWrapper
+   *   Either a \EntityStructureWrapper or a \EntityListWrapper.
+   *
+   * @throws ServerConfigurationException
+   */
+  protected function propertyWrapper(DataInterpreterInterface $interpreter) {
+    $property_wrapper = parent::propertyWrapper($interpreter);
+    // If the file_entity module is not installed, throw an exception.
+    if (!module_exists('file_entity')) {
+      throw new ServerConfigurationException(sprintf('You cannot use %s if file_entity is not installed.', __CLASS__));
+    }
+    // If the wrapper is around the file array, then get the entity wrapper.
+    if ($property_wrapper instanceof \EntityDrupalWrapper) {
+      return $property_wrapper;
+    }
+    $file_array = $property_wrapper->value();
+    return new \EntityDrupalWrapper('file', $file_array['fid']);
+  }
+
+}

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -129,6 +129,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $expected_includes = array(
       array(
         'attributes' => array(
+          'entity_reference_single' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
           'id' => $wrapper->entity_reference_multiple[0]->getIdentifier(),
           'label' => $wrapper->entity_reference_multiple[0]->label(),
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
@@ -139,6 +140,15 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
         ),
         'type' => 'main',
+        'relationships' => array(
+          'entity_reference_single_resource' => array(
+            'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+            'links' => array(
+              'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+            ),
+            'type' => 'main',
+          ),
+        ),
       ),
       array(
         'attributes' => array(
@@ -184,8 +194,21 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $resource_field_collections = $this->handler->process();
     $result = drupal_json_decode($this->formatter->format($resource_field_collections));
     $included = $result['included'];
-    $this->assertEqual(1, count($included));
+    $this->assertEqual(2, count($included));
     $expected_includes = array(
+      array(
+        'type' => 'main',
+        'id' => (string) $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+        'links' => array(
+          'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->entity_reference_single->getIdentifier()),
+        ),
+        'attributes' => array(
+          'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+          'label' => $wrapper->entity_reference_single->entity_reference_single->label(),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->entity_reference_single->getIdentifier()),
+        ),
+      ),
       array(
         'type' => 'main',
         'id' => (string) $wrapper->entity_reference_single->getIdentifier(),
@@ -194,14 +217,25 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->getIdentifier()),
         ),
         'attributes' => array(
+          'entity_reference_single' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
           'id' => $wrapper->entity_reference_single->getIdentifier(),
           'label' => $wrapper->entity_reference_single->label(),
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->getIdentifier()),
+        ),
+        'relationships' => array(
+          'entity_reference_single_resource' => array(
+            'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+            'type' => 'main',
+            'links' => array(
+              'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+            ),
+          ),
         ),
       ),
     );
     // Remove the empty fields from the actual response for easier comparison.
     $included[0]['attributes'] = array_filter($included[0]['attributes']);
+    $included[1]['attributes'] = array_filter($included[1]['attributes']);
     $this->assertEqual($expected_includes, $included);
 
 
@@ -314,6 +348,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $wrapper->text_multiple->set(array($text1, $text2));
 
     $wrapper->entity_reference_single->set($entities[0]);
+    $wrapper->entity_reference_single->entity_reference_single->set($entities[1]);
     $wrapper->entity_reference_multiple[] = $entities[0];
     $wrapper->entity_reference_multiple[] = $entities[1];
 

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -169,7 +169,72 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $included[1]['attributes'] = array_filter($included[1]['attributes']);
     $this->assertEqual($expected_includes, $included);
 
-    // 3. Assert the attributes for a list.
+    // 3. Assert the nested relationships.
+    $relationships = $result['data']['relationships'];
+    // Make sure that the entity_reference_*_resource are included as
+    // relationships.
+    $this->assertEqual($relationships['entity_reference_single_resource']['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_single_resource']['id'], $wrapper->entity_reference_single->getIdentifier());
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['id'], $wrapper->entity_reference_multiple[0]->getIdentifier());
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['id'], $wrapper->entity_reference_multiple[1]->getIdentifier());
+
+    // Make a request with the include query string.
+    $this->handler->setRequest(Request::create('api/v1.1/main/' . $wrapper->getIdentifier(), array('include' => 'entity_reference_single_resource.entity_reference_single_resource')));
+    $this->handler->setPath($wrapper->getIdentifier());
+    $this->formatter->setResource($this->handler);
+    $resource_field_collections = $this->handler->process();
+    $result = drupal_json_decode($this->formatter->format($resource_field_collections));
+    $included = $result['included'];
+    // Make sure there are no repeated includes.
+    $this->assertEqual(2, count($included));
+    $expected_includes = array(
+      array(
+        'attributes' => array(
+          'entity_reference_single' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+          'id' => $wrapper->entity_reference_multiple[0]->getIdentifier(),
+          'label' => $wrapper->entity_reference_multiple[0]->label(),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
+        ),
+        'id' => $wrapper->entity_reference_multiple[0]->getIdentifier(),
+        'links' => array(
+          'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_multiple[0]->getIdentifier())))),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
+        ),
+        'type' => 'main',
+        'relationships' => array(
+          'entity_reference_single_resource' => array(
+            'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+            'links' => array(
+              'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+            ),
+            'type' => 'main',
+          ),
+        ),
+      ),
+      array(
+        'attributes' => array(
+          'id' => $wrapper->entity_reference_multiple[1]->getIdentifier(),
+          'label' => $wrapper->entity_reference_multiple[1]->label(),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[1]->getIdentifier()),
+        ),
+        'id' => $wrapper->entity_reference_multiple[1]->getIdentifier(),
+        'links' => array(
+          'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_multiple[1]->getIdentifier())))),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[1]->getIdentifier()),
+        ),
+        'type' => 'main',
+      ),
+    );
+    // Remove the empty fields from the actual response for easier comparison.
+    $included[0]['attributes'] = array_filter($included[0]['attributes']);
+    $included[1]['attributes'] = array_filter($included[1]['attributes']);
+    sort($expected_includes);
+    sort($included);
+    $this->assertEqual($expected_includes, $included);
+
+    // 4. Assert the attributes for a list.
     // Make a list request and check the attributes.
     $this->handler->setRequest(Request::create(''));
     $this->handler->setPath('');
@@ -187,7 +252,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $attributes = array_filter($result['data'][2]['attributes']);
     $this->assertEqual($expected, $attributes);
 
-    // 4. Assert the relationships for a list.
+    // 5. Assert the relationships for a list.
     $this->handler->setRequest(Request::create('', array('include' => 'entity_reference_single_resource')));
     $this->handler->setPath('');
     $this->formatter->setResource($this->handler);
@@ -239,7 +304,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $this->assertEqual($expected_includes, $included);
 
 
-    // 5. Assert request processing.
+    // 6. Assert request processing.
     $request = Request::create('', array(
       'fields' => 'first.second.third.fourth,first.third.fourth',
       'include' => 'fifth.sixth.seventh',

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -203,6 +203,16 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     // Remove the empty fields from the actual response for easier comparison.
     $included[0]['attributes'] = array_filter($included[0]['attributes']);
     $this->assertEqual($expected_includes, $included);
+
+
+    // 5. Assert request processing.
+    $request = Request::create('', array(
+      'fields' => 'first.second.third.fourth,first.third.fourth',
+      'include' => 'fifth.sixth.seventh',
+    ));
+    $input = $request->getParsedInput();
+    $this->assertEqual($input['fields'], 'first,first.second,first.second.third,first.second.third.fourth,first.third,first.third.fourth');
+    $this->assertEqual($input['include'], 'fifth,fifth.sixth,fifth.sixth.seventh');
   }
 
   /**


### PR DESCRIPTION
Allow files to be treated as entity references. Instead of getting
the file array, get the entity id or the full entity. To use this
behaviour use the 'class' property in the publicFields() definition.
