### PR TITLE
[BUGFIX] Fix includes and fields for nested

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -339,9 +339,11 @@ class Request implements RequestInterface {
     // fieldsets. fields=active,image.category.name,image.description becomes
     // fields=active,image,image.category,image.category.name,image.description
     foreach (array('fields', 'include') as $key_name) {
-      $keys = empty($input[$key_name]) ? array() : explode(',', $input[$key_name]);
+      if (empty($input[$key_name])) {
+        continue;
+      }
       $added_keys = array();
-      foreach ($keys as $key) {
+      foreach (explode(',', $input[$key_name]) as $key) {
         $parts = explode('.', $key);
         for ($index = 0; $index < count($parts); $index++) {
           $path = implode('.', array_slice($parts, 0, $index + 1));

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -137,7 +137,8 @@ class Request implements RequestInterface {
    */
   public function __construct($path, array $query, $method = 'GET', HttpHeaderBag $headers, $via_router = FALSE, $csrf_token = NULL, array $cookies = array(), array $files = array(), array $server = array(), $parsed_body = NULL) {
     $this->path = $path;
-    $this->query = !isset($query) ? static::parseInput($method) : $query;
+    $this->query = !isset($query) ? static::parseInput() : $query;
+    $this->query = $this->fixQueryFields($this->query);
     // If the method is empty, fall back to GET.
     $this->method = $method ?: static::METHOD_GET;
     $this->headers = $headers;
@@ -320,10 +321,38 @@ class Request implements RequestInterface {
    * @return array
    *   The parsed input.
    */
-  protected static function parseInput($method) {
+  protected static function parseInput() {
     return $_GET;
   }
 
+  /**
+   * Helps fixing the fields to ensure that dot-notation makes sense.
+   *
+   * @param array $input
+   *   The parsed input to fix.
+   *
+   * @return array
+   *   The parsed input array.
+   */
+  protected function fixQueryFields(array $input) {
+    // Make sure to add all of the parents for the dot-notation sparse
+    // fieldsets. fields=active,image.category.name,image.description becomes
+    // fields=active,image,image.category,image.category.name,image.description
+    foreach (array('fields', 'include') as $key_name) {
+      $keys = empty($input[$key_name]) ? array() : explode(',', $input[$key_name]);
+      $added_keys = array();
+      foreach ($keys as $key) {
+        $parts = explode('.', $key);
+        for ($index = 0; $index < count($parts); $index++) {
+          $path = implode('.', array_slice($parts, 0, $index + 1));
+          $added_keys[$path] = TRUE;
+        }
+      }
+      $input[$key_name] = implode(',', array_keys(array_filter($added_keys))) ?: NULL;
+    }
+
+    return $input;
+  }
   /**
    * Parses the header names and values from globals.
    *

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -46,21 +46,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
 
     $included = array();
     $output = array('data' => $this->extractFieldValues($data, $included));
-    // Loop through the included resource entities and add them to the output if
-    // they are included from the request.
-    $input = $this->getRequest()->getParsedInput();
-    $requested_includes = empty($input['include']) ? array() : explode(',', $input['include']);
-    // Keep track of everything that has been included.
-    $include_keys = array();
-    foreach ($requested_includes as $requested_include) {
-      foreach ($included[$requested_include] as $include_key => $included_item) {
-        if (in_array($include_key, $include_keys)) {
-          continue;
-        }
-        $output['included'][] = $included_item;
-        $include_keys[] = $include_key;
-      }
-    }
+    $this->moveEmbedsToIncluded($output, $included);
 
     if ($resource = $this->getResource()) {
       $request = $resource->getRequest();
@@ -99,14 +85,15 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
    *
    * @throws InternalServerErrorException
    */
-  protected function extractFieldValues($data, &$included) {
+  protected function extractFieldValues($data, &$included, array $parents = array()) {
     $output = array();
     foreach ($data as $public_field_name => $resource_field) {
       if (!$resource_field instanceof ResourceFieldInterface) {
         // If $resource_field is not a ResourceFieldInterface it means that we
         // are dealing with a nested structure of some sort. If it is an array
         // we process it as a set of rows, if not then use the value directly.
-        $output[$public_field_name] = static::isIterable($resource_field) ? $this->extractFieldValues($resource_field, $included) : $resource_field;
+        $parents[] = $public_field_name;
+        $output[$public_field_name] = static::isIterable($resource_field) ? $this->extractFieldValues($resource_field, $included, $parents) : $resource_field;
         continue;
       }
       if (!$data instanceof ResourceFieldCollectionInterface) {
@@ -124,7 +111,9 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
         static::isIterable($value) &&
         $resource_field instanceof ResourceFieldResourceInterface
       ) {
-        $value = $this->extractFieldValues($value, $included);
+        $new_parents = $parents;
+        $new_parents[] = $public_field_name;
+        $value = $this->extractFieldValues($value, $included, $new_parents);
         $ids = $resource_field->compoundDocumentId($interpreter);
         $cardinality = $resource_field->cardinality();
         if ($cardinality == 1) {
@@ -153,7 +142,18 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
           $resource_plugin = $resource_field->getResourcePlugin();
           $this->addHateoas($included_item, $resource_plugin, $id);
 
-          $included[$public_field_name][$included_item['type'] . $included_item['id']] = $included_item;
+          // We want to be able to include only the images in articles.images,
+          //but not articles.related.images. That's why we need the path
+          //including the parents.
+
+          // Remove numeric parents since those only indicate that the field was
+          // multivalue, not a parent.
+          $array_path = $parents;
+          array_push($array_path, $public_field_name);
+          $include_path = implode('.', array_filter($array_path, function ($item) {
+            return !is_numeric($item);
+          }));
+          $included[$include_path][$included_item['type'] . $included_item['id']] = $included_item;
         }
         if ($cardinality == 1) {
           // Make them single items.
@@ -249,6 +249,34 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
       return $resource->getRequest();
     }
     return restful()->getRequest();
+  }
+
+  /**
+   * Move the embedded resources to the included key.
+   *
+   * @param array $output
+   *   The output array to modify to include the compounded documents.
+   * @param array $included
+   *   Pool of documents to compound.
+   *
+   * @throws \Drupal\restful\Exception\InternalServerErrorException
+   */
+  protected function moveEmbedsToIncluded(array &$output, array $included) {
+    // Loop through the included resource entities and add them to the output if
+    // they are included from the request.
+    $input = $this->getRequest()->getParsedInput();
+    $requested_includes = empty($input['include']) ? array() : explode(',', $input['include']);
+    // Keep track of everything that has been included.
+    $include_keys = array();
+    foreach ($requested_includes as $requested_include) {
+      foreach ($included[$requested_include] as $include_key => $included_item) {
+        if (in_array($include_key, $include_keys)) {
+          continue;
+        }
+        $output['included'][] = $included_item;
+        $include_keys[] = $include_key;
+      }
+    }
   }
 
 }

--- a/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
+++ b/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
@@ -213,7 +213,7 @@ class DataProviderDbQuery extends DataProvider implements DataProviderDbQueryInt
    * {@inheritdoc}
    */
   protected function mapDbRowToPublicFields($row) {
-    $resource_field_collection = new ResourceFieldCollection();
+    $resource_field_collection = new ResourceFieldCollection(array(), $this->getRequest());
     $interpreter = new DataInterpreterArray($this->getAccount(), new ArrayWrapper((array) $row));
     $resource_field_collection->setInterpreter($interpreter);
 

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -231,7 +231,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       return NULL;
     }
 
-    $resource_field_collection = new ResourceFieldCollection();
+    $resource_field_collection = new ResourceFieldCollection(array(), $this->getRequest());
     /* @var \EntityDrupalWrapper $wrapper */
     $wrapper = entity_metadata_wrapper($this->entityType, $entity_id);
     $wrapper->language($this->getLangCode());

--- a/src/Plugin/resource/DataProvider/DataProviderPlug.php
+++ b/src/Plugin/resource/DataProvider/DataProviderPlug.php
@@ -64,7 +64,7 @@ class DataProviderPlug extends DataProvider implements DataProviderInterface {
     catch (PluginNotFoundException $e) {
       throw new NotFoundException('Invalid URL path.');
     }
-    $resource_field_collection = new ResourceFieldCollection();
+    $resource_field_collection = new ResourceFieldCollection(array(), $this->getRequest());
     $interpreter = new DataInterpreterPlug($this->getAccount(), new PluginWrapper($plugin));
     $resource_field_collection->setInterpreter($interpreter);
 

--- a/src/Plugin/resource/DataProvider/DataProviderResource.php
+++ b/src/Plugin/resource/DataProvider/DataProviderResource.php
@@ -55,8 +55,8 @@ class DataProviderResource extends DataProvider implements DataProviderResourceI
    *   The referenced resource.
    */
   public function __construct(RequestInterface $request, ResourceFieldCollectionInterface $field_definitions, $account, $resource_path, array $options, $langcode = NULL, ResourceInterface $resource = NULL) {
-    $this->resource = $resource;
     $resource->setRequest($request);
+    $this->resource = $resource;
     $this->referencedDataProvider = $resource->getDataProvider();
     parent::__construct($request, $field_definitions, $account, $resource_path, $options, $langcode);
   }

--- a/src/Plugin/resource/Field/ResourceField.php
+++ b/src/Plugin/resource/Field/ResourceField.php
@@ -47,6 +47,7 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
       // Call the create factory in the derived class.
       return call_user_func_array(array($class_name, 'create'), array(
         $field,
+        $request,
         new static($field, $request),
       ));
     }

--- a/src/Plugin/resource/Field/ResourceField.php
+++ b/src/Plugin/resource/Field/ResourceField.php
@@ -9,6 +9,7 @@ namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Exception\IncompatibleFieldDefinitionException;
 use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Resource\ResourceManager;
 
@@ -22,7 +23,8 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
    *
    * @throws ServerConfigurationException
    */
-  public function __construct(array $field) {
+  public function __construct(array $field, RequestInterface $request) {
+    $this->setRequest($request);
     if (empty($field['public_name'])) {
       throw new ServerConfigurationException('No public name provided in the field mappings.');
     }
@@ -39,13 +41,17 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field) {
+  public static function create(array $field, RequestInterface $request = NULL) {
+    $request = $request ?: restful()->getRequest();
     if ($class_name = static::fieldClassName($field)) {
       // Call the create factory in the derived class.
-      return call_user_func_array(array($class_name, 'create'), array($field, new static($field)));
+      return call_user_func_array(array($class_name, 'create'), array(
+        $field,
+        new static($field, $request),
+      ));
     }
     // If no other class was found, then use the current one.
-    $resource_field = new static($field);
+    $resource_field = new static($field, $request);
     $resource_field->addDefaults();
     return $resource_field;
   }

--- a/src/Plugin/resource/Field/ResourceFieldBase.php
+++ b/src/Plugin/resource/Field/ResourceFieldBase.php
@@ -125,6 +125,33 @@ abstract class ResourceFieldBase implements ResourceFieldInterface {
   );
 
   /**
+   * The request object to be used.
+   *
+   * @var RequestInterface
+   */
+  protected $request;
+
+  /**
+   * Get the request in the data provider.
+   *
+   * @return RequestInterface
+   *   The request.
+   */
+  public function getRequest() {
+    return $this->request;
+  }
+
+  /**
+   * Set the request.
+   *
+   * @param RequestInterface $request
+   *   The request.
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->request = $request;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function getPublicName() {

--- a/src/Plugin/resource/Field/ResourceFieldCollection.php
+++ b/src/Plugin/resource/Field/ResourceFieldCollection.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldCollection implements ResourceFieldCollectionInterface {
@@ -85,7 +86,7 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
    *     ignored.
    *     It is also possible to pass an array as the value, with:
    *     - "name": The resource name.
-   *     - "full_view": Determines if the referenced resource should be rendered,
+   *     - "full_view": Determines if the referenced resource should be rendered
    *     or just the referenced ID(s) to appear. Defaults to TRUE.
    *     array(
    *       // Shorthand.
@@ -99,16 +100,18 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
    *   - "create_or_update_passthrough": Determines if a public field that isn't
    *     mapped to any property or field, may be passed upon create or update
    *     of an entity. Defaults to FALSE.
+   * @param RequestInterface $request
+   *   The request.
    */
-  public function __construct(array $fields = array()) {
+  public function __construct(array $fields = array(), RequestInterface $request) {
     foreach ($fields as $public_name => $field_info) {
       $field_info['public_name'] = $public_name;
       // The default values are added.
       if (empty($field_info['resource'])) {
-        $resource_field = ResourceField::create($field_info);
+        $resource_field = ResourceField::create($field_info, $request);
       }
       else {
-        $resource_field = ResourceFieldResource::create($field_info);
+        $resource_field = ResourceFieldResource::create($field_info, $request);
       }
       $this->fields[$resource_field->id()] = $resource_field;
     }
@@ -118,9 +121,9 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
   /**
    * {@inheritdoc}
    */
-  public static function factory(array $fields = array()) {
+  public static function factory(array $fields = array(), RequestInterface $request = NULL) {
     // TODO: Explore the possibility to change factory methods by using FactoryInterface.
-    return new static($fields);
+    return new static($fields, $request ?: restful()->getRequest());
   }
 
   /**

--- a/src/Plugin/resource/Field/ResourceFieldCollectionInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldCollectionInterface.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 interface ResourceFieldCollectionInterface extends \Iterator, \Countable {
@@ -19,11 +20,13 @@ interface ResourceFieldCollectionInterface extends \Iterator, \Countable {
    *
    * @param array $fields
    *   An array of field mappings.
+   * @param RequestInterface $request
+   *   The request.
    *
    * @return ResourceFieldCollectionInterface
    *   The newly created object.
    */
-  public static function factory(array $fields = array());
+  public static function factory(array $fields = array(), RequestInterface $request = NULL);
 
   /**
    * Factory.

--- a/src/Plugin/resource/Field/ResourceFieldDbColumn.php
+++ b/src/Plugin/resource/Field/ResourceFieldDbColumn.php
@@ -8,6 +8,7 @@
 namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldDbColumn extends ResourceField implements ResourceFieldDbColumnInterface {
@@ -26,16 +27,16 @@ class ResourceFieldDbColumn extends ResourceField implements ResourceFieldDbColu
    *
    * @throws ServerConfigurationException
    */
-  public function __construct(array $field) {
-    parent::__construct($field);
+  public function __construct(array $field, RequestInterface $request) {
+    parent::__construct($field, $request);
     $this->columnForQuery = empty($field['columnForQuery']) ? $this->getProperty() : $field['columnForQuery'];
   }
 
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field) {
-    $resource_field = new static($field);
+  public static function create(array $field, RequestInterface $request = NULL) {
+    $resource_field = new static($field, $request ?: restful()->getRequest());
     $resource_field->addDefaults();
     return $resource_field;
   }

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -119,7 +119,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field, ResourceFieldInterface $decorated = NULL, RequestInterface $request = NULL) {
+  public static function create(array $field, RequestInterface $request = NULL, ResourceFieldInterface $decorated = NULL) {
     $request = $request ?: restful()->getRequest();
     $resource_field = NULL;
     $class_name = static::fieldClassName($field);
@@ -140,7 +140,9 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
       // Create the current object.
       $resource_field = new static($field, $request);
     }
-
+    if (!$resource_field) {
+      throw new ServerConfigurationException('Unable to create resource field');
+    }
     // Set the basic object to the decorated property.
     $resource_field->decorate($decorated ? $decorated : new ResourceField($field, $request));
     $resource_field->decorated->addDefaults();

--- a/src/Plugin/resource/Field/ResourceFieldEntityFile.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityFile.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
+
 class ResourceFieldEntityFile extends ResourceFieldEntity implements ResourceFieldEntityInterface {
 
   /**
@@ -38,6 +40,20 @@ class ResourceFieldEntityFile extends ResourceFieldEntity implements ResourceFie
    */
   public function executeProcessCallbacks($value) {
     return $this->decorated->executeProcessCallbacks($value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -9,6 +9,7 @@ namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Http\HttpHeaderBag;
 use Drupal\restful\Http\Request;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderResource;
 
@@ -29,9 +30,12 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
    *
    * @param array $field
    *   Contains the field values.
+   *
+   * @param RequestInterface $request
+   *   The request.
    */
-  public function __construct(array $field) {
-    parent::__construct($field);
+  public function __construct(array $field, RequestInterface $request) {
+    parent::__construct($field, $request);
     if (!empty($field['referencedIdProperty'])) {
       $this->referencedIdProperty = $field['referencedIdProperty'];
     }
@@ -266,6 +270,20 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
       return $identifier;
     }
     return $identifier ? $property_wrapper->{$this->referencedIdProperty}->value() : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntityText.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityText.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldEntityText extends ResourceFieldEntity implements ResourceFieldEntityInterface {
@@ -71,6 +72,20 @@ class ResourceFieldEntityText extends ResourceFieldEntity implements ResourceFie
    */
   public function executeProcessCallbacks($value) {
     return $this->decorated->executeProcessCallbacks($value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
@@ -8,6 +8,7 @@
 namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldFileEntityReference extends ResourceFieldEntityReference implements ResourceFieldEntityReferenceInterface {
@@ -36,6 +37,20 @@ class ResourceFieldFileEntityReference extends ResourceFieldEntityReference impl
     }
     $file_array = $property_wrapper->value();
     return new \EntityDrupalWrapper('file', $file_array['fid']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Plugin\resource\Field\ResourceFieldFileEntityReference.
+ */
+
+namespace Drupal\restful\Plugin\resource\Field;
+
+use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
+
+class ResourceFieldFileEntityReference extends ResourceFieldEntityReference implements ResourceFieldEntityReferenceInterface {
+
+  // TODO: Add testing to this!
+  /**
+   * Get the wrapper for the property associated to the current field.
+   *
+   * @param DataInterpreterInterface $interpreter
+   *   The data source.
+   *
+   * @return \EntityMetadataWrapper
+   *   Either a \EntityStructureWrapper or a \EntityListWrapper.
+   *
+   * @throws ServerConfigurationException
+   */
+  protected function propertyWrapper(DataInterpreterInterface $interpreter) {
+    $property_wrapper = parent::propertyWrapper($interpreter);
+    // If the file_entity module is not installed, throw an exception.
+    if (!module_exists('file_entity')) {
+      throw new ServerConfigurationException(sprintf('You cannot use %s if file_entity is not installed.', __CLASS__));
+    }
+    // If the wrapper is around the file array, then get the entity wrapper.
+    if ($property_wrapper instanceof \EntityDrupalWrapper) {
+      return $property_wrapper;
+    }
+    $file_array = $property_wrapper->value();
+    return new \EntityDrupalWrapper('file', $file_array['fid']);
+  }
+
+}

--- a/src/Plugin/resource/Field/ResourceFieldInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldInterface.php
@@ -111,13 +111,15 @@ interface ResourceFieldInterface {
    *
    * @param array $field
    *   Contains the field values.
+   * @param RequestInterface $request
+   *   The request.
    *
    * @return ResourceFieldInterface
    *   The created field
    *
    * @throws ServerConfigurationException
    */
-  public static function create(array $field);
+  public static function create(array $field, RequestInterface $request = NULL);
 
   /**
    * Gets the value for the field given a data source.

--- a/src/Plugin/resource/Field/ResourceFieldInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldInterface.php
@@ -9,6 +9,7 @@ namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Exception\IncompatibleFieldDefinitionException;
 use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Resource\ResourceManager;
 
@@ -245,5 +246,21 @@ interface ResourceFieldInterface {
    *   constants.
    */
   public function cardinality();
+
+  /**
+   * Get the request in the data provider.
+   *
+   * @return RequestInterface
+   *   The request.
+   */
+  public function getRequest();
+
+  /**
+   * Set the request.
+   *
+   * @param RequestInterface $request
+   *   The request.
+   */
+  public function setRequest(RequestInterface $request);
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldKeyValue.php
+++ b/src/Plugin/resource/Field/ResourceFieldKeyValue.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldKeyValue extends ResourceField implements ResourceFieldInterface {
@@ -14,8 +15,9 @@ class ResourceFieldKeyValue extends ResourceField implements ResourceFieldInterf
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field) {
-    $resource_field = new static($field);
+  public static function create(array $field, RequestInterface $request = NULL) {
+    $request = $request ?: restful()->getRequest();
+    $resource_field = new static($field, $request);
     $resource_field->addDefaults();
     return $resource_field;
   }

--- a/src/Plugin/resource/Field/ResourceFieldResource.php
+++ b/src/Plugin/resource/Field/ResourceFieldResource.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Plugin\resource\ResourceInterface;
 
@@ -47,8 +48,14 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
    *
    * @param array $field
    *   Contains the field values.
+   *
+   * @param RequestInterface $request
+   *   The request.
    */
-  public function __construct(array $field) {
+  public function __construct(array $field, RequestInterface $request) {
+    if ($this->decorated) {
+      $this->setRequest($request);
+    }
     $this->resourceMachineName = $field['resource']['name'];
   }
 
@@ -102,9 +109,9 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field) {
-    $resource_field = ResourceField::create($field);
-    $output = new static($field);
+  public static function create(array $field, RequestInterface $request = NULL) {
+    $resource_field = ResourceField::create($field, $request);
+    $output = new static($field, $request);
     $output->decorate($resource_field);
     return $output;
   }
@@ -304,6 +311,20 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
    */
   public function __call($name, $arguments) {
     return call_user_func_array(array($this->decorated, $name), $arguments);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldResource.php
+++ b/src/Plugin/resource/Field/ResourceFieldResource.php
@@ -110,6 +110,7 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
    * {@inheritdoc}
    */
   public static function create(array $field, RequestInterface $request = NULL) {
+    $request = $request ?: restful()->getRequest();
     $resource_field = ResourceField::create($field, $request);
     $output = new static($field, $request);
     $output->decorate($resource_field);

--- a/src/Plugin/resource/Resource.php
+++ b/src/Plugin/resource/Resource.php
@@ -82,7 +82,7 @@ abstract class Resource extends PluginBase implements ResourceInterface {
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->fieldDefinitions = ResourceFieldCollection::factory($this->processPublicFields($this->publicFields()));
+    $this->fieldDefinitions = ResourceFieldCollection::factory($this->processPublicFields($this->publicFields()), $this->getRequest());
 
     $this->initAuthenticationManager();
   }
@@ -148,6 +148,10 @@ abstract class Resource extends PluginBase implements ResourceInterface {
     $this->request = $request;
     // Make sure that the request is updated in the data provider.
     $this->getDataProvider()->setRequest($request);
+    foreach ($this->fieldDefinitions as $resource_field) {
+      /* @var \Drupal\restful\Plugin\resource\Field\ResourceFieldInterface $resource_field */
+      $resource_field->setRequest($request);
+    }
   }
 
   /**

--- a/src/Plugin/resource/ResourceEntity.php
+++ b/src/Plugin/resource/ResourceEntity.php
@@ -58,7 +58,7 @@ abstract class ResourceEntity extends Resource {
     $field_definitions = $this->getFieldDefinitions();
     if (!empty($plugin_definition['dataProvider']['viewMode'])) {
       $field_definitions_array = $this->viewModeFields($plugin_definition['dataProvider']['viewMode']);
-      $field_definitions = ResourceFieldCollection::factory($field_definitions_array);
+      $field_definitions = ResourceFieldCollection::factory($field_definitions_array, $this->getRequest());
     }
     $class_name = $this->dataProviderClassName();
     if (!class_exists($class_name)) {

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -129,6 +129,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $expected_includes = array(
       array(
         'attributes' => array(
+          'entity_reference_single' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
           'id' => $wrapper->entity_reference_multiple[0]->getIdentifier(),
           'label' => $wrapper->entity_reference_multiple[0]->label(),
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
@@ -139,6 +140,15 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
         ),
         'type' => 'main',
+        'relationships' => array(
+          'entity_reference_single_resource' => array(
+            'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+            'links' => array(
+              'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+            ),
+            'type' => 'main',
+          ),
+        ),
       ),
       array(
         'attributes' => array(
@@ -184,8 +194,21 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $resource_field_collections = $this->handler->process();
     $result = drupal_json_decode($this->formatter->format($resource_field_collections));
     $included = $result['included'];
-    $this->assertEqual(1, count($included));
+    $this->assertEqual(2, count($included));
     $expected_includes = array(
+      array(
+        'type' => 'main',
+        'id' => (string) $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+        'links' => array(
+          'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->entity_reference_single->getIdentifier()),
+        ),
+        'attributes' => array(
+          'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+          'label' => $wrapper->entity_reference_single->entity_reference_single->label(),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->entity_reference_single->getIdentifier()),
+        ),
+      ),
       array(
         'type' => 'main',
         'id' => (string) $wrapper->entity_reference_single->getIdentifier(),
@@ -194,14 +217,25 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->getIdentifier()),
         ),
         'attributes' => array(
+          'entity_reference_single' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
           'id' => $wrapper->entity_reference_single->getIdentifier(),
           'label' => $wrapper->entity_reference_single->label(),
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->getIdentifier()),
+        ),
+        'relationships' => array(
+          'entity_reference_single_resource' => array(
+            'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+            'type' => 'main',
+            'links' => array(
+              'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+            ),
+          ),
         ),
       ),
     );
     // Remove the empty fields from the actual response for easier comparison.
     $included[0]['attributes'] = array_filter($included[0]['attributes']);
+    $included[1]['attributes'] = array_filter($included[1]['attributes']);
     $this->assertEqual($expected_includes, $included);
 
 
@@ -314,6 +348,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $wrapper->text_multiple->set(array($text1, $text2));
 
     $wrapper->entity_reference_single->set($entities[0]);
+    $wrapper->entity_reference_single->entity_reference_single->set($entities[1]);
     $wrapper->entity_reference_multiple[] = $entities[0];
     $wrapper->entity_reference_multiple[] = $entities[1];
 

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -169,7 +169,72 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $included[1]['attributes'] = array_filter($included[1]['attributes']);
     $this->assertEqual($expected_includes, $included);
 
-    // 3. Assert the attributes for a list.
+    // 3. Assert the nested relationships.
+    $relationships = $result['data']['relationships'];
+    // Make sure that the entity_reference_*_resource are included as
+    // relationships.
+    $this->assertEqual($relationships['entity_reference_single_resource']['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_single_resource']['id'], $wrapper->entity_reference_single->getIdentifier());
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['id'], $wrapper->entity_reference_multiple[0]->getIdentifier());
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['id'], $wrapper->entity_reference_multiple[1]->getIdentifier());
+
+    // Make a request with the include query string.
+    $this->handler->setRequest(Request::create('api/v1.1/main/' . $wrapper->getIdentifier(), array('include' => 'entity_reference_single_resource.entity_reference_single_resource')));
+    $this->handler->setPath($wrapper->getIdentifier());
+    $this->formatter->setResource($this->handler);
+    $resource_field_collections = $this->handler->process();
+    $result = drupal_json_decode($this->formatter->format($resource_field_collections));
+    $included = $result['included'];
+    // Make sure there are no repeated includes.
+    $this->assertEqual(2, count($included));
+    $expected_includes = array(
+      array(
+        'attributes' => array(
+          'entity_reference_single' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+          'id' => $wrapper->entity_reference_multiple[0]->getIdentifier(),
+          'label' => $wrapper->entity_reference_multiple[0]->label(),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
+        ),
+        'id' => $wrapper->entity_reference_multiple[0]->getIdentifier(),
+        'links' => array(
+          'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_multiple[0]->getIdentifier())))),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
+        ),
+        'type' => 'main',
+        'relationships' => array(
+          'entity_reference_single_resource' => array(
+            'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+            'links' => array(
+              'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+            ),
+            'type' => 'main',
+          ),
+        ),
+      ),
+      array(
+        'attributes' => array(
+          'id' => $wrapper->entity_reference_multiple[1]->getIdentifier(),
+          'label' => $wrapper->entity_reference_multiple[1]->label(),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[1]->getIdentifier()),
+        ),
+        'id' => $wrapper->entity_reference_multiple[1]->getIdentifier(),
+        'links' => array(
+          'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_multiple[1]->getIdentifier())))),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[1]->getIdentifier()),
+        ),
+        'type' => 'main',
+      ),
+    );
+    // Remove the empty fields from the actual response for easier comparison.
+    $included[0]['attributes'] = array_filter($included[0]['attributes']);
+    $included[1]['attributes'] = array_filter($included[1]['attributes']);
+    sort($expected_includes);
+    sort($included);
+    $this->assertEqual($expected_includes, $included);
+
+    // 4. Assert the attributes for a list.
     // Make a list request and check the attributes.
     $this->handler->setRequest(Request::create(''));
     $this->handler->setPath('');
@@ -187,7 +252,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $attributes = array_filter($result['data'][2]['attributes']);
     $this->assertEqual($expected, $attributes);
 
-    // 4. Assert the relationships for a list.
+    // 5. Assert the relationships for a list.
     $this->handler->setRequest(Request::create('', array('include' => 'entity_reference_single_resource')));
     $this->handler->setPath('');
     $this->formatter->setResource($this->handler);
@@ -239,7 +304,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $this->assertEqual($expected_includes, $included);
 
 
-    // 5. Assert request processing.
+    // 6. Assert request processing.
     $request = Request::create('', array(
       'fields' => 'first.second.third.fourth,first.third.fourth',
       'include' => 'fifth.sixth.seventh',

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -203,6 +203,16 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     // Remove the empty fields from the actual response for easier comparison.
     $included[0]['attributes'] = array_filter($included[0]['attributes']);
     $this->assertEqual($expected_includes, $included);
+
+
+    // 5. Assert request processing.
+    $request = Request::create('', array(
+      'fields' => 'first.second.third.fourth,first.third.fourth',
+      'include' => 'fifth.sixth.seventh',
+    ));
+    $input = $request->getParsedInput();
+    $this->assertEqual($input['fields'], 'first,first.second,first.second.third,first.second.third.fourth,first.third,first.third.fourth');
+    $this->assertEqual($input['include'], 'fifth,fifth.sixth,fifth.sixth.seventh');
   }
 
   /**


### PR DESCRIPTION
Pass the request down to the resource fields so we can pass relevant
query string parameters to compound documents. The parameters are
detected by stripping the public name + a dot from the beginning
of the parameter. So if 'related.images.uri' is passed to the top
request, 'images.uri' will be passed to the ResourceFieldResource
for 'related'. The resource field for 'images' will receive 'uri'
in the generated request object to compound the document.
