### PR TITLE
[Bugfix] Issue with minor_version=0

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1324,7 +1324,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
         );
 
         // Set the default value for the version of the referenced resource.
-        if (empty($resource['major_version']) || empty($resource['minor_version'])) {
+        if (!isset($resource['major_version']) || !isset($resource['minor_version'])) {
           list($major_version, $minor_version) = static::getResourceLastVersion($resource['name']);
           $resource['major_version'] = $major_version;
           $resource['minor_version'] = $minor_version;


### PR DESCRIPTION
When referenced resource with minor_version=0 it alway looking for lasted version because empty($resource['minor_version']) always  return true.
