### PR TITLE
[BUGFIX] Clean entity IDs

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -724,7 +724,10 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
   protected function isValidEntity($op, $entity_id) {
     $entity_type = $this->entityType;
 
-    if (!$entity = entity_load_single($entity_type, $entity_id)) {
+    if (!ctype_digit((string) $entity_id) || !$entity = entity_load_single($entity_type, $entity_id)) {
+      // We need to check if the entity ID is numeric since if this is a uuid
+      // that starts by the number 4, and there is an entity with ID 4 that
+      // entity will be loaded incorrectly.
       throw new UnprocessableEntityException(sprintf('The entity ID %s does not exist.', $entity_id));
     }
 


### PR DESCRIPTION
Steps to reproduce the issue: (1) Load entity_test 4 so it gets
statically cached. (2) Load entity_test '4asdg'. You get the entity
4 instead of FALSE.
