### PR TITLE
Fix: 204 status code for HTTP DELETE method doesn't take effect

### DIFF
--- a/restful.module
+++ b/restful.module
@@ -614,6 +614,13 @@ function restful_parse_request() {
  * @see restful_menu_process_callback()
  */
 function restful_delivery($var = NULL, $method = 'format') {
+  if ($restful_handler = restful_get_restful_handler_for_path()) {
+    // Allow the handler to change the HTTP headers.
+    foreach ($restful_handler->getHttpHeaders() as $key => $value) {
+      drupal_add_http_header($key, $value);
+    }
+  }
+
   if (!isset($var)) {
     return;
   }
@@ -626,18 +633,12 @@ function restful_delivery($var = NULL, $method = 'format') {
     drupal_add_http_header('Content-Type', 'application/problem+json; charset=utf-8');
   }
 
-  // Get the formatter for the current resource.
-  if ($restful_handler = restful_get_restful_handler_for_path()) {
-    // Allow the handler to change the HTTP headers.
-    foreach ($restful_handler->getHttpHeaders() as $key => $value) {
-      drupal_add_http_header($key, $value);
-    }
-    // If we are returning from an OPTIONS call, always use render.
-    if ($restful_handler->getMethod() == \RestfulInterface::OPTIONS) {
-      $method = 'render';
-    }
+  // If we are returning from an OPTIONS call, always use render.
+  if ($restful_handler && $restful_handler->getMethod() == \RestfulInterface::OPTIONS) {
+    $method = 'render';
   }
 
+  // Get the formatter for the current resource.
   try {
     $formatter_handler = \RestfulManager::outputFormat($restful_handler);
     $output = $formatter_handler->{$method}($var);


### PR DESCRIPTION
execute:

```
curl -X DELETE -D- http://www.example.com/api/articles/100
```

`200` status code returned, it should be `204`.
