### PR TITLE
[FEATURE] Add metadata collection to data provider

### DIFF
--- a/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\DataProvider;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Drupal\restful\Exception\NotImplementedException;
 use Drupal\restful\Exception\UnauthorizedException;
 use Drupal\restful\Http\Request;
@@ -31,6 +32,14 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface 
   protected $cacheController;
 
   /**
+   * Array of metadata. Use this as a mean to pass info to the render layer.
+   *
+   * @var ArrayCollection
+   *   Key value store.
+   */
+  protected $metadata;
+
+  /**
    * Constructs a CacheDecoratedDataProvider object.
    *
    * @param DataProviderInterface $subject
@@ -41,6 +50,7 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface 
   public function __construct(DataProviderInterface $subject, \DrupalCacheInterface $cache_controller) {
     $this->subject = $subject;
     $this->cacheController = $cache_controller;
+    $this->metadata = new ArrayCollection();
   }
 
   /**
@@ -464,6 +474,13 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface 
    */
   public function getResourcePath() {
     return $this->subject->getResourcePath();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMetadata() {
+    return $this->metadata;
   }
 
 }

--- a/src/Plugin/resource/DataProvider/DataProvider.php
+++ b/src/Plugin/resource/DataProvider/DataProvider.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\resource\DataProvider;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Drupal\restful\Exception\BadRequestException;
 use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Exception\ServiceUnavailableException;
@@ -66,6 +67,14 @@ abstract class DataProvider implements DataProviderInterface {
    * @var string
    */
   protected $resourcePath;
+
+  /**
+   * Array of metadata. Use this as a mean to pass info to the render layer.
+   *
+   * @var ArrayCollection
+   *   Key value store.
+   */
+  protected $metadata;
 
   /**
    * {@inheritdoc}
@@ -140,6 +149,7 @@ abstract class DataProvider implements DataProviderInterface {
       $this->range = $options['range'];
     }
     $this->langcode = $langcode ?: static::getLanguage();
+    $this->metadata = new ArrayCollection();
   }
 
   /**
@@ -500,6 +510,13 @@ abstract class DataProvider implements DataProviderInterface {
    */
   public static function isNestedField($field_name) {
     return strpos($field_name, '.') !== FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMetadata() {
+    return $this->metadata;
   }
 
 }

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -753,6 +753,13 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
         // Just return FALSE, without an exception, for example when a list of
         // entities is requested, and we don't want to fail all the list because
         // of a single item without access.
+
+        // Add the inaccessible item to the metadata to fix the record count in
+        // the formatter.
+        $inaccessible_records = $this->getMetadata()->get('inaccessible_records');
+        $inaccessible_records[] = $entity_id;
+        $this->getMetadata()->set('inaccessible_records', $inaccessible_records);
+
         return FALSE;
       }
 

--- a/src/Plugin/resource/DataProvider/DataProviderInterface.php
+++ b/src/Plugin/resource/DataProvider/DataProviderInterface.php
@@ -192,4 +192,12 @@ interface DataProviderInterface extends CrudInterface {
    */
   public function getResourcePath();
 
+  /**
+   * Returns the metadata collection.
+   *
+   * @return ArrayCollection
+   *   The collection object.
+   */
+  public function getMetadata();
+
 }


### PR DESCRIPTION
Data providers can add metadata reflecting the data gathering/setting
process. This information is made available to Formatters via the
resource so extra metadata can be added to the output.
