### PR TITLE
Fixes #666: Refresh Token cleanup

### DIFF
--- a/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/refresh_token/1.0/RestfulRefreshTokenAuthentication.class.php
+++ b/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/refresh_token/1.0/RestfulRefreshTokenAuthentication.class.php
@@ -49,16 +49,16 @@ class RestfulRefreshTokenAuthentication extends \RestfulTokenAuthenticationBase 
     $uid = $refresh_token->uid;
 
     // Get the access token linked to this refresh token then do some cleanup.
-    $accessTokenQuery = new EntityFieldQuery();
-    $accessTokenReference = $accessTokenQuery
+    $access_token_query = new EntityFieldQuery();
+    $access_token_reference = $access_token_query
       ->entityCondition('entity_type', 'restful_token_auth')
       ->entityCondition('bundle', 'access_token')
       ->fieldCondition('refresh_token_reference', 'target_id', $refresh_token->id)
       ->range(0, 1)
       ->execute();
 
-    if (!empty($accessTokenReference['restful_token_auth'])) {
-      $access_token = key($accessTokenReference['restful_token_auth']);
+    if (!empty($access_token_reference['restful_token_auth'])) {
+      $access_token = key($access_token_reference['restful_token_auth']);
       entity_delete('access_token', $refresh_token->id);
       entity_delete('restful_token_auth', $access_token);
     }

--- a/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/refresh_token/1.0/RestfulRefreshTokenAuthentication.class.php
+++ b/modules/restful_token_auth/plugins/restful/restful_token_auth/token_auth/refresh_token/1.0/RestfulRefreshTokenAuthentication.class.php
@@ -59,7 +59,6 @@ class RestfulRefreshTokenAuthentication extends \RestfulTokenAuthenticationBase 
 
     if (!empty($access_token_reference['restful_token_auth'])) {
       $access_token = key($access_token_reference['restful_token_auth']);
-      entity_delete('access_token', $refresh_token->id);
       entity_delete('restful_token_auth', $access_token);
     }
 


### PR DESCRIPTION
Delete the access token associated with a refresh token when a new refresh token is created. Also clean up the reference table.
