### PR TITLE
[FEATURE] Clear caches on invalidation for embedded resources

### DIFF
--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -86,9 +86,11 @@ function restful_entity_update($entity, $type) {
     if (!$handler->hasSimpleInvalidation()) {
       return;
     }
-    $handler
-      ->getCacheController()
-      ->clear($hash);
+    // You can get away without the fragments for a clear.
+    $cache_object = new RenderCache(new ArrayCollection(), $hash, $handler->getCacheController());
+    // Do a clear with the RenderCache object to also remove the cache fragment
+    // entities.
+    $cache_object->clear();
   }
 }
 
@@ -106,10 +108,11 @@ function restful_entity_delete($entity, $type) {
     if (!$handler->hasSimpleInvalidation()) {
       return;
     }
-    // Resource takes care of its own invalidation.
-    $handler
-      ->getCacheController()
-      ->clear($hash);
+    // You can get away without the fragments for a clear.
+    $cache_object = new RenderCache(new ArrayCollection(), $hash, $handler->getCacheController());
+    // Do a clear with the RenderCache object to also remove the cache fragment
+    // entities.
+    $cache_object->clear();
   }
 }
 

--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -5,6 +5,7 @@
  * Contains entity related code.
  */
 
+use Drupal\restful\Plugin\resource\Decorators\CacheDecoratedResource;
 use Drupal\restful\Plugin\resource\Decorators\CacheDecoratedResourceInterface;
 use Drupal\restful\RenderCache\Entity\CacheFragmentController;
 use Drupal\restful\RenderCache\RenderCache;
@@ -63,23 +64,12 @@ function _restful_entity_cache_hashes($entity, $type) {
     return array();
   }
   // Limit to the fragments for our entity type.
-  $query = new \EntityFieldQuery();
-  $query
-    ->entityCondition('entity_type', 'cache_fragment')
-    ->propertyCondition('type', 'entity_type')
-    ->propertyCondition('value', $type);
-  if (!$hashes = CacheFragmentController::lookUpHashes($query)) {
-    return array();
-  }
-
-  // Search for all the cache fragments with our entity id.
   list($entity_id) = entity_extract_ids($type, $entity);
   $query = new \EntityFieldQuery();
   $query
     ->entityCondition('entity_type', 'cache_fragment')
-    ->propertyCondition('type', 'entity_id')
-    ->propertyCondition('value', $entity_id)
-    ->propertyCondition('hash', $hashes, 'IN');
+    ->propertyCondition('type', 'entity')
+    ->propertyCondition('value', CacheDecoratedResource::serializeKeyValue($type, $entity_id));
   return CacheFragmentController::lookUpHashes($query);
 }
 

--- a/src/Formatter/FormatterManager.php
+++ b/src/Formatter/FormatterManager.php
@@ -212,9 +212,9 @@ class FormatterManager implements FormatterManagerInterface {
   protected function getPluginByName($name) {
     /* @var FormatterInterface $formatter */
     $formatter = $this->plugins->get($name);
-    $formatter->setConfiguration(array(
-      'resource' => $this->resource,
-    ));
+    if ($this->resource) {
+      $formatter->setResource($this->resource);
+    }
     return $formatter;
   }
 

--- a/src/Plugin/formatter/Formatter.php
+++ b/src/Plugin/formatter/Formatter.php
@@ -253,7 +253,7 @@ abstract class Formatter extends PluginBase implements FormatterInterface {
       if ($allowed_fields !== FALSE && !in_array($field_name, $allowed_fields)) {
         continue;
       }
-      $result[$field_name] = $this->limitFields($field_contents, $this->unprefixAllowedFields($allowed_fields, $field_name));
+      $result[$field_name] = $this->limitFields($field_contents, $this->unprefixInputOptions($allowed_fields, $field_name));
     }
     return $result;
   }
@@ -269,7 +269,7 @@ abstract class Formatter extends PluginBase implements FormatterInterface {
    * @return bool|string[]
    *   The new allowed fields for the nested sub-request.
    */
-  protected static function unprefixAllowedFields($allowed_fields, $prefix) {
+  protected static function unprefixInputOptions($allowed_fields, $prefix) {
     if ($allowed_fields === FALSE) {
       return FALSE;
     }

--- a/src/Plugin/formatter/Formatter.php
+++ b/src/Plugin/formatter/Formatter.php
@@ -261,15 +261,18 @@ abstract class Formatter extends PluginBase implements FormatterInterface {
   /**
    * Given a prefix, return the allowed fields that apply removing the prefix.
    *
-   * @param array $allowed_fields
+   * @param bool|string[] $allowed_fields
    *   The list of allowed fields in dot notation.
    * @param string $prefix
    *   The prefix used to select the fields and to remove from the front.
    *
-   * @return array
+   * @return bool|string[]
    *   The new allowed fields for the nested sub-request.
    */
-  protected static function unprefixAllowedFields(array $allowed_fields, $prefix) {
+  protected static function unprefixAllowedFields($allowed_fields, $prefix) {
+    if ($allowed_fields === FALSE) {
+      return FALSE;
+    }
     $closure_unprefix = function ($field_limit) use ($prefix) {
       if ($field_limit == $prefix) {
         return NULL;

--- a/src/Plugin/formatter/Formatter.php
+++ b/src/Plugin/formatter/Formatter.php
@@ -73,6 +73,9 @@ abstract class Formatter extends PluginBase implements FormatterInterface {
    */
   public function setResource(ResourceInterface $resource) {
     $this->resource = $resource;
+    $this->setConfiguration(array(
+      'resource' => $resource,
+    ));
   }
 
   /**

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -483,7 +483,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
    */
   protected function needsIncluding(ResourceFieldResourceInterface $resource_field, $parents) {
     $input = $this->getRequest()->getParsedInput();
-    $includes = explode(',', $input['include']);
+    $includes = empty($input['include']) ? array() : explode(',', $input['include']);
     return in_array($this->buildIncludePath($parents, $resource_field->getPublicName()), $includes);
   }
 

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -525,7 +525,11 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
    * @throws \Drupal\restful\Exception\InternalServerErrorException
    */
   protected function populateCachePlaceholder(array $field_item) {
-    if (empty($field_item['#cache_placeholder']) || empty($field_item['#resource_id'])) {
+    if (
+      empty($field_item['#cache_placeholder']) ||
+      empty($field_item['#resource_id']) ||
+      empty($field_item['#resource_plugin'])
+    ) {
       return $field_item;
     }
     $embedded_resource = restful()

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -250,7 +250,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
    *   The output array to modify to include the compounded documents.
    * @param array $included
    *   Pool of documents to compound.
-   * @param mixed $allowed_fields
+   * @param bool|string[] $allowed_fields
    *   The sparse fieldset information. FALSE to select all fields.
    *
    * @return array

--- a/src/Plugin/resource/DataProvider/DataProvider.php
+++ b/src/Plugin/resource/DataProvider/DataProvider.php
@@ -13,6 +13,7 @@ use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Exception\ServiceUnavailableException;
 use Drupal\restful\Http\HttpHeader;
 use Drupal\restful\Http\RequestInterface;
+use Drupal\restful\Plugin\resource\Decorators\CacheDecoratedResource;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldCollection;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldCollectionInterface;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldInterface;
@@ -248,8 +249,7 @@ abstract class DataProvider implements DataProviderInterface {
       $identifier = implode(',', $identifier);
     }
     $fragments = new ArrayCollection(array(
-      'resource' => $this->pluginId,
-      'id' => (int) $identifier,
+      'resource' => CacheDecoratedResource::serializeKeyValue($this->pluginId, $this->canonicalPath($identifier)),
     ));
     $options = $this->getOptions();
     switch ($options['renderCache']['granularity']) {

--- a/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
+++ b/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
@@ -14,6 +14,7 @@ use Drupal\restful\Exception\ServiceUnavailableException;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\ArrayWrapper;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterArray;
+use Drupal\restful\Plugin\resource\Decorators\CacheDecoratedResource;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldCollection;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldCollectionInterface;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldDbColumnInterface;
@@ -105,10 +106,9 @@ class DataProviderDbQuery extends DataProvider implements DataProviderDbQueryInt
       $identifier = implode(ResourceInterface::IDS_SEPARATOR, $identifier);
     }
     $fragments = new ArrayCollection(array(
-      'resource' => $this->pluginId,
+      'resource' => CacheDecoratedResource::serializeKeyValue($this->pluginId, $this->canonicalPath($identifier)),
       'table_name' => $this->getTableName(),
       'column' => implode(',', $this->getIdColumn()),
-      'id' => (int) $identifier,
     ));
     $options = $this->getOptions();
     switch ($options['renderCache']['granularity']) {
@@ -232,6 +232,7 @@ class DataProviderDbQuery extends DataProvider implements DataProviderDbQueryInt
     $resource_field_collection->setInterpreter($interpreter);
     $id_field_name = empty($this->options['idField']) ? 'id' : $this->options['idField'];
     $resource_field_collection->setIdField($this->fieldDefinitions->get($id_field_name));
+    $resource_field_collection->setResourceId($this->pluginId);
 
     // Loop over all the defined public fields.
     foreach ($this->fieldDefinitions as $public_field_name => $resource_field) {

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -14,6 +14,7 @@ use Drupal\restful\Exception\InternalServerErrorException;
 use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Http\Request;
 use Drupal\restful\Http\RequestInterface;
+use Drupal\restful\Plugin\resource\Decorators\CacheDecoratedResource;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldResourceInterface;
 use Drupal\restful\Plugin\resource\ResourceEntity;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterEMW;
@@ -116,10 +117,8 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       $identifier = implode(ResourceInterface::IDS_SEPARATOR, $identifier);
     }
     $fragments = new ArrayCollection(array(
-      'resource' => $this->pluginId,
-      'entity_type' => $this->entityType,
-      'id' => (int) $identifier,
-      'entity_id' => (int) $this->getEntityIdByFieldId($identifier),
+      'resource' => CacheDecoratedResource::serializeKeyValue($this->pluginId, $this->canonicalPath($identifier)),
+      'entity' => CacheDecoratedResource::serializeKeyValue($this->entityType, $this->getEntityIdByFieldId($identifier)),
     ));
     $options = $this->getOptions();
     switch ($options['renderCache']['granularity']) {
@@ -247,6 +246,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     $resource_field_collection->setInterpreter($interpreter);
     $id_field_name = empty($this->options['idField']) ? 'id' : $this->options['idField'];
     $resource_field_collection->setIdField($this->fieldDefinitions->get($id_field_name));
+    $resource_field_collection->setResourceId($this->pluginId);
 
     // Defer sparse fieldsets to the formatter. That way we can minimize cache
     // fragmentation because we have a unique cache record for all the sparse

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -765,7 +765,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     list(,, $bundle) = entity_extract_ids($entity_type, $entity);
 
     if (!empty($this->bundles) && !in_array($bundle, $this->bundles)) {
-      throw new UnprocessableEntityException(sprintf('The entity ID %s is not valid.', $entity_id));
+      throw new UnprocessableEntityException(sprintf('The bundle "%s" is not valid.', $entity_id));
     }
 
     if ($this->checkEntityAccess($op, $entity_type, $entity) === FALSE) {

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -1106,7 +1106,9 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       list($item, $definitions) = $this->getFieldsFromPublicNameItem($resource_field);
       $fields[] = $item;
     }
-    $resource_field = $definitions->get($last_public_field_name);
+    if (!$resource_field = $definitions->get($last_public_field_name)) {
+      throw new BadRequestException(sprintf('Invalid nested field provided %s', $last_public_field_name));
+    }
     $property = $resource_field->getProperty();
     $item = array(
       'name' => $property,

--- a/src/Plugin/resource/Decorators/CacheDecoratedResourceInterface.php
+++ b/src/Plugin/resource/Decorators/CacheDecoratedResourceInterface.php
@@ -9,6 +9,18 @@ namespace Drupal\restful\Plugin\resource\Decorators;
 
 
 interface CacheDecoratedResourceInterface extends ResourceDecoratorInterface {
+  /**
+   * Generates a serialized key value pair.
+   *
+   * @param string $key
+   *   The key
+   * @param string $value
+   *   The value.
+   *
+   * @return string
+   *   The serialized value.
+   */
+  public static function serializeKeyValue($key, $value);
 
 
   /**

--- a/src/Plugin/resource/Decorators/ResourceDecoratorBase.php
+++ b/src/Plugin/resource/Decorators/ResourceDecoratorBase.php
@@ -309,4 +309,11 @@ abstract class ResourceDecoratorBase extends PluginBase implements ResourceDecor
     return $this->subject->getUrl($options, $keep_query, $request);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginId() {
+    return $this->subject->getPluginId();
+  }
+
 }

--- a/src/Plugin/resource/Field/ResourceFieldCollection.php
+++ b/src/Plugin/resource/Field/ResourceFieldCollection.php
@@ -10,6 +10,7 @@ namespace Drupal\restful\Plugin\resource\Field;
 use Doctrine\Common\Collections\ArrayCollection;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
+use Drupal\restful\Plugin\resource\Resource;
 
 class ResourceFieldCollection implements ResourceFieldCollectionInterface {
 
@@ -49,6 +50,13 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
    * @var string[]
    */
   protected $limitFields = array();
+
+  /**
+   * Contains the resource ID this field collection is for.
+   *
+   * @var string
+   */
+  protected $resourceId;
 
   /**
    * Constructor.
@@ -238,6 +246,29 @@ class ResourceFieldCollection implements ResourceFieldCollectionInterface {
    */
   public function setIdField($id_field) {
     $this->idField = $id_field;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResourceName() {
+    $resource_id = $this->getResourceId();
+    $pos = strpos($resource_id, Resource::DERIVATIVE_SEPARATOR);
+    return $pos === FALSE ? $resource_id : substr($resource_id, 0, $pos);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResourceId() {
+    return $this->resourceId;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setResourceId($resource_id) {
+    $this->resourceId = $resource_id;
   }
 
   /**

--- a/src/Plugin/resource/Field/ResourceFieldCollectionInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldCollectionInterface.php
@@ -149,4 +149,28 @@ interface ResourceFieldCollectionInterface extends \Iterator, \Countable {
    */
   public function setLimitFields($limit_fields);
 
+  /**
+   * Gets the resource name.
+   *
+   * @return string
+   *   The resource name.
+   */
+  public function getResourceName();
+
+  /**
+   * Gets the resource ID.
+   *
+   * @return string
+   *   The resource ID.
+   */
+  public function getResourceId();
+
+  /**
+   * Sets the resource ID.
+   *
+   * @param string $resource_id
+   *   The resource ID.
+   */
+  public function setResourceId($resource_id);
+
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -13,7 +13,6 @@ use Drupal\restful\Exception\UnprocessableEntityException;
 use Drupal\restful\Http\Request;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProvider;
-use Drupal\restful\Plugin\resource\DataProvider\DataProviderResource;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Plugin\resource\Field\PublicFieldInfo\PublicFieldInfoEntity;
 use Drupal\restful\Plugin\resource\Field\PublicFieldInfo\PublicFieldInfoEntityInterface;

--- a/src/RenderCache/Entity/CacheFragmentController.php
+++ b/src/RenderCache/Entity/CacheFragmentController.php
@@ -8,6 +8,7 @@
 namespace Drupal\restful\RenderCache\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Drupal\restful\Plugin\resource\Decorators\CacheDecoratedResource;
 
 class CacheFragmentController extends \EntityAPIController {
 
@@ -137,7 +138,8 @@ class CacheFragmentController extends \EntityAPIController {
       return NULL;
     }
     $cache_fragment = entity_load_single('cache_fragment', key($results['cache_fragment']));
-    return $cache_fragment->value;
+    $pos = strpos($cache_fragment->value, CacheDecoratedResource::CACHE_PAIR_SEPARATOR);
+    return $pos === FALSE ? $cache_fragment->value : substr($cache_fragment->value, 0, $pos);
   }
 
 }

--- a/src/RenderCache/RenderCache.php
+++ b/src/RenderCache/RenderCache.php
@@ -104,6 +104,13 @@ class RenderCache implements RenderCacheInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function getCid() {
+    return $this->hash;
+  }
+
+  /**
    * Generates the cache id based on the hash and the fragment IDs.
    *
    * @return string

--- a/src/RenderCache/RenderCacheInterface.php
+++ b/src/RenderCache/RenderCacheInterface.php
@@ -47,4 +47,12 @@ interface RenderCacheInterface {
    */
   public function clear();
 
+  /**
+   * Get the cache ID (aka cache hash).
+   *
+   * @return string
+   *   The cache ID.
+   */
+  public function getCid();
+
 }

--- a/src/Resource/ResourceManager.php
+++ b/src/Resource/ResourceManager.php
@@ -104,6 +104,10 @@ class ResourceManager implements ResourceManagerInterface {
     if ($request) {
       $plugin->setRequest($request);
     }
+    // Allow altering the resource, this way we can read the resource's
+    // definition to return a different class that is using composition.
+    drupal_alter('restful_resource', $plugin);
+    $plugin = $plugin->isEnabled() ? $plugin : NULL;
     return $plugin;
   }
 

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -501,7 +501,7 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     variable_set('restful_test_alternative_id_error', TRUE);
     $resource_manager->clearPluginCache('main:1.7');
     $handler = $resource_manager->getPlugin('main:1.7');
-    $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid));
+    $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid, array('include' => 'entity_reference_resource_error')));
     $handler->setPath($entities[2]->uuid);
     $format_manager->setResource($handler);
     try {

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -501,7 +501,9 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     variable_set('restful_test_alternative_id_error', TRUE);
     $resource_manager->clearPluginCache('main:1.7');
     $handler = $resource_manager->getPlugin('main:1.7');
-    $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid, array('include' => 'entity_reference_resource_error')));
+    $handler->setRequest(Request::create('api/main/v1.7/' . $entities[2]->uuid, array(
+      'include' => 'entity_reference_resource_error',
+    )));
     $handler->setPath($entities[2]->uuid);
     $format_manager->setResource($handler);
     try {

--- a/tests/RestfulListTestCase.test
+++ b/tests/RestfulListTestCase.test
@@ -174,18 +174,22 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
       array(
         'id' => $node->nid,
         'label' => 'abc',
+        'self' => $handler->versionedUrl($node->nid),
       ),
       array(
         'id' => $nodes['abc'],
         'label' => 'abc',
+        'self' => $handler->versionedUrl($nodes['abc']),
       ),
       array(
         'id' => $nodes['efg'],
         'label' => 'efg',
+        'self' => $handler->versionedUrl($nodes['efg']),
       ),
       array(
         'id' => $nodes['xyz'],
         'label' => 'xyz',
+        'self' => $handler->versionedUrl($nodes['xyz']),
       ),
     );
     $this->assertEqual($result, $expected_result, 'Default sort by ID and by label.');
@@ -202,18 +206,22 @@ class RestfulListTestCase extends RestfulCurlBaseTestCase {
       array(
         'id' => $nodes['abc'],
         'label' => 'abc',
+        'self' => $handler->versionedUrl($nodes['abc']),
       ),
       array(
         'id' => $nodes['xyz'],
         'label' => 'xyz',
+        'self' => $handler->versionedUrl($nodes['xyz']),
       ),
       array(
         'id' => $nodes['efg'],
         'label' => 'efg',
+        'self' => $handler->versionedUrl($nodes['efg']),
       ),
       array(
         'id' => $node->nid,
         'label' => 'abc',
+        'self' => $handler->versionedUrl($node->nid),
       ),
     );
     $this->assertEqual($result, $expected_result, 'Sort by ID, overriding default sort.');

--- a/tests/RestfulRenderCacheTestCase.test
+++ b/tests/RestfulRenderCacheTestCase.test
@@ -78,10 +78,8 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
     // Get a cached result directly from the cache backend.
     $node = reset($nodes);
     $fragments = new ArrayCollection(array(
-      'resource' => $handler->getResourceName(),
-      'entity_type' => 'node',
-      'id' => (int) $node->nid,
-      'entity_id' => (int) $node->nid,
+      'resource' => $handler->getResourceName() . '#' . $node->nid,
+      'entity' => 'node#' . $node->nid,
       'user_id' => (int) $account->uid,
       'formatter' => 'json',
     ));
@@ -156,12 +154,10 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
       $handler->setPath($nid);
       restful()->getFormatterManager()->format($handler->process(), 'json');
     }
-    // Make sure that every node creates 6 cache fragment entities.
+    // Make sure that every node creates 4 cache fragment entities.
     $fragment_types = array(
       'resource',
-      'entity_type',
-      'id',
-      'entity_id',
+      'entity',
       'user_id',
       'formatter',
     );
@@ -190,10 +186,8 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
     $handler->setPath('');
     restful()->getFormatterManager()->format($handler->process(), 'json');
     $role_fragments = new ArrayCollection(array(
-      'resource' => $handler->getResourceName(),
-      'entity_type' => 'node',
-      'id' => (int) $node->nid,
-      'entity_id' => (int) $node->nid,
+      'resource' => $handler->getResourceName() . '#' . $node->nid,
+      'entity' => 'node#' . $node->nid,
       'user_role' => 'anonymous user,authenticated user',
       'formatter' => 'json',
     ));

--- a/tests/RestfulRenderCacheTestCase.test
+++ b/tests/RestfulRenderCacheTestCase.test
@@ -154,22 +154,6 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
       $handler->setPath($nid);
       restful()->getFormatterManager()->format($handler->process(), 'json');
     }
-    // Make sure that every node creates 4 cache fragment entities.
-    $fragment_types = array(
-      'resource',
-      'entity',
-      'user_id',
-      'formatter',
-    );
-    foreach ($fragment_types as $fragment_type) {
-      $query = new \EntityFieldQuery();
-      $results = $query
-        ->entityCondition('entity_type', 'cache_fragment')
-        ->propertyCondition('type', $fragment_type)
-        ->count()
-        ->execute();
-      $this->assertEqual($results, count($nodes));
-    }
 
     // Test PER_ROLE granularity.
     $cache->clear('*', TRUE);


### PR DESCRIPTION
If a resource was cached in a denormalized response as an embedded
resource, and that resource needs to be invalidated; we also need to
clear all the resources containing it.
