### PR TITLE
JSON API schema

### DIFF
--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -69,7 +69,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
       if ($is_list_request) {
         // Get the total number of items for the current request without
         // pagination.
-        $output['count'] = $data_provider->count();
+        $output['meta']['count'] = $data_provider->count();
       }
       else {
         // For non-list requests do not return an array of one item.
@@ -134,8 +134,10 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
         $combined = $ids ? array_combine($ids, array_pad($value, count($ids), NULL)) : array();
         foreach ($combined as $id => $value_item) {
           $basic_info = array(
-            'type' => $resource_field->getResourceMachineName(),
-            'id' => (string) $id,
+            'data' => array(
+              'type' => $resource_field->getResourceMachineName(),
+              'id' => (string) $id,
+            ),
           );
           // If there is a resource plugin for the parent, set the related
           // links.

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -150,7 +150,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
             ));
           }
           $output['relationships'][$public_field_name][] = $basic_info;
-          $included_item = is_array($value_item) ? $basic_info + $value_item : $basic_info;
+          $included_item = is_array($value_item) ? $basic_info['data'] + $value_item : $basic_info['data'];
           // Set the resource for the reference to get HATEOAS from them.
           $resource_plugin = $resource_field->getResourcePlugin();
           $this->addHateoas($included_item, $resource_plugin, $id);

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -205,8 +205,8 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
     // number of items of the current request plus the number of items in
     // previous pages.
     $items_per_page = empty($original_input['range']) ? $data_provider->getRange() : $original_input['range'];
-    if (isset($data['count']) && $data['count'] > $items_per_page) {
-      $num_pages = ceil($data['count'] / $items_per_page);
+    if (isset($data['meta']['count']) && $data['meta']['count'] > $items_per_page) {
+      $num_pages = ceil($data['meta']['count'] / $items_per_page);
       unset($input['page']);
       $data['links']['first'] = $resource->getUrl(array('query' => $input), FALSE);
 

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -134,10 +134,8 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
         $combined = $ids ? array_combine($ids, array_pad($value, count($ids), NULL)) : array();
         foreach ($combined as $id => $value_item) {
           $basic_info = array(
-            'data' => array(
-              'type' => $resource_field->getResourceMachineName(),
-              'id' => (string) $id,
-            ),
+            'type' => $resource_field->getResourceMachineName(),
+            'id' => (string) $id,
           );
           // If there is a resource plugin for the parent, set the related
           // links.
@@ -149,8 +147,13 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
               ),
             ));
           }
-          $output['relationships'][$public_field_name][] = $basic_info;
-          $included_item = is_array($value_item) ? $basic_info['data'] + $value_item : $basic_info['data'];
+
+          $related_info = array(
+            'data' => array('type' => $basic_info['type'], 'id' => $basic_info['id']),
+            'links' => $basic_info['links']
+          );
+          $output['relationships'][$public_field_name][] = $related_info;
+          $included_item = is_array($value_item) ? $basic_info + $value_item : $basic_info;
           // Set the resource for the reference to get HATEOAS from them.
           $resource_plugin = $resource_field->getResourcePlugin();
           $this->addHateoas($included_item, $resource_plugin, $id);

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -110,12 +110,12 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $relationships = $result['data']['relationships'];
     // Make sure that the entity_reference_*_resource are included as
     // relationships.
-    $this->assertEqual($relationships['entity_reference_single_resource']['type'], 'main');
-    $this->assertEqual($relationships['entity_reference_single_resource']['id'], $wrapper->entity_reference_single->getIdentifier());
-    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['type'], 'main');
-    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['id'], $wrapper->entity_reference_multiple[0]->getIdentifier());
-    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['type'], 'main');
-    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['id'], $wrapper->entity_reference_multiple[1]->getIdentifier());
+    $this->assertEqual($relationships['entity_reference_single_resource']['data']['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_single_resource']['data']['id'], $wrapper->entity_reference_single->getIdentifier());
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['data']['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][0]['data']['id'], $wrapper->entity_reference_multiple[0]->getIdentifier());
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['data']['type'], 'main');
+    $this->assertEqual($relationships['entity_reference_multiple_resource'][1]['data']['id'], $wrapper->entity_reference_multiple[1]->getIdentifier());
 
     // Make a request with the include query string.
     $this->handler->setRequest(Request::create('api/v1.1/main/' . $wrapper->getIdentifier(), array('include' => 'entity_reference_multiple_resource,entity_reference_single_resource')));


### PR DESCRIPTION
This branch moves `count` inside a `meta` object and `type` and `id` from `relationships` into a `data` object, as defined by the [JSON API schema](http://jsonapi.org/schema).
