### PR TITLE
Fix basePath so it works when lang code is in URL

### DIFF
--- a/modules/restful_angular_example/restful_angular_example.module
+++ b/modules/restful_angular_example/restful_angular_example.module
@@ -210,7 +210,7 @@ function restful_angular_example_page($example) {
   if ($example == 'form') {
     // Pass info via Drupal.settings.
     $settings['restfulExample'] = array(
-      'basePath' => url('', array('absolute' => TRUE)),
+      'basePath' => url('', array('absolute' => TRUE)) .'/',
       'csrfToken' => drupal_get_token(\RestfulInterface::TOKEN_VALUE),
       'data' => array(
         'article' => array(


### PR DESCRIPTION
The basePath prepared by `url('', array('absolute' => TRUE))` doesn't have a trailing / like it should. Without it, the example angular code breaks on a site with language codes in the url e.g. domain.com/en/api/v1.5/articles. At present the code tries to go to e.g. domain.com/enapi/v1.5/articles

Not sure why you aren't using Drupal's `base_path()` but assuming you have your reasons :)
