### PR TITLE
[BUGFIX] Apply targetted nested filter to relationships

### DIFF
--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -126,6 +126,22 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
           $value = array($value);
           $ids = array($ids);
         }
+        // If some IDs were filtered out in the value while rendering due to the
+        // nested filtering with a target, we should remove those from the IDs
+        // in the relationship.
+        $filter_invalid_ids = function ($id) use ($value) {
+          foreach ($value as $info) {
+            if (empty($info['id'])) {
+              return FALSE;
+            }
+            if ($info['id'] == $id) {
+              return TRUE;
+            }
+          }
+          return FALSE;
+        };
+        $ids = array_filter($ids, $filter_invalid_ids);
+        $value = array_filter($value);
         $combined = $ids ? array_combine($ids, array_pad($value, count($ids), NULL)) : array();
         foreach ($combined as $id => $value_item) {
           $basic_info = array(

--- a/src/Util/EntityFieldQuery.php
+++ b/src/Util/EntityFieldQuery.php
@@ -124,11 +124,11 @@ class EntityFieldQuery extends \EntityFieldQuery implements EntityFieldQueryRela
       }
       elseif ($condition->getType() == RelationalFilterInterface::TYPE_PROPERTY) {
         if (in_array($relationship['operator'], array('IN', 'BETWEEN'))) {
-          $select_query->condition($entity_info['base table'] . '.' . $condition->getName(), $relationship['value'], $relationship['operator'][0]);
+          $select_query->condition($entity_table_alias . '.' . $condition->getName(), $relationship['value'], $relationship['operator'][0]);
         }
         else {
           for ($index = 0; $index < count($relationship['value']); $index++) {
-            $select_query->condition($entity_info['base table'] . '.' . $condition->getName(), $relationship['value'][$index], $relationship['operator'][$index]);
+            $select_query->condition($entity_table_alias . '.' . $condition->getName(), $relationship['value'][$index], $relationship['operator'][$index]);
           }
         }
       }


### PR DESCRIPTION
Check the rendered value to see if the referenced entity passes a
targetted nested filter. Failing to do this leads to the relationships
to be included anyways for JSON API.
