### PR TITLE
Fix path to statically-served files

### DIFF
--- a/modules/restful_angular_example/restful_angular_example.module
+++ b/modules/restful_angular_example/restful_angular_example.module
@@ -235,7 +235,7 @@ function restful_angular_example_page($example) {
     // Theme function simply declares the angular app, and ng-includes the app's
     // view.
     $app_path = drupal_get_path('module', 'restful_angular_example') . '/components/restful-app/dist';
-    $url = url($app_path . '/views/form.html', array('absolute' => TRUE));
+    $url = url($app_path . '/views/form.html', array('absolute' => TRUE, 'language' => LANGUAGE_NONE));
 
     // Add the library.
     drupal_add_library('restful_angular_example', 'restful-angular-form');
@@ -264,7 +264,7 @@ function restful_angular_example_page($example) {
     // Theme function simply declares the angular app, and ng-includes the app's
     // view.
     $app_path = drupal_get_path('module', 'restful_angular_example') . '/components/restful-app/dist';
-    $url = url($app_path . '/views/admin.html', array('absolute' => TRUE));
+    $url = url($app_path . '/views/admin.html', array('absolute' => TRUE, 'language' => LANGUAGE_NONE));
 
     // Add the library.
     drupal_add_library('restful_angular_example', 'restful-angular-admin');


### PR DESCRIPTION
When Drupal has language-codes in the URL, RESTful_angular_example.module calculates the path to statically-served files incorrectly. This patch should fix the problem.
