### PR TITLE
[FEATURE] Add tests to alternative reference id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ script:
   - drush --yes dl plug
   - drush --yes dl entity
   - drush --yes dl entityreference
+  - drush --yes dl uuid
   - drush --yes pm-enable plug
 
   # Patch Entity API.

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -339,9 +339,11 @@ class Request implements RequestInterface {
     // fieldsets. fields=active,image.category.name,image.description becomes
     // fields=active,image,image.category,image.category.name,image.description
     foreach (array('fields', 'include') as $key_name) {
-      $keys = empty($input[$key_name]) ? array() : explode(',', $input[$key_name]);
+      if (empty($input[$key_name])) {
+        continue;
+      }
       $added_keys = array();
-      foreach ($keys as $key) {
+      foreach (explode(',', $input[$key_name]) as $key) {
         $parts = explode('.', $key);
         for ($index = 0; $index < count($parts); $index++) {
           $path = implode('.', array_slice($parts, 0, $index + 1));

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -137,7 +137,8 @@ class Request implements RequestInterface {
    */
   public function __construct($path, array $query, $method = 'GET', HttpHeaderBag $headers, $via_router = FALSE, $csrf_token = NULL, array $cookies = array(), array $files = array(), array $server = array(), $parsed_body = NULL) {
     $this->path = $path;
-    $this->query = !isset($query) ? static::parseInput($method) : $query;
+    $this->query = !isset($query) ? static::parseInput() : $query;
+    $this->query = $this->fixQueryFields($this->query);
     // If the method is empty, fall back to GET.
     $this->method = $method ?: static::METHOD_GET;
     $this->headers = $headers;
@@ -320,10 +321,38 @@ class Request implements RequestInterface {
    * @return array
    *   The parsed input.
    */
-  protected static function parseInput($method) {
+  protected static function parseInput() {
     return $_GET;
   }
 
+  /**
+   * Helps fixing the fields to ensure that dot-notation makes sense.
+   *
+   * @param array $input
+   *   The parsed input to fix.
+   *
+   * @return array
+   *   The parsed input array.
+   */
+  protected function fixQueryFields(array $input) {
+    // Make sure to add all of the parents for the dot-notation sparse
+    // fieldsets. fields=active,image.category.name,image.description becomes
+    // fields=active,image,image.category,image.category.name,image.description
+    foreach (array('fields', 'include') as $key_name) {
+      $keys = empty($input[$key_name]) ? array() : explode(',', $input[$key_name]);
+      $added_keys = array();
+      foreach ($keys as $key) {
+        $parts = explode('.', $key);
+        for ($index = 0; $index < count($parts); $index++) {
+          $path = implode('.', array_slice($parts, 0, $index + 1));
+          $added_keys[$path] = TRUE;
+        }
+      }
+      $input[$key_name] = implode(',', array_keys(array_filter($added_keys))) ?: NULL;
+    }
+
+    return $input;
+  }
   /**
    * Parses the header names and values from globals.
    *

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -143,8 +143,8 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
           $this->addHateoas($included_item, $resource_plugin, $id);
 
           // We want to be able to include only the images in articles.images,
-          //but not articles.related.images. That's why we need the path
-          //including the parents.
+          // but not articles.related.images. That's why we need the path
+          // including the parents.
 
           // Remove numeric parents since those only indicate that the field was
           // multivalue, not a parent.

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -46,21 +46,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
 
     $included = array();
     $output = array('data' => $this->extractFieldValues($data, $included));
-    // Loop through the included resource entities and add them to the output if
-    // they are included from the request.
-    $input = $this->getRequest()->getParsedInput();
-    $requested_includes = empty($input['include']) ? array() : explode(',', $input['include']);
-    // Keep track of everything that has been included.
-    $include_keys = array();
-    foreach ($requested_includes as $requested_include) {
-      foreach ($included[$requested_include] as $include_key => $included_item) {
-        if (in_array($include_key, $include_keys)) {
-          continue;
-        }
-        $output['included'][] = $included_item;
-        $include_keys[] = $include_key;
-      }
-    }
+    $this->moveEmbedsToIncluded($output, $included);
 
     if ($resource = $this->getResource()) {
       $request = $resource->getRequest();
@@ -99,14 +85,15 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
    *
    * @throws InternalServerErrorException
    */
-  protected function extractFieldValues($data, &$included) {
+  protected function extractFieldValues($data, &$included, array $parents = array()) {
     $output = array();
     foreach ($data as $public_field_name => $resource_field) {
       if (!$resource_field instanceof ResourceFieldInterface) {
         // If $resource_field is not a ResourceFieldInterface it means that we
         // are dealing with a nested structure of some sort. If it is an array
         // we process it as a set of rows, if not then use the value directly.
-        $output[$public_field_name] = static::isIterable($resource_field) ? $this->extractFieldValues($resource_field, $included) : $resource_field;
+        $parents[] = $public_field_name;
+        $output[$public_field_name] = static::isIterable($resource_field) ? $this->extractFieldValues($resource_field, $included, $parents) : $resource_field;
         continue;
       }
       if (!$data instanceof ResourceFieldCollectionInterface) {
@@ -124,7 +111,9 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
         static::isIterable($value) &&
         $resource_field instanceof ResourceFieldResourceInterface
       ) {
-        $value = $this->extractFieldValues($value, $included);
+        $new_parents = $parents;
+        $new_parents[] = $public_field_name;
+        $value = $this->extractFieldValues($value, $included, $new_parents);
         $ids = $resource_field->compoundDocumentId($interpreter);
         $cardinality = $resource_field->cardinality();
         if ($cardinality == 1) {
@@ -153,7 +142,18 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
           $resource_plugin = $resource_field->getResourcePlugin();
           $this->addHateoas($included_item, $resource_plugin, $id);
 
-          $included[$public_field_name][$included_item['type'] . $included_item['id']] = $included_item;
+          // We want to be able to include only the images in articles.images,
+          //but not articles.related.images. That's why we need the path
+          //including the parents.
+
+          // Remove numeric parents since those only indicate that the field was
+          // multivalue, not a parent.
+          $array_path = $parents;
+          array_push($array_path, $public_field_name);
+          $include_path = implode('.', array_filter($array_path, function ($item) {
+            return !is_numeric($item);
+          }));
+          $included[$include_path][$included_item['type'] . $included_item['id']] = $included_item;
         }
         if ($cardinality == 1) {
           // Make them single items.
@@ -249,6 +249,34 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
       return $resource->getRequest();
     }
     return restful()->getRequest();
+  }
+
+  /**
+   * Move the embedded resources to the included key.
+   *
+   * @param array $output
+   *   The output array to modify to include the compounded documents.
+   * @param array $included
+   *   Pool of documents to compound.
+   *
+   * @throws \Drupal\restful\Exception\InternalServerErrorException
+   */
+  protected function moveEmbedsToIncluded(array &$output, array $included) {
+    // Loop through the included resource entities and add them to the output if
+    // they are included from the request.
+    $input = $this->getRequest()->getParsedInput();
+    $requested_includes = empty($input['include']) ? array() : explode(',', $input['include']);
+    // Keep track of everything that has been included.
+    $include_keys = array();
+    foreach ($requested_includes as $requested_include) {
+      foreach ($included[$requested_include] as $include_key => $included_item) {
+        if (in_array($include_key, $include_keys)) {
+          continue;
+        }
+        $output['included'][] = $included_item;
+        $include_keys[] = $include_key;
+      }
+    }
   }
 
 }

--- a/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
+++ b/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
@@ -213,7 +213,7 @@ class DataProviderDbQuery extends DataProvider implements DataProviderDbQueryInt
    * {@inheritdoc}
    */
   protected function mapDbRowToPublicFields($row) {
-    $resource_field_collection = new ResourceFieldCollection();
+    $resource_field_collection = new ResourceFieldCollection(array(), $this->getRequest());
     $interpreter = new DataInterpreterArray($this->getAccount(), new ArrayWrapper((array) $row));
     $resource_field_collection->setInterpreter($interpreter);
 

--- a/src/Plugin/resource/DataProvider/DataProviderDecorator.php
+++ b/src/Plugin/resource/DataProvider/DataProviderDecorator.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Plugin\resource\DataProvider\DataProviderDecorator.
+ */
+
+namespace Drupal\restful\Plugin\resource\DataProvider;
+
+use Drupal\restful\Http\RequestInterface;
+use Drupal\restful\Plugin\resource\Field\ResourceFieldInterface;
+
+abstract class DataProviderDecorator implements DataProviderInterface {
+
+  /**
+   * Decorated provider.
+   *
+   * @var DataProviderInterface
+   */
+  protected $decorated;
+
+  /**
+   * Contstructs a DataProviderDecorator class.
+   *
+   * @param DataProviderInterface $decorated
+   *   The decorated data provider.
+   */
+  public function __construct(DataProviderInterface $decorated) {
+    $this->decorated = $decorated;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRange() {
+    return $this->decorated->getRange();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRange($range) {
+    $this->decorated->setRange($range);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAccount() {
+    return $this->decorated->getAccount();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setAccount($account) {
+    $this->decorated->setAccount($account);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLangCode() {
+    return $this->decorated->getLangCode();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setLangCode($langcode) {
+    $this->decorated->setLangCode($langcode);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptions() {
+    return $this->decorated->getOptions();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addOptions(array $options) {
+    $this->decorated->addOptions($options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContext($identifier) {
+    $this->decorated->getContext($identifier);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function canonicalPath($path) {
+    return $this->decorated->canonicalPath($path);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function methodAccess(ResourceFieldInterface $resource_field) {
+    return $this->decorated->methodAccess($resource_field);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOptions(array $options) {
+    $this->decorated->setOptions($options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIndexIds() {
+    return $this->decorated->getIndexIds();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function index() {
+    return $this->decorated->index();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function count() {
+    return $this->decorated->count();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function create($object) {
+    return $this->decorated->create($object);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function view($identifier) {
+    return $this->decorated->view($identifier);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewMultiple(array $identifiers) {
+    return $this->decorated->viewMultiple($identifiers);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function update($identifier, $object, $replace = FALSE) {
+    return $this->decorated->update($identifier, $object, $replace);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function remove($identifier) {
+    $this->decorated->remove($identifier);
+  }
+
+}

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -231,7 +231,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       return NULL;
     }
 
-    $resource_field_collection = new ResourceFieldCollection();
+    $resource_field_collection = new ResourceFieldCollection(array(), $this->getRequest());
     /* @var \EntityDrupalWrapper $wrapper */
     $wrapper = entity_metadata_wrapper($this->entityType, $entity_id);
     $wrapper->language($this->getLangCode());

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -535,7 +535,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     parent::addExtraInfoToQuery($query);
     // The only time you need to add the access tags to a EFQ is when you don't
     // have fieldConditions.
-    if (empty($query->fieldConditions)) {
+    if (empty($query->fieldConditions) && empty($query->order)) {
       // Add a generic entity access tag to the query.
       $query->addTag($this->entityType . '_access');
     }

--- a/src/Plugin/resource/DataProvider/DataProviderEntityDecorator.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntityDecorator.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Plugin\resource\DataProvider\DataProviderEntityDecorator.
+ */
+
+namespace Drupal\restful\Plugin\resource\DataProvider;
+
+use Drupal\restful\Exception\BadRequestException;
+
+abstract class DataProviderEntityDecorator extends DataProviderDecorator implements DataProviderEntityInterface {
+
+  /**
+   * Decorated provider.
+   *
+   * @var DataProviderEntityInterface
+   */
+  protected $decorated;
+
+  /**
+   * Contstructs a DataProviderDecorator class.
+   *
+   * @param DataProviderEntityInterface $decorated
+   *   The decorated data provider.
+   */
+  public function __construct(DataProviderEntityInterface $decorated) {
+    // We are overriding the constructor only for the
+    // DataProviderEntityInterface type hinting.
+    parent::__construct($decorated);
+  }
+
+  /**
+   * Allow manipulating the entity before it is saved.
+   *
+   * @param \EntityDrupalWrapper $wrapper
+   *   The unsaved wrapped entity.
+   */
+  public function entityPreSave(\EntityDrupalWrapper $wrapper) {
+    $this->decorated->entityPreSave($wrapper);
+  }
+
+  /**
+   * Validate an entity before it is saved.
+   *
+   * @param \EntityDrupalWrapper $wrapper
+   *   The wrapped entity.
+   *
+   * @throws BadRequestException
+   */
+  public function entityValidate(\EntityDrupalWrapper $wrapper) {
+    $this->decorated->entityValidate($wrapper);
+  }
+
+  /**
+   * Gets a EFQ object.
+   *
+   * @return \EntityFieldQuery
+   *   The object that inherits from \EntityFieldQuery.
+   */
+  public function EFQObject() {
+    return $this->decorated->EFQObject();
+  }
+
+}

--- a/src/Plugin/resource/DataProvider/DataProviderPlug.php
+++ b/src/Plugin/resource/DataProvider/DataProviderPlug.php
@@ -64,7 +64,7 @@ class DataProviderPlug extends DataProvider implements DataProviderInterface {
     catch (PluginNotFoundException $e) {
       throw new NotFoundException('Invalid URL path.');
     }
-    $resource_field_collection = new ResourceFieldCollection();
+    $resource_field_collection = new ResourceFieldCollection(array(), $this->getRequest());
     $interpreter = new DataInterpreterPlug($this->getAccount(), new PluginWrapper($plugin));
     $resource_field_collection->setInterpreter($interpreter);
 

--- a/src/Plugin/resource/DataProvider/DataProviderResource.php
+++ b/src/Plugin/resource/DataProvider/DataProviderResource.php
@@ -55,8 +55,8 @@ class DataProviderResource extends DataProvider implements DataProviderResourceI
    *   The referenced resource.
    */
   public function __construct(RequestInterface $request, ResourceFieldCollectionInterface $field_definitions, $account, $resource_path, array $options, $langcode = NULL, ResourceInterface $resource = NULL) {
-    $this->resource = $resource;
     $resource->setRequest($request);
+    $this->resource = $resource;
     $this->referencedDataProvider = $resource->getDataProvider();
     parent::__construct($request, $field_definitions, $account, $resource_path, $options, $langcode);
   }

--- a/src/Plugin/resource/Field/ResourceField.php
+++ b/src/Plugin/resource/Field/ResourceField.php
@@ -47,6 +47,7 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
       // Call the create factory in the derived class.
       return call_user_func_array(array($class_name, 'create'), array(
         $field,
+        $request,
         new static($field, $request),
       ));
     }

--- a/src/Plugin/resource/Field/ResourceField.php
+++ b/src/Plugin/resource/Field/ResourceField.php
@@ -137,7 +137,7 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
    *   ResourceFieldInterface then ResourceField will be used. NULL if nothing
    *   was found.
    */
-  protected static function fieldClassName(array $field_definition) {
+  public static function fieldClassName(array $field_definition) {
     if (!empty($field_definition['class'])) {
       $class_name = $field_definition['class'];
     }

--- a/src/Plugin/resource/Field/ResourceField.php
+++ b/src/Plugin/resource/Field/ResourceField.php
@@ -9,6 +9,7 @@ namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Exception\IncompatibleFieldDefinitionException;
 use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Resource\ResourceManager;
 
@@ -22,7 +23,8 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
    *
    * @throws ServerConfigurationException
    */
-  public function __construct(array $field) {
+  public function __construct(array $field, RequestInterface $request) {
+    $this->setRequest($request);
     if (empty($field['public_name'])) {
       throw new ServerConfigurationException('No public name provided in the field mappings.');
     }
@@ -39,13 +41,17 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field) {
+  public static function create(array $field, RequestInterface $request = NULL) {
+    $request = $request ?: restful()->getRequest();
     if ($class_name = static::fieldClassName($field)) {
       // Call the create factory in the derived class.
-      return call_user_func_array(array($class_name, 'create'), array($field, new static($field)));
+      return call_user_func_array(array($class_name, 'create'), array(
+        $field,
+        new static($field, $request),
+      ));
     }
     // If no other class was found, then use the current one.
-    $resource_field = new static($field);
+    $resource_field = new static($field, $request);
     $resource_field->addDefaults();
     return $resource_field;
   }

--- a/src/Plugin/resource/Field/ResourceField.php
+++ b/src/Plugin/resource/Field/ResourceField.php
@@ -36,6 +36,9 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
     $this->processCallbacks = isset($field['process_callbacks']) ? $field['process_callbacks'] : $this->processCallbacks;
     $this->resource = isset($field['resource']) ? $field['resource'] : $this->resource;
     $this->methods = isset($field['methods']) ? $field['methods'] : $this->methods;
+    // Store the definition, useful to access custom keys on custom resource
+    // fields.
+    $this->definition = $field;
   }
 
   /**

--- a/src/Plugin/resource/Field/ResourceFieldBase.php
+++ b/src/Plugin/resource/Field/ResourceFieldBase.php
@@ -132,6 +132,15 @@ abstract class ResourceFieldBase implements ResourceFieldInterface {
   protected $request;
 
   /**
+   * The field definition array.
+   *
+   * Use with caution.
+   *
+   * @var array
+   */
+  protected $definition = array();
+
+  /**
    * Get the request in the data provider.
    *
    * @return RequestInterface
@@ -300,6 +309,13 @@ abstract class ResourceFieldBase implements ResourceFieldInterface {
     $element = $this->internalMetadataElement($key);
 
     return isset($element[$leave]) ? $element[$leave] : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinition() {
+    return $this->definition;
   }
 
   /**

--- a/src/Plugin/resource/Field/ResourceFieldBase.php
+++ b/src/Plugin/resource/Field/ResourceFieldBase.php
@@ -125,6 +125,33 @@ abstract class ResourceFieldBase implements ResourceFieldInterface {
   );
 
   /**
+   * The request object to be used.
+   *
+   * @var RequestInterface
+   */
+  protected $request;
+
+  /**
+   * Get the request in the data provider.
+   *
+   * @return RequestInterface
+   *   The request.
+   */
+  public function getRequest() {
+    return $this->request;
+  }
+
+  /**
+   * Set the request.
+   *
+   * @param RequestInterface $request
+   *   The request.
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->request = $request;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function getPublicName() {

--- a/src/Plugin/resource/Field/ResourceFieldCollection.php
+++ b/src/Plugin/resource/Field/ResourceFieldCollection.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldCollection implements ResourceFieldCollectionInterface {
@@ -85,7 +86,7 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
    *     ignored.
    *     It is also possible to pass an array as the value, with:
    *     - "name": The resource name.
-   *     - "full_view": Determines if the referenced resource should be rendered,
+   *     - "full_view": Determines if the referenced resource should be rendered
    *     or just the referenced ID(s) to appear. Defaults to TRUE.
    *     array(
    *       // Shorthand.
@@ -99,16 +100,18 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
    *   - "create_or_update_passthrough": Determines if a public field that isn't
    *     mapped to any property or field, may be passed upon create or update
    *     of an entity. Defaults to FALSE.
+   * @param RequestInterface $request
+   *   The request.
    */
-  public function __construct(array $fields = array()) {
+  public function __construct(array $fields = array(), RequestInterface $request) {
     foreach ($fields as $public_name => $field_info) {
       $field_info['public_name'] = $public_name;
       // The default values are added.
       if (empty($field_info['resource'])) {
-        $resource_field = ResourceField::create($field_info);
+        $resource_field = ResourceField::create($field_info, $request);
       }
       else {
-        $resource_field = ResourceFieldResource::create($field_info);
+        $resource_field = ResourceFieldResource::create($field_info, $request);
       }
       $this->fields[$resource_field->id()] = $resource_field;
     }
@@ -118,9 +121,9 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
   /**
    * {@inheritdoc}
    */
-  public static function factory(array $fields = array()) {
+  public static function factory(array $fields = array(), RequestInterface $request = NULL) {
     // TODO: Explore the possibility to change factory methods by using FactoryInterface.
-    return new static($fields);
+    return new static($fields, $request ?: restful()->getRequest());
   }
 
   /**

--- a/src/Plugin/resource/Field/ResourceFieldCollectionInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldCollectionInterface.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 interface ResourceFieldCollectionInterface extends \Iterator, \Countable {
@@ -19,11 +20,13 @@ interface ResourceFieldCollectionInterface extends \Iterator, \Countable {
    *
    * @param array $fields
    *   An array of field mappings.
+   * @param RequestInterface $request
+   *   The request.
    *
    * @return ResourceFieldCollectionInterface
    *   The newly created object.
    */
-  public static function factory(array $fields = array());
+  public static function factory(array $fields = array(), RequestInterface $request = NULL);
 
   /**
    * Factory.

--- a/src/Plugin/resource/Field/ResourceFieldDbColumn.php
+++ b/src/Plugin/resource/Field/ResourceFieldDbColumn.php
@@ -8,6 +8,7 @@
 namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldDbColumn extends ResourceField implements ResourceFieldDbColumnInterface {
@@ -26,16 +27,16 @@ class ResourceFieldDbColumn extends ResourceField implements ResourceFieldDbColu
    *
    * @throws ServerConfigurationException
    */
-  public function __construct(array $field) {
-    parent::__construct($field);
+  public function __construct(array $field, RequestInterface $request) {
+    parent::__construct($field, $request);
     $this->columnForQuery = empty($field['columnForQuery']) ? $this->getProperty() : $field['columnForQuery'];
   }
 
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field) {
-    $resource_field = new static($field);
+  public static function create(array $field, RequestInterface $request = NULL) {
+    $resource_field = new static($field, $request ?: restful()->getRequest());
     $resource_field->addDefaults();
     return $resource_field;
   }

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -212,7 +212,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
     if ($property_wrapper instanceof \EntityDrupalWrapper) {
       // The property wrapper is a reference to another entity get the entity
       // ID.
-      $identifier = $property_wrapper->getIdentifier() ?: NULL;
+      $identifier = $this->referencedId($property_wrapper);
       $resource = $this->getResource();
       // TODO: Make sure we still want to support full_view.
       if (!$resource || !$identifier || (isset($resource['full_view']) && $resource['full_view'] === FALSE)) {
@@ -525,6 +525,13 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
    */
   public function render(DataInterpreterInterface $interpreter) {
     return $this->executeProcessCallbacks($this->value($interpreter));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinition() {
+    return $this->decorated->getDefinition();
   }
 
   /**
@@ -963,7 +970,10 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
   /**
    * Builds a metadata item for a field value.
    *
-   * It will add information about the referenced entity.
+   * It will add information about the referenced entity. NOTE: Do not type hint
+   * the $wrapper argument to avoid PHP errors for the file entities. Those are
+   * no true entity references, but file arrays (although they reference file
+   * entities)
    *
    * @param \EntityDrupalWrapper $wrapper
    *   The wrapper to the referenced entity.
@@ -971,7 +981,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
    * @return array
    *   The metadata array item.
    */
-  protected function buildResourceMetadataItem(\EntityDrupalWrapper $wrapper) {
+  protected function buildResourceMetadataItem($wrapper) {
     $id = $wrapper->getIdentifier();
     $bundle = $wrapper->getBundle();
     $resource = $this->getResource();
@@ -981,6 +991,19 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
       'bundle' => $bundle,
       'resource_name' => $resource['name'],
     );
+  }
+
+  /**
+   * Helper function to get the referenced entity ID.
+   *
+   * @param \EntityDrupalWrapper $property_wrapper
+   *   The wrapper for the referenced file array.
+   *
+   * @return mixed
+   *   The ID.
+   */
+  protected function referencedId($property_wrapper) {
+    return $property_wrapper->getIdentifier() ?: NULL;
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -739,7 +739,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
   /**
    * {@inheritdoc}
    */
-  public function getImageUris(array $file_array, $image_styles) {
+  public static function getImageUris(array $file_array, $image_styles) {
     // Return early if there are no image styles.
     if (empty($image_styles)) {
       return $file_array;
@@ -749,7 +749,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
     if (static::isArrayNumeric($file_array)) {
       $output = array();
       foreach ($file_array as $item) {
-        $output[] = $this->getImageUris($item, $image_styles);
+        $output[] = static::getImageUris($item, $image_styles);
       }
       return $output;
     }

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -119,7 +119,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field, ResourceFieldInterface $decorated = NULL, RequestInterface $request = NULL) {
+  public static function create(array $field, RequestInterface $request = NULL, ResourceFieldInterface $decorated = NULL) {
     $request = $request ?: restful()->getRequest();
     $resource_field = NULL;
     $class_name = static::fieldClassName($field);
@@ -140,7 +140,9 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
       // Create the current object.
       $resource_field = new static($field, $request);
     }
-
+    if (!$resource_field) {
+      throw new ServerConfigurationException('Unable to create resource field');
+    }
     // Set the basic object to the decorated property.
     $resource_field->decorate($decorated ? $decorated : new ResourceField($field, $request));
     $resource_field->decorated->addDefaults();

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -795,7 +795,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
    *   ResourceFieldInterface then ResourceField will be used. NULL if nothing
    *   was found.
    */
-  protected static function fieldClassName(array $field_definition) {
+  public static function fieldClassName(array $field_definition) {
     if (!empty($field_definition['class']) && $field_definition['class'] != '\Drupal\restful\Plugin\resource\Field\ResourceFieldEntity') {
       // If there is a class that is not the current, return it.
       return $field_definition['class'];

--- a/src/Plugin/resource/Field/ResourceFieldEntityFile.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityFile.php
@@ -56,4 +56,11 @@ class ResourceFieldEntityFile extends ResourceFieldEntity implements ResourceFie
     $this->decorated->setRequest($request);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinition() {
+    return $this->decorated->getDefinition();
+  }
+
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntityFile.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityFile.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
+
 class ResourceFieldEntityFile extends ResourceFieldEntity implements ResourceFieldEntityInterface {
 
   /**
@@ -38,6 +40,20 @@ class ResourceFieldEntityFile extends ResourceFieldEntity implements ResourceFie
    */
   public function executeProcessCallbacks($value) {
     return $this->decorated->executeProcessCallbacks($value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntityInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityInterface.php
@@ -107,7 +107,7 @@ interface ResourceFieldEntityInterface extends ResourceFieldInterface {
    * @return array
    *   The input file array with an extra key for the image styles.
    */
-  public function getImageUris(array $file_array, $image_styles);
+  public static function getImageUris(array $file_array, $image_styles);
 
   /**
    * Checks if a given string represents a Field API field.

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -246,7 +246,6 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
     if ($property_wrapper instanceof \EntityListWrapper) {
       $values = array();
       foreach ($property_wrapper->getIterator() as $item_wrapper) {
-        /* @var $item_wrapper \EntityDrupalWrapper */
         $values[] = $this->referencedId($item_wrapper);
       }
       return $values;
@@ -264,7 +263,7 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
    * @return mixed
    *   The ID.
    */
-  protected function referencedId(\EntityDrupalWrapper $property_wrapper) {
+  protected function referencedId($property_wrapper) {
     $identifier = $property_wrapper->getIdentifier();
     if (!$this->referencedIdProperty) {
       return $identifier;
@@ -284,6 +283,13 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
    */
   public function setRequest(RequestInterface $request) {
     $this->decorated->setRequest($request);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinition() {
+    return $this->decorated->getDefinition();
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -9,6 +9,7 @@ namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Http\HttpHeaderBag;
 use Drupal\restful\Http\Request;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderResource;
 
@@ -29,9 +30,12 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
    *
    * @param array $field
    *   Contains the field values.
+   *
+   * @param RequestInterface $request
+   *   The request.
    */
-  public function __construct(array $field) {
-    parent::__construct($field);
+  public function __construct(array $field, RequestInterface $request) {
+    parent::__construct($field, $request);
     if (!empty($field['referencedIdProperty'])) {
       $this->referencedIdProperty = $field['referencedIdProperty'];
     }
@@ -266,6 +270,20 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
       return $identifier;
     }
     return $identifier ? $property_wrapper->{$this->referencedIdProperty}->value() : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -241,6 +241,10 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
     // we can know for sure that the property wrappers are instances of
     // \EntityDrupalWrapper or lists of them.
     $property_wrapper = $this->propertyWrapper($interpreter);
+    if (!$property_wrapper->value()) {
+      // If there is no referenced entity, return.
+      return NULL;
+    }
 
     // If this is a multivalue field, then call recursively on the items.
     if ($property_wrapper instanceof \EntityListWrapper) {

--- a/src/Plugin/resource/Field/ResourceFieldEntityText.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityText.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldEntityText extends ResourceFieldEntity implements ResourceFieldEntityInterface {
@@ -71,6 +72,20 @@ class ResourceFieldEntityText extends ResourceFieldEntity implements ResourceFie
    */
   public function executeProcessCallbacks($value) {
     return $this->decorated->executeProcessCallbacks($value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntityText.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityText.php
@@ -88,4 +88,11 @@ class ResourceFieldEntityText extends ResourceFieldEntity implements ResourceFie
     $this->decorated->setRequest($request);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinition() {
+    return $this->decorated->getDefinition();
+  }
+
 }

--- a/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
@@ -8,6 +8,7 @@
 namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldFileEntityReference extends ResourceFieldEntityReference implements ResourceFieldEntityReferenceInterface {
@@ -36,6 +37,20 @@ class ResourceFieldFileEntityReference extends ResourceFieldEntityReference impl
     }
     $file_array = $property_wrapper->value();
     return new \EntityDrupalWrapper('file', $file_array['fid']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldFileEntityReference.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Plugin\resource\Field\ResourceFieldFileEntityReference.
+ */
+
+namespace Drupal\restful\Plugin\resource\Field;
+
+use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
+
+class ResourceFieldFileEntityReference extends ResourceFieldEntityReference implements ResourceFieldEntityReferenceInterface {
+
+  // TODO: Add testing to this!
+  /**
+   * Get the wrapper for the property associated to the current field.
+   *
+   * @param DataInterpreterInterface $interpreter
+   *   The data source.
+   *
+   * @return \EntityMetadataWrapper
+   *   Either a \EntityStructureWrapper or a \EntityListWrapper.
+   *
+   * @throws ServerConfigurationException
+   */
+  protected function propertyWrapper(DataInterpreterInterface $interpreter) {
+    $property_wrapper = parent::propertyWrapper($interpreter);
+    // If the file_entity module is not installed, throw an exception.
+    if (!module_exists('file_entity')) {
+      throw new ServerConfigurationException(sprintf('You cannot use %s if file_entity is not installed.', __CLASS__));
+    }
+    // If the wrapper is around the file array, then get the entity wrapper.
+    if ($property_wrapper instanceof \EntityDrupalWrapper) {
+      return $property_wrapper;
+    }
+    $file_array = $property_wrapper->value();
+    return new \EntityDrupalWrapper('file', $file_array['fid']);
+  }
+
+}

--- a/src/Plugin/resource/Field/ResourceFieldInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldInterface.php
@@ -265,4 +265,12 @@ interface ResourceFieldInterface {
    */
   public function setRequest(RequestInterface $request);
 
+  /**
+   * Gets the original field definition as declared in Resource::publicFields().
+   *
+   * @return array
+   *   The field definition.
+   */
+  public function getDefinition();
+
 }

--- a/src/Plugin/resource/Field/ResourceFieldInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldInterface.php
@@ -111,13 +111,15 @@ interface ResourceFieldInterface {
    *
    * @param array $field
    *   Contains the field values.
+   * @param RequestInterface $request
+   *   The request.
    *
    * @return ResourceFieldInterface
    *   The created field
    *
    * @throws ServerConfigurationException
    */
-  public static function create(array $field);
+  public static function create(array $field, RequestInterface $request = NULL);
 
   /**
    * Gets the value for the field given a data source.

--- a/src/Plugin/resource/Field/ResourceFieldInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldInterface.php
@@ -9,6 +9,7 @@ namespace Drupal\restful\Plugin\resource\Field;
 
 use Drupal\restful\Exception\IncompatibleFieldDefinitionException;
 use Drupal\restful\Exception\ServerConfigurationException;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Resource\ResourceManager;
 
@@ -245,5 +246,21 @@ interface ResourceFieldInterface {
    *   constants.
    */
   public function cardinality();
+
+  /**
+   * Get the request in the data provider.
+   *
+   * @return RequestInterface
+   *   The request.
+   */
+  public function getRequest();
+
+  /**
+   * Set the request.
+   *
+   * @param RequestInterface $request
+   *   The request.
+   */
+  public function setRequest(RequestInterface $request);
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldKeyValue.php
+++ b/src/Plugin/resource/Field/ResourceFieldKeyValue.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 
 class ResourceFieldKeyValue extends ResourceField implements ResourceFieldInterface {
@@ -14,8 +15,9 @@ class ResourceFieldKeyValue extends ResourceField implements ResourceFieldInterf
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field) {
-    $resource_field = new static($field);
+  public static function create(array $field, RequestInterface $request = NULL) {
+    $request = $request ?: restful()->getRequest();
+    $resource_field = new static($field, $request);
     $resource_field->addDefaults();
     return $resource_field;
   }

--- a/src/Plugin/resource/Field/ResourceFieldResource.php
+++ b/src/Plugin/resource/Field/ResourceFieldResource.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Plugin\resource\ResourceInterface;
 
@@ -47,8 +48,14 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
    *
    * @param array $field
    *   Contains the field values.
+   *
+   * @param RequestInterface $request
+   *   The request.
    */
-  public function __construct(array $field) {
+  public function __construct(array $field, RequestInterface $request) {
+    if ($this->decorated) {
+      $this->setRequest($request);
+    }
     $this->resourceMachineName = $field['resource']['name'];
   }
 
@@ -102,9 +109,9 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
   /**
    * {@inheritdoc}
    */
-  public static function create(array $field) {
-    $resource_field = ResourceField::create($field);
-    $output = new static($field);
+  public static function create(array $field, RequestInterface $request = NULL) {
+    $resource_field = ResourceField::create($field, $request);
+    $output = new static($field, $request);
     $output->decorate($resource_field);
     return $output;
   }
@@ -304,6 +311,20 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
    */
   public function __call($name, $arguments) {
     return call_user_func_array(array($this->decorated, $name), $arguments);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequest() {
+    return $this->decorated->getRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRequest(RequestInterface $request) {
+    $this->decorated->setRequest($request);
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldResource.php
+++ b/src/Plugin/resource/Field/ResourceFieldResource.php
@@ -110,6 +110,7 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
    * {@inheritdoc}
    */
   public static function create(array $field, RequestInterface $request = NULL) {
+    $request = $request ?: restful()->getRequest();
     $resource_field = ResourceField::create($field, $request);
     $output = new static($field, $request);
     $output->decorate($resource_field);

--- a/src/Plugin/resource/Field/ResourceFieldResource.php
+++ b/src/Plugin/resource/Field/ResourceFieldResource.php
@@ -328,4 +328,11 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
     $this->decorated->setRequest($request);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinition() {
+    return $this->decorated->getDefinition();
+  }
+
 }

--- a/src/Plugin/resource/Resource.php
+++ b/src/Plugin/resource/Resource.php
@@ -82,7 +82,7 @@ abstract class Resource extends PluginBase implements ResourceInterface {
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->fieldDefinitions = ResourceFieldCollection::factory($this->processPublicFields($this->publicFields()));
+    $this->fieldDefinitions = ResourceFieldCollection::factory($this->processPublicFields($this->publicFields()), $this->getRequest());
 
     $this->initAuthenticationManager();
   }
@@ -148,6 +148,10 @@ abstract class Resource extends PluginBase implements ResourceInterface {
     $this->request = $request;
     // Make sure that the request is updated in the data provider.
     $this->getDataProvider()->setRequest($request);
+    foreach ($this->fieldDefinitions as $resource_field) {
+      /* @var \Drupal\restful\Plugin\resource\Field\ResourceFieldInterface $resource_field */
+      $resource_field->setRequest($request);
+    }
   }
 
   /**

--- a/src/Plugin/resource/ResourceEntity.php
+++ b/src/Plugin/resource/ResourceEntity.php
@@ -58,7 +58,7 @@ abstract class ResourceEntity extends Resource {
     $field_definitions = $this->getFieldDefinitions();
     if (!empty($plugin_definition['dataProvider']['viewMode'])) {
       $field_definitions_array = $this->viewModeFields($plugin_definition['dataProvider']['viewMode']);
-      $field_definitions = ResourceFieldCollection::factory($field_definitions_array);
+      $field_definitions = ResourceFieldCollection::factory($field_definitions_array, $this->getRequest());
     }
     $class_name = $this->dataProviderClassName();
     if (!class_exists($class_name)) {

--- a/src/Plugin/resource/ResourceEntity.php
+++ b/src/Plugin/resource/ResourceEntity.php
@@ -8,12 +8,12 @@
 namespace Drupal\restful\Plugin\resource;
 
 use Drupal\restful\Exception\InternalServerErrorException;
-use Drupal\restful\Exception\NotImplementedException;
 use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderEntityInterface;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldCollection;
+use Drupal\restful\Plugin\resource\Field\ResourceFieldEntity;
 
 abstract class ResourceEntity extends Resource {
 
@@ -187,7 +187,12 @@ abstract class ResourceEntity extends Resource {
     // ResourceFieldEntity. Otherwise they will be considered regular
     // ResourceField.
     $field_definitions = array_map(function ($field_definition) {
-      return $field_definition + array('class' => '\Drupal\restful\Plugin\resource\Field\ResourceFieldEntity');
+      $field_entity_class = '\Drupal\restful\Plugin\resource\Field\ResourceFieldEntity';
+      $class_name = ResourceFieldEntity::fieldClassName($field_definition);
+      if (!$class_name || is_subclass_of($class_name, $field_entity_class)) {
+        $class_name = $field_entity_class;
+      }
+      return $field_definition + array('class' => $class_name);
     }, $field_definitions);
 
     // If there is an alternate id field, use it instead of the entity id.

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -103,7 +103,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
       /* @var \EntityStructureWrapper $text_multiple_wrapper */
       $expected['text_multiple'][] = $text_multiple_wrapper->value();
     }
-    $this->assertEqual($expected, $attributes);
+    $this->assertEqual(array_filter($expected), array_filter($attributes));
     $this->assertEqual($this->handler->versionedUrl($wrapper->getIdentifier()), $result['links']['self']);
 
     // 2. Assert the relationships.
@@ -249,6 +249,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
       $this->assertEqual($this->entities[$delta]->pid, $row['id']);
     }
 
+    $expected = array_filter($expected);
     $attributes = array_filter($result['data'][2]['attributes']);
     $this->assertEqual($expected, $attributes);
 

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -53,7 +53,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
    * {@inheritdoc}
    */
   public function setUp() {
-    parent::setUp('restful_example', 'restful_test', 'entityreference');
+    parent::setUp('restful_example', 'restful_test', 'entityreference', 'uuid');
 
     restful_test_add_fields();
 
@@ -379,6 +379,57 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
   }
 
   /**
+   * Test alternative ID field.
+   */
+  public function testAlternativeIdField() {
+    $entities = $this->createEntities();
+    $resource_manager = restful()->getResourceManager();
+    $resource_manager->clearPluginCache('main:1.7');
+    $handler = $resource_manager->getPlugin('main:1.7');
+
+    // Add files and taxonomy term references.
+    $query = new EntityFieldQuery();
+    $result = $query
+      ->entityCondition('entity_type', 'taxonomy_term')
+      ->entityCondition('bundle', 'test_vocab')
+      ->execute();
+    $tids = array_keys($result['taxonomy_term']);
+
+    $images = array();
+    foreach ($this->drupalGetTestFiles('image') as $file) {
+      $file = file_save($file);
+      $images[] = $file->fid;
+    }
+
+    $entities[2]->term_single[LANGUAGE_NONE][] = array('tid' => $tids[0]);
+    $entities[2]->term_multiple[LANGUAGE_NONE][] = array('tid' => $tids[1]);
+    $entities[2]->term_multiple[LANGUAGE_NONE][] = array('tid' => $tids[2]);
+    $entities[2]->file_single[LANGUAGE_NONE][] = array('fid' => $images[0], 'display' => TRUE);
+    $entities[2]->file_multiple[LANGUAGE_NONE][] = array('fid' => $images[1], 'display' => TRUE);
+    $entities[2]->file_multiple[LANGUAGE_NONE][] = array('fid' => $images[2], 'display' => TRUE);
+    entity_save('entity_test', $entities[2]);
+
+
+    $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->pid));
+    $handler->setPath($entities[2]->pid);
+
+    $result = restful()
+      ->getFormatterManager()
+      ->negotiateFormatter(NULL, 'json_api')
+      ->prepare($handler->process());
+
+    $result = $result['data'][0]['attributes'];
+
+    // Make sure that IDs are UUID.
+    $this->assertEqual(count(entity_uuid_load('file', array($result['file_single']))), 1, 'UUID correctly loaded for: file_single');
+    $this->assertEqual(count(entity_uuid_load('file', $result['file_multiple'])), 2, 'UUID correctly loaded for: file_multiple');
+    $this->assertEqual(count(entity_uuid_load('taxonomy_term', array($result['term_single']))), 1, 'UUID correctly loaded for: term_single');
+    $this->assertEqual(count(entity_uuid_load('taxonomy_term', $result['term_multiple'])), 2, 'UUID correctly loaded for: term_multiple');
+    $this->assertEqual(count(entity_uuid_load('entity_test', array($result['entity_reference_single']))), 1, 'UUID correctly loaded for: entity_reference_single');
+    $this->assertEqual(count(entity_uuid_load('entity_test', $result['entity_reference_multiple'])), 2, 'UUID correctly loaded for: entity_reference_multiple');
+  }
+
+  /**
    * Create test entities.
    *
    * @return Entity[]
@@ -402,22 +453,14 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
       'name' => 'main',
       'uid' => $this->account->uid,
     ));
-    /* @var \EntityDrupalWrapper $wrapper */
-    $wrapper = entity_metadata_wrapper('entity_test', $entities[2]);
 
-    $text1 = $this->randomName();
-    $text2 = $this->randomName();
+    $entities[0]->entity_reference_single[LANGUAGE_NONE][] = array('target_id' => $entities[1]->pid);
+    $entities[0]->save();
+    $entities[2]->entity_reference_single[LANGUAGE_NONE][] = array('target_id' => $entities[0]->pid);
+    $entities[2]->entity_reference_multiple[LANGUAGE_NONE][] = array('target_id' => $entities[0]->pid);
+    $entities[2]->entity_reference_multiple[LANGUAGE_NONE][] = array('target_id' => $entities[1]->pid);
+    $entities[2]->save();
 
-
-    $wrapper->text_single->set($text1);
-    $wrapper->text_multiple->set(array($text1, $text2));
-
-    $wrapper->entity_reference_single->set($entities[0]);
-    $wrapper->entity_reference_single->entity_reference_single->set($entities[1]);
-    $wrapper->entity_reference_multiple[] = $entities[0];
-    $wrapper->entity_reference_multiple[] = $entities[1];
-
-    $wrapper->save();
     return $entities;
   }
 

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -129,6 +129,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $expected_includes = array(
       array(
         'attributes' => array(
+          'entity_reference_single' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
           'id' => $wrapper->entity_reference_multiple[0]->getIdentifier(),
           'label' => $wrapper->entity_reference_multiple[0]->label(),
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
@@ -139,6 +140,15 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
         ),
         'type' => 'main',
+        'relationships' => array(
+          'entity_reference_single_resource' => array(
+            'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+            'links' => array(
+              'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+            ),
+            'type' => 'main',
+          ),
+        ),
       ),
       array(
         'attributes' => array(
@@ -184,8 +194,21 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $resource_field_collections = $this->handler->process();
     $result = drupal_json_decode($this->formatter->format($resource_field_collections));
     $included = $result['included'];
-    $this->assertEqual(1, count($included));
+    $this->assertEqual(2, count($included));
     $expected_includes = array(
+      array(
+        'type' => 'main',
+        'id' => (string) $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+        'links' => array(
+          'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->entity_reference_single->getIdentifier()),
+        ),
+        'attributes' => array(
+          'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+          'label' => $wrapper->entity_reference_single->entity_reference_single->label(),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->entity_reference_single->getIdentifier()),
+        ),
+      ),
       array(
         'type' => 'main',
         'id' => (string) $wrapper->entity_reference_single->getIdentifier(),
@@ -194,14 +217,25 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->getIdentifier()),
         ),
         'attributes' => array(
+          'entity_reference_single' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
           'id' => $wrapper->entity_reference_single->getIdentifier(),
           'label' => $wrapper->entity_reference_single->label(),
           'self' => $this->handler->versionedUrl($wrapper->entity_reference_single->getIdentifier()),
+        ),
+        'relationships' => array(
+          'entity_reference_single_resource' => array(
+            'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+            'type' => 'main',
+            'links' => array(
+              'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+            ),
+          ),
         ),
       ),
     );
     // Remove the empty fields from the actual response for easier comparison.
     $included[0]['attributes'] = array_filter($included[0]['attributes']);
+    $included[1]['attributes'] = array_filter($included[1]['attributes']);
     $this->assertEqual($expected_includes, $included);
 
 
@@ -314,6 +348,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $wrapper->text_multiple->set(array($text1, $text2));
 
     $wrapper->entity_reference_single->set($entities[0]);
+    $wrapper->entity_reference_single->entity_reference_single->set($entities[1]);
     $wrapper->entity_reference_multiple[] = $entities[0];
     $wrapper->entity_reference_multiple[] = $entities[1];
 

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -385,6 +385,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
   public function testAlternativeIdField() {
     $entities = $this->createEntities();
     $resource_manager = restful()->getResourceManager();
+    $format_manager = restful()->getFormatterManager();
     $resource_manager->clearPluginCache('main:1.7');
     $handler = $resource_manager->getPlugin('main:1.7');
 
@@ -414,8 +415,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid));
     $handler->setPath($entities[2]->uuid);
 
-    $response = restful()
-      ->getFormatterManager()
+    $response = $format_manager
       ->negotiateFormatter(NULL, 'json_api')
       ->prepare($handler->process());
 
@@ -442,8 +442,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid));
     $handler->setPath($entities[2]->uuid);
     try {
-      restful()
-        ->getFormatterManager()
+      $format_manager
         ->negotiateFormatter(NULL, 'json_api')
         ->prepare($handler->process());
       $this->fail('Entity can be loaded with uuid when there is no idField.');
@@ -452,6 +451,30 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
       $this->pass('Entity cannot be loaded with uuid when there is no idField.');
     }
     variable_del('restful_test_alternative_id_error');
+
+    // Clear caches to remove error field.
+    $resource_manager->clearPluginCache('main:1.7');
+    $handler = $resource_manager->getPlugin('main:1.7');
+    $format_manager->setResource($handler);
+
+    // Filter the entities by the reference.
+    $handler->setRequest(Request::create('api/main/v1.7', array(
+      'filter' => array('entity_reference_single' => $entities[0]->uuid),
+    )));
+    $handler->setPath('');
+    $response = drupal_json_decode($format_manager
+      ->format($handler->process(), 'json_api'));
+    // Assert that $entities[2] points to $entities[0]
+    $this->assertEqual($response['data'][0]['id'], $entities[2]->uuid);
+    // Filter the entities by the reference.
+    $handler->setRequest(Request::create('api/main/v1.7', array(
+      'filter' => array('entity_reference_multiple' => $entities[1]->uuid),
+    )));
+    $handler->setPath('');
+    $response = drupal_json_decode($format_manager
+      ->format($handler->process(), 'json_api'));
+    // Assert that $entities[2] points to $entities[0]
+    $this->assertEqual($response['data'][0]['id'], $entities[2]->uuid);
   }
 
   /**

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -386,6 +386,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $entities = $this->createEntities();
     $resource_manager = restful()->getResourceManager();
     $format_manager = restful()->getFormatterManager();
+    $formatter = $format_manager->negotiateFormatter(NULL, 'json_api');
     $resource_manager->clearPluginCache('main:1.7');
     $handler = $resource_manager->getPlugin('main:1.7');
 
@@ -414,12 +415,10 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
 
     $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid));
     $handler->setPath($entities[2]->uuid);
+    $formatter->setResource($handler);
+    $response = $formatter->prepare($handler->process());
 
-    $response = $format_manager
-      ->negotiateFormatter(NULL, 'json_api')
-      ->prepare($handler->process());
-
-    $result = $response['data'][0]['attributes'];
+    $result = $response['data']['attributes'];
 
     // Make sure that IDs are UUID.
     $this->assertEqual(count(entity_uuid_load('file', array($result['file_single']))), 1, 'UUID correctly loaded for: file_single');
@@ -430,9 +429,12 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $this->assertEqual(count(entity_uuid_load('entity_test', $result['entity_reference_multiple'])), 2, 'UUID correctly loaded for: entity_reference_multiple');
 
     // Assert relationship.
-    $relationships = $response['data'][0]['relationships'];
+    $relationships = $response['data']['relationships'];
     $this->assertEqual($relationships['entity_reference_resource']['id'], $entities[0]->uuid);
     $this->assertEqual($relationships['entity_reference_resource']['type'], 'main');
+
+    // Assert that the self link contains the UUID.
+    $this->assertTrue(strpos($response['links']['self'], $entities[2]->uuid) !== FALSE, 'UUID found in self link.');
 
     // Test that if referencedIdProperty and idField don't match, embedding does
     // not happen.
@@ -441,6 +443,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $handler = $resource_manager->getPlugin('main:1.7');
     $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid));
     $handler->setPath($entities[2]->uuid);
+    $format_manager->setResource($handler);
     try {
       $format_manager
         ->negotiateFormatter(NULL, 'json_api')
@@ -455,15 +458,14 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     // Clear caches to remove error field.
     $resource_manager->clearPluginCache('main:1.7');
     $handler = $resource_manager->getPlugin('main:1.7');
-    $format_manager->setResource($handler);
 
     // Filter the entities by the reference.
     $handler->setRequest(Request::create('api/main/v1.7', array(
       'filter' => array('entity_reference_single' => $entities[0]->uuid),
     )));
     $handler->setPath('');
-    $response = drupal_json_decode($format_manager
-      ->format($handler->process(), 'json_api'));
+    $formatter->setResource($handler);
+    $response = $formatter->prepare($handler->process());
     // Assert that $entities[2] points to $entities[0]
     $this->assertEqual($response['data'][0]['id'], $entities[2]->uuid);
     // Filter the entities by the reference.
@@ -471,8 +473,8 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
       'filter' => array('entity_reference_multiple' => $entities[1]->uuid),
     )));
     $handler->setPath('');
-    $response = drupal_json_decode($format_manager
-      ->format($handler->process(), 'json_api'));
+    $formatter->setResource($handler);
+    $response = $formatter->prepare($handler->process());
     // Assert that $entities[2] points to $entities[0]
     $this->assertEqual($response['data'][0]['id'], $entities[2]->uuid);
   }

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -5,7 +5,7 @@
  * Contains \RestfulJsonApiTestCase
  */
 
-use Drupal\restful\Http\RequestInterface;
+use Drupal\restful\Exception\UnprocessableEntityException;
 use Drupal\restful\Http\Request;
 
 class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
@@ -411,15 +411,15 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     entity_save('entity_test', $entities[2]);
 
 
-    $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->pid));
-    $handler->setPath($entities[2]->pid);
+    $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid));
+    $handler->setPath($entities[2]->uuid);
 
-    $result = restful()
+    $response = restful()
       ->getFormatterManager()
       ->negotiateFormatter(NULL, 'json_api')
       ->prepare($handler->process());
 
-    $result = $result['data'][0]['attributes'];
+    $result = $response['data'][0]['attributes'];
 
     // Make sure that IDs are UUID.
     $this->assertEqual(count(entity_uuid_load('file', array($result['file_single']))), 1, 'UUID correctly loaded for: file_single');
@@ -428,6 +428,30 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $this->assertEqual(count(entity_uuid_load('taxonomy_term', $result['term_multiple'])), 2, 'UUID correctly loaded for: term_multiple');
     $this->assertEqual(count(entity_uuid_load('entity_test', array($result['entity_reference_single']))), 1, 'UUID correctly loaded for: entity_reference_single');
     $this->assertEqual(count(entity_uuid_load('entity_test', $result['entity_reference_multiple'])), 2, 'UUID correctly loaded for: entity_reference_multiple');
+
+    // Assert relationship.
+    $relationships = $response['data'][0]['relationships'];
+    $this->assertEqual($relationships['entity_reference_resource']['id'], $entities[0]->uuid);
+    $this->assertEqual($relationships['entity_reference_resource']['type'], 'main');
+
+    // Test that if referencedIdProperty and idField don't match, embedding does
+    // not happen.
+    variable_set('restful_test_alternative_id_error', TRUE);
+    $resource_manager->clearPluginCache('main:1.7');
+    $handler = $resource_manager->getPlugin('main:1.7');
+    $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid));
+    $handler->setPath($entities[2]->uuid);
+    try {
+      restful()
+        ->getFormatterManager()
+        ->negotiateFormatter(NULL, 'json_api')
+        ->prepare($handler->process());
+      $this->fail('Entity can be loaded with uuid when there is no idField.');
+    }
+    catch (UnprocessableEntityException $e) {
+      $this->pass('Entity cannot be loaded with uuid when there is no idField.');
+    }
+    variable_del('restful_test_alternative_id_error');
   }
 
   /**

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -169,7 +169,72 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $included[1]['attributes'] = array_filter($included[1]['attributes']);
     $this->assertEqual($expected_includes, $included);
 
-    // 3. Assert the attributes for a list.
+    // 3. Assert the nested relationships.
+    $relationships = $result['data']['relationships'];
+    // Make sure that the entity_reference_*_resource are included as
+    // relationships.
+    $this->assertEqual($relationships['entity_reference_single_resource']['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_single_resource']['id'], $wrapper->entity_reference_single->getIdentifier());
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['id'], $wrapper->entity_reference_multiple[0]->getIdentifier());
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['id'], $wrapper->entity_reference_multiple[1]->getIdentifier());
+
+    // Make a request with the include query string.
+    $this->handler->setRequest(Request::create('api/v1.1/main/' . $wrapper->getIdentifier(), array('include' => 'entity_reference_single_resource.entity_reference_single_resource')));
+    $this->handler->setPath($wrapper->getIdentifier());
+    $this->formatter->setResource($this->handler);
+    $resource_field_collections = $this->handler->process();
+    $result = drupal_json_decode($this->formatter->format($resource_field_collections));
+    $included = $result['included'];
+    // Make sure there are no repeated includes.
+    $this->assertEqual(2, count($included));
+    $expected_includes = array(
+      array(
+        'attributes' => array(
+          'entity_reference_single' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+          'id' => $wrapper->entity_reference_multiple[0]->getIdentifier(),
+          'label' => $wrapper->entity_reference_multiple[0]->label(),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
+        ),
+        'id' => $wrapper->entity_reference_multiple[0]->getIdentifier(),
+        'links' => array(
+          'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_multiple[0]->getIdentifier())))),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[0]->getIdentifier()),
+        ),
+        'type' => 'main',
+        'relationships' => array(
+          'entity_reference_single_resource' => array(
+            'id' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier(),
+            'links' => array(
+              'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_single->entity_reference_single->getIdentifier())))),
+            ),
+            'type' => 'main',
+          ),
+        ),
+      ),
+      array(
+        'attributes' => array(
+          'id' => $wrapper->entity_reference_multiple[1]->getIdentifier(),
+          'label' => $wrapper->entity_reference_multiple[1]->label(),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[1]->getIdentifier()),
+        ),
+        'id' => $wrapper->entity_reference_multiple[1]->getIdentifier(),
+        'links' => array(
+          'related' => $this->handler->versionedUrl('', array('query' => array('filter' => array('entity_reference_single_resource' => $wrapper->entity_reference_multiple[1]->getIdentifier())))),
+          'self' => $this->handler->versionedUrl($wrapper->entity_reference_multiple[1]->getIdentifier()),
+        ),
+        'type' => 'main',
+      ),
+    );
+    // Remove the empty fields from the actual response for easier comparison.
+    $included[0]['attributes'] = array_filter($included[0]['attributes']);
+    $included[1]['attributes'] = array_filter($included[1]['attributes']);
+    sort($expected_includes);
+    sort($included);
+    $this->assertEqual($expected_includes, $included);
+
+    // 4. Assert the attributes for a list.
     // Make a list request and check the attributes.
     $this->handler->setRequest(Request::create(''));
     $this->handler->setPath('');
@@ -187,7 +252,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $attributes = array_filter($result['data'][2]['attributes']);
     $this->assertEqual($expected, $attributes);
 
-    // 4. Assert the relationships for a list.
+    // 5. Assert the relationships for a list.
     $this->handler->setRequest(Request::create('', array('include' => 'entity_reference_single_resource')));
     $this->handler->setPath('');
     $this->formatter->setResource($this->handler);
@@ -239,7 +304,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $this->assertEqual($expected_includes, $included);
 
 
-    // 5. Assert request processing.
+    // 6. Assert request processing.
     $request = Request::create('', array(
       'fields' => 'first.second.third.fourth,first.third.fourth',
       'include' => 'fifth.sixth.seventh',

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -203,6 +203,16 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     // Remove the empty fields from the actual response for easier comparison.
     $included[0]['attributes'] = array_filter($included[0]['attributes']);
     $this->assertEqual($expected_includes, $included);
+
+
+    // 5. Assert request processing.
+    $request = Request::create('', array(
+      'fields' => 'first.second.third.fourth,first.third.fourth',
+      'include' => 'fifth.sixth.seventh',
+    ));
+    $input = $request->getParsedInput();
+    $this->assertEqual($input['fields'], 'first,first.second,first.second.third,first.second.third.fourth,first.third,first.third.fourth');
+    $this->assertEqual($input['include'], 'fifth,fifth.sixth,fifth.sixth.seventh');
   }
 
   /**

--- a/tests/modules/restful_test/restful_test.install
+++ b/tests/modules/restful_test/restful_test.install
@@ -41,6 +41,7 @@ function restful_test_schema_alter(&$schema = array()) {
  * Implements hook_uninstall().
  */
 function restful_test_uninstall() {
+  variable_del('restful_test_alternative_id_error');
   field_attach_delete_bundle('restful_test_translatable_entity', 'restful_test_translatable_entity');
 }
 

--- a/tests/modules/restful_test/restful_test.install
+++ b/tests/modules/restful_test/restful_test.install
@@ -6,6 +6,38 @@
  */
 
 /**
+ * Implements hook_install().
+ */
+function restful_test_install() {
+  if (!db_field_exists('entity_test', 'uuid')) {
+    db_add_field('entity_test', 'uuid', array(
+      'type' => 'char',
+      'length' => 36,
+      'not null' => TRUE,
+      'default' => '',
+      'description' => 'The Universally Unique Identifier.',
+    ));
+    db_add_index('entity_test', 'uuid', array('uuid'));
+  }
+}
+
+/**
+ * Implements hook_schema_alter().
+ */
+function restful_test_schema_alter(&$schema = array()) {
+  $field = array(
+    'type' => 'char',
+    'length' => 36,
+    'not null' => TRUE,
+    'default' => '',
+    'description' => 'The Universally Unique Identifier.',
+  );
+  foreach (array('entity_test', 'restful_test_translatable_entity') as $table) {
+    $schema[$table]['fields']['uuid'] = $field;
+  }
+}
+
+/**
  * Implements hook_uninstall().
  */
 function restful_test_uninstall() {
@@ -44,9 +76,17 @@ function restful_test_schema() {
         'not null' => TRUE,
         'default' => '',
       ),
+      'uuid' => array(
+        'type' => 'char',
+        'length' => 36,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The Universally Unique Identifier.',
+      ),
     ),
     'indexes' => array(
       'uid' => array('uid'),
+      'uuid' => array('uuid'),
     ),
     'foreign keys' => array(
       'uid' => array('users' => 'uid'),

--- a/tests/modules/restful_test/restful_test.module
+++ b/tests/modules/restful_test/restful_test.module
@@ -426,6 +426,7 @@ function restful_test_entity_info() {
         'id' => 'pid',
         'bundle' => 'name',
         'label' => 'label',
+        'uuid' => 'uuid',
       ),
       // Make use the class' label() and uri() implementation by default.
       'label callback' => 'entity_class_label',
@@ -442,6 +443,7 @@ function restful_test_entity_info() {
       'translation' => array(
         'locale' => TRUE,
       ),
+      'uuid' => TRUE,
     ),
   );
 }
@@ -456,5 +458,42 @@ function restful_test_restful_resource_alter(\Drupal\restful\Plugin\resource\Res
   // Disable the Files Upload resource based on the settings variable.
   if ($resource->getResourceMachineName() == 'files_upload_test') {
     variable_get('restful_file_upload', FALSE) ? $resource->enable() : $resource->disable();
+  }
+}
+
+/**
+ * Implements hook_entity_info_alter().
+ */
+function restful_test_entity_info_alter(&$entity_info) {
+  $entity_info['entity_test']['uuid'] = TRUE;
+  $entity_info['entity_test']['entity keys']['uuid'] = 'uuid';
+}
+
+/**
+ * Implements hook_entity_property_info_alter().
+ */
+function restful_test_entity_property_info_alter(&$info) {
+  $entity_types = array('entity_test', 'restful_test_translatable_entity');
+  foreach ($entity_types as $entity_type) {
+    $entity_info = entity_get_info($entity_type);
+    if (isset($entity_info['uuid']) && $entity_info['uuid'] == TRUE
+      && !empty($entity_info['entity keys']['uuid'])
+      && empty($info[$entity_type]['properties'][$entity_info['entity keys']['uuid']])) {
+      $info[$entity_type]['properties'][$entity_info['entity keys']['uuid']] = array(
+        'label' => t('UUID'),
+        'type' => 'text',
+        'description' => t('The universally unique ID.'),
+        'schema field' => $entity_info['entity keys']['uuid'],
+      );
+      if (!empty($entity_info['entity keys']['revision uuid'])
+        && empty($info[$entity_type]['properties'][$entity_info['entity keys']['revision uuid']])) {
+        $info[$entity_type]['properties'][$entity_info['entity keys']['revision uuid']] = array(
+          'label' => t('Revision UUID'),
+          'type' => 'text',
+          'description' => t("The revision's universally unique ID."),
+          'schema field' => $entity_info['entity keys']['revision uuid'],
+        );
+      }
+    }
   }
 }

--- a/tests/modules/restful_test/src/Plugin/resource/entity_test/main/v1/Main__1_7.php
+++ b/tests/modules/restful_test/src/Plugin/resource/entity_test/main/v1/Main__1_7.php
@@ -27,6 +27,7 @@ use Drupal\restful\Plugin\resource\ResourceInterface;
  *     "bundles": {
  *       "main"
  *     },
+ *     "idField": "uuid"
  *   },
  *   majorVersion = 1,
  *   minorVersion = 7
@@ -39,48 +40,79 @@ class Main__1_7 extends Main__1_0 implements ResourceInterface {
    */
   protected function publicFields() {
     $public_fields = parent::publicFields();
+    $public_fields['uuid'] = array(
+      'property' => 'uuid',
+      'methods' => array(),
+    );
 
-    // Single entity reference field with "resource".
+    // Single entity reference field without "resource".
     $public_fields['entity_reference_single'] = array(
       'property' => 'entity_reference_single',
       'referencedIdProperty' => 'uuid',
-      // Add a fake resource to get only the ID.
     );
 
-    // Multiple entity reference field with "resource".
+    // Single entity reference field with "resource" that loads by uuid.
+    $public_fields['entity_reference_resource'] = array(
+      'property' => 'entity_reference_single',
+      'referencedIdProperty' => 'uuid',
+      'resource' => array(
+        'name' => 'main',
+        'majorVersion' => 1,
+        'minorVersion' => 7,
+      ),
+    );
+
+    // Multiple entity reference field without "resource".
     $public_fields['entity_reference_multiple'] = array(
       'property' => 'entity_reference_multiple',
       'referencedIdProperty' => 'uuid',
-      // Add a fake resource to get only the ID.
     );
 
     $public_fields['term_single'] = array(
       'property' => 'term_single',
       'referencedIdProperty' => 'uuid',
-      // Add a fake resource to get only the ID.
     );
 
     $public_fields['term_multiple'] = array(
       'property' => 'term_multiple',
       'referencedIdProperty' => 'uuid',
-      // Add a fake resource to get only the ID.
     );
 
     $public_fields['file_single'] = array(
       'property' => 'file_single',
       'class' => '\Drupal\restful\Plugin\resource\Field\ResourceFieldFileEntityReference',
       'referencedIdProperty' => 'uuid',
-      // Add a fake resource to get only the ID.
     );
 
     $public_fields['file_multiple'] = array(
       'property' => 'file_multiple',
       'class' => '\Drupal\restful\Plugin\resource\Field\ResourceFieldFileEntityReference',
       'referencedIdProperty' => 'uuid',
-      // Add a fake resource to get only the ID.
     );
 
     return $public_fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function processPublicFields(array $field_definitions) {
+    $field_definitions = parent::processPublicFields($field_definitions);
+    if (variable_get('restful_test_alternative_id_error', FALSE)) {
+      // Single entity reference field with "resource" that does not load by
+      // uuid.
+      $field_definitions['entity_reference_resource_error'] = array(
+        'property' => 'entity_reference_single',
+        'referencedIdProperty' => 'uuid',
+        'resource' => array(
+          'name' => 'main',
+          'majorVersion' => 1,
+          'minorVersion' => 6,
+        ),
+      );
+    }
+
+    return $field_definitions;
   }
 
 }

--- a/tests/modules/restful_test/src/Plugin/resource/entity_test/main/v1/Main__1_7.php
+++ b/tests/modules/restful_test/src/Plugin/resource/entity_test/main/v1/Main__1_7.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful_test\Plugin\resource\entity_test\main\v1\Main__1_7.
+ */
+
+namespace Drupal\restful_test\Plugin\resource\entity_test\main\v1;
+
+use Drupal\restful\Plugin\resource\ResourceInterface;
+
+/**
+ * Class Main__1_7
+ * @package Drupal\restful_test\Plugin\resource
+ *
+ * @Resource(
+ *   name = "main:1.7",
+ *   resource = "main",
+ *   label = "Main",
+ *   description = "Export the entity test 'main' bundle.",
+ *   authenticationTypes = {
+ *     "basic_auth",
+ *     "cookie"
+ *   },
+ *   dataProvider = {
+ *     "entityType": "entity_test",
+ *     "bundles": {
+ *       "main"
+ *     },
+ *   },
+ *   majorVersion = 1,
+ *   minorVersion = 7
+ * )
+ */
+class Main__1_7 extends Main__1_0 implements ResourceInterface {
+
+  /**
+   * Overrides ResourceEntity::publicFields().
+   */
+  protected function publicFields() {
+    $public_fields = parent::publicFields();
+
+    // Single entity reference field with "resource".
+    $public_fields['entity_reference_single'] = array(
+      'property' => 'entity_reference_single',
+      'referencedIdProperty' => 'uuid',
+      // Add a fake resource to get only the ID.
+    );
+
+    // Multiple entity reference field with "resource".
+    $public_fields['entity_reference_multiple'] = array(
+      'property' => 'entity_reference_multiple',
+      'referencedIdProperty' => 'uuid',
+      // Add a fake resource to get only the ID.
+    );
+
+    $public_fields['term_single'] = array(
+      'property' => 'term_single',
+      'referencedIdProperty' => 'uuid',
+      // Add a fake resource to get only the ID.
+    );
+
+    $public_fields['term_multiple'] = array(
+      'property' => 'term_multiple',
+      'referencedIdProperty' => 'uuid',
+      // Add a fake resource to get only the ID.
+    );
+
+    $public_fields['file_single'] = array(
+      'property' => 'file_single',
+      'class' => '\Drupal\restful\Plugin\resource\Field\ResourceFieldFileEntityReference',
+      'referencedIdProperty' => 'uuid',
+      // Add a fake resource to get only the ID.
+    );
+
+    $public_fields['file_multiple'] = array(
+      'property' => 'file_multiple',
+      'class' => '\Drupal\restful\Plugin\resource\Field\ResourceFieldFileEntityReference',
+      'referencedIdProperty' => 'uuid',
+      // Add a fake resource to get only the ID.
+    );
+
+    return $public_fields;
+  }
+
+}


### PR DESCRIPTION
Suggestions:
- [x] Use the `uuid` module as the alternate ID.

Entity ID (idField):
- [x] Test that the self link and self ID are UUID.
- [x] Test that entities are loaded based on UUID.
- [x] Test that lists can be filtered by UUID.
- [x] Test that the compound resource ID is UUID in JSON API.

Reference fields. Include file, entityreference and taxonomy reference. (referencedPropertyId + idField)
- [x] Test that fields without a resource return the UUID when no resource is specified.
- [x] Test that fields with a resource connect with the embedded entity through the UUID if there is a matching idField.
- [x] Test that fields with a resource do not connect with the embedded entity through the UUID if there is not a matching idField.
