### PR TITLE
[BUGFIX] Allow having and idField to use with JSON API

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
+++ b/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
@@ -8,7 +8,6 @@
 namespace Drupal\restful\Plugin\resource\DataProvider;
 
 use Drupal\restful\Exception\BadRequestException;
-
 use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Exception\ServiceUnavailableException;
 use Drupal\restful\Http\RequestInterface;
@@ -216,6 +215,8 @@ class DataProviderDbQuery extends DataProvider implements DataProviderDbQueryInt
     $resource_field_collection = new ResourceFieldCollection(array(), $this->getRequest());
     $interpreter = new DataInterpreterArray($this->getAccount(), new ArrayWrapper((array) $row));
     $resource_field_collection->setInterpreter($interpreter);
+    $id_field_name = empty($this->options['idField']) ? 'id' : $this->options['idField'];
+    $resource_field_collection->setIdField($this->fieldDefinitions->get($id_field_name));
 
     // Loop over all the defined public fields.
     foreach ($this->fieldDefinitions as $public_field_name => $resource_field) {
@@ -225,21 +226,6 @@ class DataProviderDbQuery extends DataProvider implements DataProviderDbQueryInt
         // Allow passing the value in the request.
         continue;
       }
-//      // If there is a callback defined execute it instead of a direct mapping.
-//      if ($callback = $resource_field->getCallback()) {
-//        $value = ResourceManager::executeCallback($callback, array($row));
-//      }
-//      // Map row names to public properties.
-//      elseif ($property = $resource_field->getProperty()) {
-//        $value = $row->{$property};
-//      }
-//      // Execute the process callbacks.
-//      $process_callbacks = $resource_field->getProcessCallbacks();
-//      if ($value && $process_callbacks) {
-//        foreach ($process_callbacks as $process_callback) {
-//          $value = ResourceManager::executeCallback($process_callback, array($value));
-//        }
-//      }
       $resource_field_collection->set($resource_field->id(), $resource_field);
     }
     return $resource_field_collection;
@@ -409,7 +395,10 @@ class DataProviderDbQuery extends DataProvider implements DataProviderDbQueryInt
     $sorts = $this->parseRequestForListSort();
     $sorts = $sorts ? $sorts : $this->defaultSortInfo();
     foreach ($sorts as $sort => $direction) {
-      $query->orderBy($this->fieldDefinitions->get($sort)->getColumnForQuery(), $direction);
+      /* @var ResourceFieldDbColumnInterface $sort_field */
+      if ($sort_field = $this->fieldDefinitions->get($sort)) {
+        $query->orderBy($sort_field->getColumnForQuery(), $direction);
+      }
     }
   }
 
@@ -425,7 +414,11 @@ class DataProviderDbQuery extends DataProvider implements DataProviderDbQueryInt
    */
   protected function queryForListFilter(\SelectQuery $query) {
     foreach ($this->parseRequestForListFilter() as $filter) {
-      $column_name = $this->fieldDefinitions->get($filter['public_field'])->getColumnForQuery();
+      /* @var ResourceFieldDbColumnInterface $filter_field */
+      if (!$filter_field = $this->fieldDefinitions->get($filter['public_field'])) {
+        continue;
+      }
+      $column_name = $filter_field->getColumnForQuery();
       if (in_array(strtoupper($filter['operator'][0]), array('IN', 'NOT IN', 'BETWEEN'))) {
         $query->condition($column_name, $filter['value'], $filter['operator'][0]);
         continue;

--- a/tests/RestfulDbQueryTestCase.test
+++ b/tests/RestfulDbQueryTestCase.test
@@ -68,13 +68,21 @@ class RestfulDbQueryTestCase extends DrupalWebTestCase {
     $handler->setPath($id);
     $result = $handler->process();
     /* @var \Drupal\restful\Plugin\resource\Field\ResourceFieldCollection $collection */
-    $collection = $result[0];;
+    $collection = $result[0];
     $this->assertEqual($collection->get('string')
       ->value($collection->getInterpreter()), $mock_data['str_field'], 'The record was retrieved successfully.');
     $this->assertEqual($collection->get('integer')
       ->value($collection->getInterpreter()), $mock_data['int_field'], 'The record was retrieved successfully.');
     $this->assertEqual($collection->get('serialized')
       ->value($collection->getInterpreter()), $mock_data['serialized_field'], 'The record was retrieved successfully.');
+
+    // Testing JSON API formatter.
+    $result = drupal_json_decode(restful()
+      ->getFormatterManager()
+      ->format($handler->process(), 'json_api'));
+    $this->assertEqual($result['data'][0]['attributes']['string'], $mock_data['str_field'], 'The record was retrieved successfully.');
+    $this->assertEqual($result['data'][0]['attributes']['integer'], $mock_data['int_field'], 'The record was retrieved successfully.');
+    $this->assertEqual($result['data'][0]['attributes']['serialized'], $mock_data['serialized_field'], 'The record was retrieved successfully.');
 
     // Testing update context.
     $mock_data2 = array(

--- a/tests/RestfulDbQueryTestCase.test
+++ b/tests/RestfulDbQueryTestCase.test
@@ -77,12 +77,12 @@ class RestfulDbQueryTestCase extends DrupalWebTestCase {
       ->value($collection->getInterpreter()), $mock_data['serialized_field'], 'The record was retrieved successfully.');
 
     // Testing JSON API formatter.
-    $result = drupal_json_decode(restful()
-      ->getFormatterManager()
-      ->format($handler->process(), 'json_api'));
-    $this->assertEqual($result['data'][0]['attributes']['string'], $mock_data['str_field'], 'The record was retrieved successfully.');
-    $this->assertEqual($result['data'][0]['attributes']['integer'], $mock_data['int_field'], 'The record was retrieved successfully.');
-    $this->assertEqual($result['data'][0]['attributes']['serialized'], $mock_data['serialized_field'], 'The record was retrieved successfully.');
+    $formatter_manager = restful()->getFormatterManager();
+    $formatter_manager->setResource($handler);
+    $result = drupal_json_decode($formatter_manager->format($handler->process(), 'json_api'));
+    $this->assertEqual($result['data']['attributes']['string'], $mock_data['str_field'], 'The record was retrieved successfully.');
+    $this->assertEqual($result['data']['attributes']['integer'], $mock_data['int_field'], 'The record was retrieved successfully.');
+    $this->assertEqual($result['data']['attributes']['serialized'], $mock_data['serialized_field'], 'The record was retrieved successfully.');
 
     // Testing update context.
     $mock_data2 = array(

--- a/tests/modules/restful_test/src/Plugin/resource/db_query_test/v1/DbQueryTest__1_0.php
+++ b/tests/modules/restful_test/src/Plugin/resource/db_query_test/v1/DbQueryTest__1_0.php
@@ -23,6 +23,7 @@ use Drupal\restful\Plugin\resource\ResourceInterface;
  *     "tableName": "restful_test_db_query",
  *     "idColumn": "id",
  *     "primary": "id",
+ *     "idField": "id",
  *   },
  *   authenticationTypes = TRUE,
  *   authenticationOptional = TRUE,


### PR DESCRIPTION
JSON API requires an identifier for its display. Since we cannot
provide a default id field, we need to specify it in the annotation.
