### PR TITLE
[BUGFIX] Token resources need a special formatter

### DIFF
--- a/modules/restful_token_auth/restful_token_auth.module
+++ b/modules/restful_token_auth/restful_token_auth.module
@@ -28,31 +28,6 @@ function restful_token_auth_menu() {
 }
 
 /**
- * Implements hook_menu_alter().
- */
-function restful_token_auth_menu_alter(&$items) {
-  $access_token_plugin_definitions = array();
-  $plugins = restful()
-    ->getResourceManager()
-    ->getPlugins();
-  foreach ($plugins as $plugin) {
-    /* @var ResourceInterface $plugin */
-    $plugin_definition = $plugin->getPluginDefinition();
-    if (!empty($plugin_definition['dataProvider']['entityType']) && $plugin_definition['dataProvider']['entityType'] == 'restful_token_auth') {
-      $access_token_plugin_definitions[] = $plugin_definition;
-    }
-  }
-  if (empty($access_token_plugin_definitions)) {
-    return;
-  }
-  foreach ($access_token_plugin_definitions as $access_token_plugin_definition) {
-    if (!empty($items[$access_token_plugin_definition['menuItem']])) {
-      $items[$access_token_plugin_definition['menuItem']]['delivery callback'] = 'restful_unprepared_delivery';
-    }
-  }
-}
-
-/**
  * Implements hook_restful_parse_request_alter().
  */
 function restful_token_auth_restful_parse_request_alter(RequestInterface &$request) {
@@ -132,4 +107,22 @@ function restful_token_auth_cron() {
 
   $ids = array_keys($result['restful_token_auth']);
   entity_delete_multiple('restful_token_auth', $ids);
+}
+
+/**
+ * Implements hook_restful_resource_alter().
+ */
+function restful_token_auth_restful_resource_alter(ResourceInterface &$resource) {
+  $plugin_definition = $resource->getPluginDefinition();
+  if (
+    empty($plugin_definition['dataProvider']['entityType']) ||
+    $plugin_definition['dataProvider']['entityType'] != 'restful_token_auth' ||
+    !empty($plugin_definition['formatter'])
+  ) {
+    return;
+  }
+  // If this resource is based on access token entities and does not have an
+  // explicit formatter attached to it, then use the single_json formatter.
+  $plugin_definition['formatter'] = 'single_json';
+  $resource->setPluginDefinition($plugin_definition);
 }

--- a/modules/restful_token_auth/src/Plugin/formatter/FormatterSingleJson.php
+++ b/modules/restful_token_auth/src/Plugin/formatter/FormatterSingleJson.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful_token_auth\Plugin\formatter\FormatterSingleJson.
+ */
+
+namespace Drupal\restful_token_auth\Plugin\formatter;
+
+use Drupal\restful\Plugin\formatter\FormatterJson;
+use Drupal\restful\Plugin\resource\Field\ResourceFieldBase;
+
+/**
+ * Class FormatterSingleJson
+ * @package Drupal\restful\Plugin\formatter
+ *
+ * @Formatter(
+ *   id = "single_json",
+ *   label = "Single JSON",
+ *   description = "Output a single item using the JSON format."
+ * )
+ */
+class FormatterSingleJson extends FormatterJson {
+
+  /**
+   * Content Type
+   *
+   * @var string
+   */
+  protected $contentType = 'application/drupal.single+json; charset=utf-8';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepare(array $data) {
+    // If we're returning an error then set the content type to
+    // 'application/problem+json; charset=utf-8'.
+    if (!empty($data['status']) && floor($data['status'] / 100) != 2) {
+      $this->contentType = 'application/problem+json; charset=utf-8';
+      return $data;
+    }
+
+    $extracted = $this->extractFieldValues($data);
+    $output = $this->limitFields($extracted);
+    // Force returning a single item.
+    $output = ResourceFieldBase::isArrayNumeric($output) ? reset($output) : $output;
+
+    return $output ?: array();
+  }
+
+}
+

--- a/modules/restful_token_auth/src/Plugin/resource/AccessToken__1_0.php
+++ b/modules/restful_token_auth/src/Plugin/resource/AccessToken__1_0.php
@@ -31,6 +31,7 @@ use Drupal\restful\Plugin\resource\DataProvider\DataProviderEntityInterface;
  *       "access_token"
  *     },
  *   },
+ *   formatter = "single_json",
  *   majorVersion = 1,
  *   minorVersion = 0
  * )

--- a/modules/restful_token_auth/src/Plugin/resource/RefreshToken__1_0.php
+++ b/modules/restful_token_auth/src/Plugin/resource/RefreshToken__1_0.php
@@ -29,6 +29,7 @@ use Drupal\restful_token_auth\Entity\RestfulTokenAuth;
  *       "access_token"
  *     },
  *   },
+ *   formatter = "single_json",
  *   majorVersion = 1,
  *   minorVersion = 0
  * )

--- a/restful.module
+++ b/restful.module
@@ -45,7 +45,7 @@ function restful_menu() {
       'access arguments' => array($plugin_definition['resource']),
       'page callback' => RestfulManager::FRONT_CONTROLLER_CALLBACK,
       'page arguments' => array($plugin_definition['resource']),
-      'delivery callback' => 'restful_formatted_delivery',
+      'delivery callback' => 'restful_delivery',
       'type' => MENU_CALLBACK,
     );
     // If there is no specific menu item allow the different version variations.
@@ -65,11 +65,6 @@ function restful_menu() {
     else {
       $items[$plugin_definition['menuItem']] = $item;
     }
-  }
-
-  // Make sure the CRSF token endpoint is not HAL.
-  if (!empty($items[$base_path . '/session/token'])) {
-    $items[$base_path . '/session/token']['delivery callback'] = 'restful_unprepared_delivery';
   }
 
   // Make sure the Login endpoint has the correct access callback.
@@ -267,12 +262,10 @@ function restful_menu_process_callback($resource_name, $version = NULL) {
  *
  * @param mixed $var
  *   (optional) If set, the variable will be converted to JSON and output.
- * @param string $method
- *   Name of the method for the formatter.
  *
  * @see restful_menu_process_callback()
  */
-function restful_delivery($var = NULL, $method = 'format') {
+function restful_delivery($var = NULL) {
   if (!isset($var)) {
     return;
   }
@@ -330,7 +323,7 @@ function restful_delivery($var = NULL, $method = 'format') {
     else {
       $formatter_name = isset($plugin_definition['formatter']) ? $plugin_definition['formatter'] : NULL;
     }
-    $output = call_user_func(array($formatter_manager, $method), $var, $formatter_name);
+    $output = $formatter_manager->format($var, $formatter_name);
     $response->setContent($output);
   }
   catch (RestfulException $e) {
@@ -344,31 +337,6 @@ function restful_delivery($var = NULL, $method = 'format') {
 
   $response->prepare($request);
   $response->send();
-}
-
-/**
- * Returns data in JSON format using data preparation in the formatter plugin.
- *
- * @param $var
- *   (optional) If set, the variable will be converted to JSON and output.
- *
- * @see restful_menu_process_callback()
- */
-function restful_formatted_delivery($var = NULL) {
-  restful_delivery($var, 'format');
-}
-
-/**
- * Returns data in JSON format not using data preparation in the formatter
- * plugin.
- *
- * @param $var
- *   (optional) If set, the variable will be converted to JSON and output.
- *
- * @see restful_menu_process_callback()
- */
-function restful_unprepared_delivery($var = NULL) {
-  restful_delivery($var, 'render');
 }
 
 /**

--- a/src/Plugin/formatter/FormatterSingleJson.php
+++ b/src/Plugin/formatter/FormatterSingleJson.php
@@ -2,12 +2,11 @@
 
 /**
  * @file
- * Contains \Drupal\restful_token_auth\Plugin\formatter\FormatterSingleJson.
+ * Contains \Drupal\restful\Plugin\formatter\FormatterSingleJson.
  */
 
-namespace Drupal\restful_token_auth\Plugin\formatter;
+namespace Drupal\restful\Plugin\formatter;
 
-use Drupal\restful\Plugin\formatter\FormatterJson;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldBase;
 
 /**

--- a/src/Plugin/resource/CsrfToken.php
+++ b/src/Plugin/resource/CsrfToken.php
@@ -19,7 +19,7 @@ use Drupal\restful\Resource\ResourceManager;
  *   label = "CSRF Token",
  *   description = "Resource that provides CSRF Tokens when using cookie authentication.",
  *   authenticationTypes = TRUE,
- *   authenticationOptional = TRUE,
+ *   authenticationOptional = FALSE,
  *   formatter = "single_json",
  *   renderCache = {
  *     "render": FALSE
@@ -69,16 +69,6 @@ class CsrfToken extends Resource implements ResourceInterface {
    */
   public static function getCsrfToken() {
     return drupal_get_token(\Drupal\restful\Plugin\authentication\Authentication::TOKEN_VALUE);
-  }
-
-  /**
-   * Overrides RestfulBase::access().
-   *
-   * Expose resource only to authenticated users.
-   */
-  public function access() {
-    $account = $this->getAccount();
-    return (bool) $account->uid && parent::access();
   }
 
   /**

--- a/src/Plugin/resource/CsrfToken.php
+++ b/src/Plugin/resource/CsrfToken.php
@@ -6,6 +6,7 @@
  */
 
 namespace Drupal\restful\Plugin\resource;
+use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Resource\ResourceManager;
 
 /**
@@ -19,6 +20,10 @@ use Drupal\restful\Resource\ResourceManager;
  *   description = "Resource that provides CSRF Tokens when using cookie authentication.",
  *   authenticationTypes = TRUE,
  *   authenticationOptional = TRUE,
+ *   formatter = "single_json",
+ *   renderCache = {
+ *     "render": FALSE
+ *   },
  *   majorVersion = 1,
  *   minorVersion = 0
  * )
@@ -59,7 +64,8 @@ class CsrfToken extends Resource implements ResourceInterface {
   /**
    * Value callback; Return the CSRF token.
    *
-   * @return array
+   * @return string
+   *   The token.
    */
   public static function getCsrfToken() {
     return drupal_get_token(\Drupal\restful\Plugin\authentication\Authentication::TOKEN_VALUE);

--- a/tests/RestfulCsrfTokenTestCase.test
+++ b/tests/RestfulCsrfTokenTestCase.test
@@ -29,6 +29,9 @@ class RestfulCsrfTokenTestCase extends RestfulCurlBaseTestCase {
    */
   protected $originalServer;
 
+  /**
+   * {@inheritdoc}
+   */
   public static function getInfo() {
     return array(
       'name' => 'CSRF token',
@@ -37,6 +40,9 @@ class RestfulCsrfTokenTestCase extends RestfulCurlBaseTestCase {
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     parent::setUp('restful_example');
   }


### PR DESCRIPTION
Add a special formatter for token resources. Deprecate the use of
restful_unprepared_delivery in favor of a more appropriate solution.
Token endpoints need a special format, that means that they deserve
their special formater.
