### PR TITLE
Fixes #662, Records last-access time for users.

### DIFF
--- a/plugins/authentication/RestfulAuthenticationManager.php
+++ b/plugins/authentication/RestfulAuthenticationManager.php
@@ -123,6 +123,10 @@ class RestfulAuthenticationManager extends \ArrayObject {
     // This is necessary because the page cache system only looks at session
     // cookies, but not at HTTP Basic Auth headers.
     drupal_page_is_cacheable(!$account->uid && variable_get('restful_page_cache', FALSE));
+
+    // Record the access time of this request.
+    $this->setAccessTime($account);
+
     return $account;
   }
 
@@ -205,5 +209,20 @@ class RestfulAuthenticationManager extends \ArrayObject {
     return $this->originalUserSession;
   }
 
-
+  /**
+   * Set the user's last access time.
+   *
+   * @param object $user
+   *   A drupal user account.
+   *
+   * @see _drupal_session_write()
+   */
+  protected function setAccessTime($user) {
+    // This logic is pulled directly from _drupal_session_write().
+    if ($user->uid && REQUEST_TIME - $user->access > variable_get('session_write_interval', 180)) {
+      db_update('users')->fields(array(
+        'access' => REQUEST_TIME,
+      ))->condition('uid', $user->uid)->execute();
+    }
+  }
 }

--- a/plugins/authentication/RestfulAuthenticationManager.php
+++ b/plugins/authentication/RestfulAuthenticationManager.php
@@ -212,17 +212,17 @@ class RestfulAuthenticationManager extends \ArrayObject {
   /**
    * Set the user's last access time.
    *
-   * @param object $user
-   *   A drupal user account.
+   * @param object $account
+   *   A user account.
    *
    * @see _drupal_session_write()
    */
-  protected function setAccessTime($user) {
+  protected function setAccessTime($account) {
     // This logic is pulled directly from _drupal_session_write().
-    if ($user->uid && REQUEST_TIME - $user->access > variable_get('session_write_interval', 180)) {
+    if ($account->uid && REQUEST_TIME - $account->access > variable_get('session_write_interval', 180)) {
       db_update('users')->fields(array(
         'access' => REQUEST_TIME,
-      ))->condition('uid', $user->uid)->execute();
+      ))->condition('uid', $account->uid)->execute();
     }
   }
 }

--- a/tests/RestfulAuthenticationTestCase.test
+++ b/tests/RestfulAuthenticationTestCase.test
@@ -152,38 +152,29 @@ class RestfulAuthenticationTestCase extends RestfulCurlBaseTestCase {
 
     // Case 1. Ensure that access time is recorded for cookie auth.
     $user = $user1;
-    $cookie_provider = restful_get_authentication_handler('cookie');
 
-    // Make a request.
-    $handler->getAccount()->uid;
+    $user1_access_time_before = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user1->uid))->fetchObject();
+
+    // Perform request authentication.
+    $handler->getAccount();
 
     $user1_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user1->uid))->fetchObject();
     $this->assertEqual($user1_access_time->access, REQUEST_TIME, 'Cookie authenticated user access time is updated.');
 
+    $this->assertNotEqual($user1_access_time_before->access, $user1_access_time->access, 'Access time before and after request are equal.');
+
     // Case 2. Ensure that access time is recorded for basic auth.
     $user = $user2;
-    $basic_auth_provider = restful_get_authentication_handler('basic_auth');
 
     $_SERVER['PHP_AUTH_USER'] = $user2->name;
     $_SERVER['PHP_AUTH_PW'] = $user2->pass_raw;
     $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] = NULL;
     $handler = restful_get_restful_handler('articles');
 
-    // Make a request.
-    $handler->getAccount()->uid;
+    // Perform request authentication.
+    $handler->getAccount();
 
     $user2_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user2->uid))->fetchObject();
     $this->assertEqual($user2_access_time->access, REQUEST_TIME, 'Basic authenticated user access time is updated.');
-
-    // Case 3. Upon re-request, access time isn't updated if it is within the
-    // configured time limit.
-    // $user = $user1;
-
-    // Make a request.
-    // $handler->getAccount()->uid;
-
-    // $user1_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user1->uid))->fetchObject();
-    // $this->assertEqual($user1_access_time->access, REQUEST_TIME, 'Basic authenticated user access time is updated.');
-
   }
 }

--- a/tests/RestfulAuthenticationTestCase.test
+++ b/tests/RestfulAuthenticationTestCase.test
@@ -182,7 +182,7 @@ class RestfulAuthenticationTestCase extends RestfulCurlBaseTestCase {
 
     // To begin, we'll set the timestamp for user1 back a little bit.
     $num_updated = db_update('users')
-      ->fields(array('access' => 1000)
+      ->fields(array('access' => 1000))
       ->condition('uid', $user1->uid)
       ->execute();
 

--- a/tests/RestfulAuthenticationTestCase.test
+++ b/tests/RestfulAuthenticationTestCase.test
@@ -180,19 +180,26 @@ class RestfulAuthenticationTestCase extends RestfulCurlBaseTestCase {
     // Case 3. Ensure that the timestamp gets updated.
     $user = $user1;
 
+    // Get a timestamp that is in the past.
+    $the_past = REQUEST_TIME - variable_get('session_write_interval');
+
     // To begin, we'll set the timestamp for user1 back a little bit.
     $num_updated = db_update('users')
-      ->fields(array('access' => 1000))
+      ->fields(array('access' => $the_past))
       ->condition('uid', $user1->uid)
       ->execute();
 
     $user1_pre_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user1->uid))->fetchObject();
-    $this->assertEqual($user1_pre_access_time->access, 1000, 'Set user1 access time to a time in the past.');
+    $this->assertEqual($user1_pre_access_time->access, $the_past, 'Set user1 access time to a time in the past.');
 
-    // Perform request authentication.
-    $handler->getAccount();
+    // Perform an authenticated request.
+    $this->drupalGet('/api/v1.5/main', array(), array(
+      'Authorization' => 'Basic ' . base64_encode($user1->name . ':' . $user1->pass_raw))
+    );
 
     $user1_post_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user1->uid))->fetchObject();
+
+    $this->assertEqual($user1_post_access_time->access, REQUEST_TIME, 'Basic authenticated user access time is updated.');
   }
 
 }

--- a/tests/RestfulAuthenticationTestCase.test
+++ b/tests/RestfulAuthenticationTestCase.test
@@ -182,7 +182,7 @@ class RestfulAuthenticationTestCase extends RestfulCurlBaseTestCase {
 
     // To begin, we'll set the timestamp for user1 back a little bit.
     $num_updated = db_update('users')
-      ->fields(['access' => 1000])
+      ->fields(array('access' => 1000)
       ->condition('uid', $user1->uid)
       ->execute();
 

--- a/tests/RestfulAuthenticationTestCase.test
+++ b/tests/RestfulAuthenticationTestCase.test
@@ -176,5 +176,23 @@ class RestfulAuthenticationTestCase extends RestfulCurlBaseTestCase {
 
     $user2_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user2->uid))->fetchObject();
     $this->assertEqual($user2_access_time->access, REQUEST_TIME, 'Basic authenticated user access time is updated.');
+
+    // Case 3. Ensure that the timestamp gets updated.
+    $user = $user1;
+
+    // To begin, we'll set the timestamp for user1 back a little bit.
+    $num_updated = db_update('users')
+      ->fields(['access' => 1000])
+      ->condition('uid', $user1->uid)
+      ->execute();
+
+    $user1_pre_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user1->uid))->fetchObject();
+    $this->assertEqual($user1_pre_access_time->access, 1000, 'Set user1 access time to a time in the past.');
+
+    // Perform request authentication.
+    $handler->getAccount();
+
+    $user1_post_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user1->uid))->fetchObject();
   }
+
 }

--- a/tests/RestfulAuthenticationTestCase.test
+++ b/tests/RestfulAuthenticationTestCase.test
@@ -138,4 +138,52 @@ class RestfulAuthenticationTestCase extends RestfulCurlBaseTestCase {
 
     $this->assertEqual($user->uid, 0, 'Global user is the correct one after an API call that switches the user.');
   }
+
+  /**
+   * Test recording of access time.
+   */
+  function testAccessTime() {
+    global $user;
+
+    $user1 = $this->drupalCreateUser();
+    $user2 = $this->drupalCreateUser();
+
+    $handler = restful_get_restful_handler('main', 1, 5);
+
+    // Case 1. Ensure that access time is recorded for cookie auth.
+    $user = $user1;
+    $cookie_provider = restful_get_authentication_handler('cookie');
+
+    // Make a request.
+    $handler->getAccount()->uid;
+
+    $user1_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user1->uid))->fetchObject();
+    $this->assertEqual($user1_access_time->access, REQUEST_TIME, 'Cookie authenticated user access time is updated.');
+
+    // Case 2. Ensure that access time is recorded for basic auth.
+    $user = $user2;
+    $basic_auth_provider = restful_get_authentication_handler('basic_auth');
+
+    $_SERVER['PHP_AUTH_USER'] = $user2->name;
+    $_SERVER['PHP_AUTH_PW'] = $user2->pass_raw;
+    $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] = NULL;
+    $handler = restful_get_restful_handler('articles');
+
+    // Make a request.
+    $handler->getAccount()->uid;
+
+    $user2_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user2->uid))->fetchObject();
+    $this->assertEqual($user2_access_time->access, REQUEST_TIME, 'Basic authenticated user access time is updated.');
+
+    // Case 3. Upon re-request, access time isn't updated if it is within the
+    // configured time limit.
+    // $user = $user1;
+
+    // Make a request.
+    // $handler->getAccount()->uid;
+
+    // $user1_access_time = db_query('SELECT access FROM {users} WHERE uid = :d', array(':d' => $user1->uid))->fetchObject();
+    // $this->assertEqual($user1_access_time->access, REQUEST_TIME, 'Basic authenticated user access time is updated.');
+
+  }
 }


### PR DESCRIPTION
When a user's account is loaded, the user table should be updated to indicate that they have made an authenticated request. This mirrors the logic in _drupal_session_write().
