### PR TITLE
[FEATURE] Provide access control headers in OPTIONS calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,23 @@ curl https://example.com/api/articles?autocomplete[string]=mystring
 
 See the [Consuming Your API](./docs/api_url.md) document for more details.
 
+## CORS
+
+RESTful provides support for preflight requests (see the
+[Wikipedia example](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing#Preflight_example)
+for more details).
+
+To configure the allowed domains, you can:
+
+  - Go to `admin/config/services/restful` and set _CORS Preflight_ to the
+allowed domain. This will apply globally unless overridden with the method
+below.
+  - Set the `allowOrigin` key in your resource definition (in the annotation)
+to the allowed domain. This setting will only apply to this resource.
+
+Bear in mind that this check is only performed to the top-level resource.
+If you are composing resources with competing `allowOrigin` settings, the
+top-level resource will be applied.
 
 ## Documenting your API
 

--- a/restful.admin.inc
+++ b/restful.admin.inc
@@ -59,6 +59,20 @@ function restful_admin_settings($form_state) {
     ),
   );
 
+  $description  = 'When you make an XHR (AJAX) call to a resource under a ';
+  $description .= 'different host, most modern browsers will make an initial ';
+  $description .= 'OPTIONS request to the resource. The response to that can ';
+  $description .= 'contain the Access-Control-Allow-Origin, if that includes ';
+  $description .= 'the domain making the request the browser will allow the ';
+  $description .= 'cross-domain request. The contents of this field will be ';
+  $description .= 'used in that header.';
+  $form['restful_allowed_origin'] = array(
+    '#type' => 'textfield',
+    '#title' => t('CORS Preflight'),
+    '#description' => t($description),
+    '#default_value' => variable_get('restful_allowed_origin', ''),
+  );
+
   $form['restful_cache'] = array(
     '#type' => 'fieldset',
     '#title' => t('Cache'),

--- a/restful.install
+++ b/restful.install
@@ -90,4 +90,6 @@ function restful_uninstall() {
 
   variable_del('restful_render_cache');
   variable_del('restful_skip_basic_auth');
+
+  variable_del('restful_allowed_origin');
 }

--- a/restful.module
+++ b/restful.module
@@ -339,7 +339,14 @@ function restful_delivery($var = NULL, $method = 'format') {
       ->getFormatterManager();
     $formatter_manager->setResource($resource);
     $plugin_definition = $resource->getPluginDefinition();
-    $formatter_name = isset($plugin_definition['formatter']) ? $plugin_definition['formatter'] : NULL;
+    if ($request->getMethod() == RequestInterface::METHOD_OPTIONS) {
+      // There is no guarantee that other formatters can process the
+      // auto-discovery output correctly.
+      $formatter_name = 'json';
+    }
+    else {
+      $formatter_name = isset($plugin_definition['formatter']) ? $plugin_definition['formatter'] : NULL;
+    }
     $output = call_user_func(array($formatter_manager, $method), $var, $formatter_name);
     $response->setContent($output);
   }

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -78,32 +78,19 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       throw new InternalServerErrorException('The entity type was not provided.');
     }
     $this->entityType = $options['entityType'];
-    if (isset($options['bundles'])) {
+    if (!empty($options['bundles'])) {
       $this->bundles = $options['bundles'];
+    }
+    else {
+      // If no bundles are passed, then assume all the bundles of the entity
+      // type.
+      $entity_info = entity_get_info($this->entityType);
+      $this->bundles = array_keys($entity_info['bundles']);
     }
     if (isset($options['EFQClass'])) {
       $this->EFQClass = $options['EFQClass'];
     }
 
-    foreach ($this->fieldDefinitions as $key => $value) {
-      // Set the entity type and bundles on the resource fields.
-      if (!($value instanceof ResourceFieldEntityInterface)) {
-        continue;
-      }
-      /* @var ResourceFieldEntityInterface $value */
-      $value->setEntityType($this->entityType);
-      if (!$value->getBundle()) {
-        // If the field definition does not contain an array of bundles for that
-        // field then assume that the field applies to all the bundles of the
-        // resource.
-        if (!$this->bundles && $entity_type = $this->entityType) {
-          // If no bundles are passed, then assume all the bundles of the entity
-          // type.
-          $entity_info = entity_get_info($entity_type);
-          $this->bundles = array_keys($entity_info['bundles']);
-        }
-      }
-    }
     $this->setResourcePath($resource_path);
     if (empty($this->options['urlParams'])) {
       $this->options['urlParams'] = array(

--- a/src/Plugin/resource/ResourceEntity.php
+++ b/src/Plugin/resource/ResourceEntity.php
@@ -35,7 +35,6 @@ abstract class ResourceEntity extends Resource {
    * {@inheritdoc}
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
     if (empty($plugin_definition['dataProvider']['entityType'])) {
       throw new InternalServerErrorException('The entity type was not provided.');
     }
@@ -43,6 +42,7 @@ abstract class ResourceEntity extends Resource {
     if (isset($plugin_definition['dataProvider']['bundles'])) {
       $this->bundles = $plugin_definition['dataProvider']['bundles'];
     }
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
 
   /**
@@ -192,7 +192,7 @@ abstract class ResourceEntity extends Resource {
       if (!$class_name || is_subclass_of($class_name, $field_entity_class)) {
         $class_name = $field_entity_class;
       }
-      return $field_definition + array('class' => $class_name);
+      return $field_definition + array('class' => $class_name, 'entityType' => $this->getEntityType());
     }, $field_definitions);
 
     // If there is an alternate id field, use it instead of the entity id.
@@ -237,6 +237,7 @@ abstract class ResourceEntity extends Resource {
       $field_definitions[$public_field_name] = array(
         'property' => $field_name,
         'formatter' => $formatter_info,
+        'entityType' => $this->getEntityType(),
       );
     }
     return $field_definitions;

--- a/tests/modules/restful_test/src/Plugin/resource/entity_test/main/v1/Main__1_7.php
+++ b/tests/modules/restful_test/src/Plugin/resource/entity_test/main/v1/Main__1_7.php
@@ -97,7 +97,6 @@ class Main__1_7 extends Main__1_0 implements ResourceInterface {
    * {@inheritdoc}
    */
   protected function processPublicFields(array $field_definitions) {
-    $field_definitions = parent::processPublicFields($field_definitions);
     if (variable_get('restful_test_alternative_id_error', FALSE)) {
       // Single entity reference field with "resource" that does not load by
       // uuid.
@@ -111,8 +110,7 @@ class Main__1_7 extends Main__1_0 implements ResourceInterface {
         ),
       );
     }
-
-    return $field_definitions;
+    return parent::processPublicFields($field_definitions);
   }
 
 }


### PR DESCRIPTION
Add the Access-Control-Allow-\* headers to provide CORS support via
preflight OPTIONS requests. The origin domain can be specified
globally for all the API or individually for every endpoint.
