### PR TITLE
7.x 2.x Undefined index notices during OPTIONS request (label, description, required)

### DIFF
--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -1170,11 +1170,6 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
         'label' => $field_instance['label'],
         'description' => $field_instance['description'],
       ));
-      $field_info = field_info_field($this->getProperty());
-      $public_field_info->addSectionDefaults('info', array(
-        'label' => $field_info['label'],
-        'description' => $field_info['description'],
-      ));
       $allowed_values = $public_field_info instanceof PublicFieldInfoEntityInterface ? $public_field_info->getFormSchemaAllowedValues() : NULL;
       $public_field_info->addSectionDefaults('form_element', array(
         'default_value' => isset($field_instance['default_value']) ? $field_instance['default_value'] : NULL,

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -1186,7 +1186,6 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
       }
       $public_field_info->addSectionDefaults('data', array(
         'type' => $property_info['type'],
-        'required' => $property_info['required'],
       ));
       $public_field_info->addSectionDefaults('info', array(
         'label' => $property_info['label'],


### PR DESCRIPTION
Receiving multiple undefined index notices while doing a OPTIONS request. Some examples:

PHP Notice:  Undefined index: label in /sites/all/modules/contrib/restful/src/Plugin/resource/Field/ResourceFieldEntity.php on line 1181

PHP Notice:  Undefined index: description in /sites/all/modules/contrib/restful/src/Plugin/resource/Field/ResourceFieldEntity.php on line 1182

PHP Notice:  Undefined index: required in /sites/all/modules/contrib/restful/src/Plugin/resource/Field/ResourceFieldEntity.php on line 1197
