### PR TITLE
2.x Formatter transformer write operations JSON API

### DIFF
--- a/docs/api_drupal.md
+++ b/docs/api_drupal.md
@@ -198,18 +198,39 @@ $parsed_body = array(
   'tags' => array(
     array(
       // Create a new term.
-      'label' => 'child1',
+      'body' => array(
+        'label' => 'child1',
+      ),
+      'request' => array(
+        'method' => 'POST',
+        'headers' => array(
+          'X-CSRF-Token' => 'my-csrf-token',
+        ),
+      ),
     ),
     array(
       // PATCH an existing term.
-      'label' => 'new title by PATCH',
+      'body' => array(
+        'label' => 'new title by PATCH',
+      ),
+      'id' => 12,
+      'request' => array(
+        'method' => 'PATCH',
+      ),
     ),
     array(
-      '__application' => array(
-        'method' => \Drupal\restful\Http\RequestInterface::METHOD_PUT,
+      // PATCH an existing term.
+      'body' => array(
+        'label' => 'new title by PUT',
       ),
-      // PUT an existing term.
-      'label' => 'new title by PUT',
+      'id' => 9,
+      'request' => array(
+        'method' => 'PUT',
+      ),
+    ),
+    // Use an existing item.
+    array(
+      'id' => 21,
     ),
   ),
 );

--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -7,9 +7,76 @@ You can manipulate the resources using different HTTP request types
 (e.g. `POST`, `GET`, `DELETE`), HTTP headers, and special query strings
 passed in the URL itself.
 
+## Write operations
+Write operations can be performed via the POTS (to create items), PUT or PATCH
+(to update items) HTTP methods.
+
+### Basic example
+The following request will create an article using the articles resource:
+
+```http
+POST /articles HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+{
+  "title": "My article",
+  "body": "<p>This is a short one</p>",
+  "tags": [1, 6, 12]
+}
+```
+
+Note how we are setting the properties that we want to set using JSON. The
+provided payload format needs to match the contents of the `Content-Type` header
+(in this case _application/json_).
+
+It's also worth noting that when settings reference fields with multiple values,
+you can submit an array of IDs or a string of IDs separated by comas.
+
+### Advanced example
+You use sub-requests to manipulate (create or alter) the relationships in a single request.The following example will:
+
+  1. Update the title of the article to be _To TDD or Not_.
+  1. Update the contents of tag 6 to replace it with the provided content.
+  1. Create a new tag and assign it to the updated article.
+
+```
+PATCH /articles/1 HTTP/1.1
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+  "title": "To TDD or Not",
+  "tags": [
+    {
+      "id": "6",
+      "body": {
+        "label": "Batman!",
+        "description": "The gadget owner."
+      },
+      "request": {
+        "method": "PATCH"
+      }
+    },
+    {
+      "body": {
+        "label": "everything",
+        "description": "I can only say: 42."
+      },
+      "request": {
+        "method": "POST",
+        "headers": {"Authorization": "Basic Yoasdkk1="}
+      }
+    }
+  ]
+}
+```
+
+See the
+[extension specification](https://gist.github.com/e0ipso/cc95bfce66a5d489bb8a)
+for an example using JSON API.
 
 ## Getting information about the resource
-
 
 ### Exploring the resource
 
@@ -19,9 +86,13 @@ about that resource, in addition to the data itself.
 ``` shell
 curl https://example.com/api/
 ``
-This will output all the available **latest** resources (of course, if you have enabled the "Discovery Resource" option). For example, if there are 3 different api version plugins for content type Article (1.0, 1.1, 2.0) it will display the latest only (2.0 in this case).
+This will output all the available **latest** resources (of course, if you have
+enabled the "Discovery Resource" option). For example, if there are 3 different
+api version plugins for content type Article (1.0, 1.1, 2.0) it will display the
+latest only (2.0 in this case).
 
-If you want to display all the versions of all the resources declared add the query **?all=true** like this.
+If you want to display all the versions of all the resources declared add the
+query **?all=true** like this.
 
 ``` shell
 curl https://example.com/api?all=true
@@ -172,12 +243,14 @@ HTTP ``X-CSRF-Token`` header on all writing requests (POST, PUT and DELETE).
 You can retrieve the token from ``/api/session/token`` with a standard HTTP
 GET request.
 
-See [this](https://github.com/Gizra/angular-restful-auth) AngularJs example that shows a login from a fully decoupled web app
-to a Drupal backend.
+See [this](https://github.com/Gizra/angular-restful-auth) AngularJs example that
+shows a login from a fully decoupled web app to a Drupal backend.
 
-Note: If you use basic auth under .htaccess password you might hit a flood exception, as the server is sending the .htaccess user name and password
- as the authentication. In such a case you may set the ``restful_skip_basic_auth`` to TRUE, in order to avoid using it. This will allow
- enabling and disabling the basic auth on different environments.
+Note: If you use basic auth under .htaccess password you might hit a flood
+exception, as the server is sending the .htaccess user name and password as the
+authentication. In such a case you may set the ``restful_skip_basic_auth`` to
+TRUE, in order to avoid using it. This will allow enabling and disabling the
+basic auth on different environments.
 
 ```bash
 # (Change username and password)
@@ -192,7 +265,7 @@ curl https://example.com/api/v1.3/articles/1?access_token=YOUR_TOKEN
 
 ## Error handling
 If an error occurs when operating the REST endpoint via URL, A valid JSON object
- with ``code``, ``message`` and ``description`` would be returned.
+with ``code``, ``message`` and ``description`` would be returned.
 
 The RESTful module adheres to the [Problem Details for HTTP
 APIs](http://tools.ietf.org/html/draft-nottingham-http-problem-06) draft to

--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -79,12 +79,15 @@ function _restful_entity_cache_hashes($entity, $type) {
 function restful_entity_update($entity, $type) {
   $resource_manager = restful()->getResourceManager();
   foreach (_restful_entity_cache_hashes($entity, $type) as $hash) {
-    $handler = $resource_manager->getPlugin(CacheFragmentController::resourceIdFromHash($hash));
+    if (!$instance_id = CacheFragmentController::resourceIdFromHash($hash)) {
+      continue;
+    }
+    $handler = $resource_manager->getPlugin($instance_id);
     if (!$handler instanceof CacheDecoratedResourceInterface) {
-      return;
+      continue;
     }
     if (!$handler->hasSimpleInvalidation()) {
-      return;
+      continue;
     }
     // You can get away without the fragments for a clear.
     $cache_object = new RenderCache(new ArrayCollection(), $hash, $handler->getCacheController());
@@ -100,13 +103,15 @@ function restful_entity_update($entity, $type) {
 function restful_entity_delete($entity, $type) {
   $resource_manager = restful()->getResourceManager();
   foreach (_restful_entity_cache_hashes($entity, $type) as $hash) {
-    $handler = $resource_manager->getPlugin(CacheFragmentController::resourceIdFromHash($hash));
+    if (!$instance_id = CacheFragmentController::resourceIdFromHash($hash)) {
+      continue;
+    }
+    $handler = $resource_manager->getPlugin($instance_id);
     if (!$handler instanceof CacheDecoratedResourceInterface) {
-      // Resource isn't using a cache decorator.
-      return;
+      continue;
     }
     if (!$handler->hasSimpleInvalidation()) {
-      return;
+      continue;
     }
     // You can get away without the fragments for a clear.
     $cache_object = new RenderCache(new ArrayCollection(), $hash, $handler->getCacheController());

--- a/src/Plugin/formatter/FormatterJson.php
+++ b/src/Plugin/formatter/FormatterJson.php
@@ -156,9 +156,7 @@ class FormatterJson extends Formatter implements FormatterInterface {
     $page = !empty($input['page']) ? $input['page'] : 1;
 
     if ($page > 1) {
-      $query = array(
-          'page' => $page - 1,
-        ) + $input;
+      $query = array('page' => $page - 1) + $input;
       $data['previous'] = array(
         'title' => 'Previous',
         'href' => $resource->versionedUrl('', array('query' => $query), TRUE),
@@ -171,9 +169,7 @@ class FormatterJson extends Formatter implements FormatterInterface {
     $items_per_page = $resource->getDataProvider()->getRange();
     $previous_items = ($page - 1) * $items_per_page;
     if (isset($data['count']) && $data['count'] > count($data['data']) + $previous_items) {
-      $query = array(
-          'page' => $page + 1,
-        ) + $input;
+      $query = array('page' => $page + 1) + $input;
       $data['next'] = array(
         'title' => 'Next',
         'href' => $resource->versionedUrl('', array('query' => $query), TRUE),

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\restful\Plugin\formatter;
 
+use Drupal\restful\Exception\BadRequestException;
 use Drupal\restful\Exception\InternalServerErrorException;
 use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Http\Request;
@@ -582,6 +583,110 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
       $field_item,
       $this->extractFieldValues($data, $field_item['#cache_placeholder']['parents'], $field_item['#cache_placeholder']['parent_hashes'])
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function parseBody($body) {
+    if (!$decoded_json = drupal_json_decode($body)) {
+      throw new BadRequestException(sprintf('Invalid JSON provided: %s.', $body));
+    }
+    if (empty($decoded_json['data'])) {
+      throw new BadRequestException(sprintf('Invalid JSON provided: %s.', $body));
+    }
+    $data = $decoded_json['data'];
+    $includes = empty($decoded_json['included']) ? array() : $decoded_json['included'];
+    // Make sure we're always dealing with a list of items.
+    $data = ResourceFieldBase::isArrayNumeric($data) ? $data : array($data);
+    $output = array();
+    foreach ($data as $item) {
+      $output[] = $this::restructureItem($item, $includes);
+    }
+
+    return $output;
+  }
+
+  /**
+   * Take a JSON API item and makes it hierarchical object, like simple JSON.
+   *
+   * @param array $item
+   *   The JSON API item.
+   * @param array $included
+   *   The included pool of elements.
+   *
+   * @return array
+   *   The hierarchical object.
+   *
+   * @throws \Drupal\restful\Exception\BadRequestException
+   */
+  protected static function restructureItem(array $item, array $included) {
+    if (empty($item['attributes']) && empty($item['relationship'])) {
+      throw new BadRequestException('Invalid JSON provided: both attributes and relationship are empty.');
+    }
+    // Make sure that the attributes and relationships are accessible.
+    $element = empty($item['attributes']) ? array() : $item['attributes'];
+    $relationships = empty($item['relationship']) ? array() : $item['relationship'];
+    // For every relationship we need to see if it was included.
+    foreach ($relationships as $field_name => $relationship) {
+      if (empty($relationship['data'])) {
+        throw new BadRequestException('Invalid JSON provided: relationship without data.');
+      }
+      $data = $relationship['data'];
+      // It's always weird to deal with lists of items vs a single item.
+      $single_item = !ResourceFieldBase::isArrayNumeric($data);
+      // Make sure we're always dealing with a list of items.
+      $data = $single_item ? array($data) : $data;
+      $element[$field_name] = array();
+      foreach ($data as $info_pair) {
+        // Validate the JSON API structure for a relationship.
+        if (empty($info_pair['type'])) {
+          throw new BadRequestException('Invalid JSON provided: relationship item without type.');
+        }
+        if (empty($info_pair['id'])) {
+          throw new BadRequestException('Invalid JSON provided: relationship item without id.');
+        }
+        // Initialize the object if empty.
+        if ($included_item = static::retrieveIncludedItem($info_pair['type'], $info_pair['id'], $included)) {
+          // If the relationship was included, restructure it and embed it.
+          $element[$field_name][] = static::restructureItem($included_item, $included);
+        }
+        else {
+          // If the include could not be retrieved, use the ID instead.
+          $element[$field_name][] = $info_pair['id'];
+        }
+      }
+      // Make the single relationships to be a single item or a single ID.
+      $element[$field_name] = $single_item ? reset($element[$field_name]) : $element[$field_name];
+    }
+    return $element;
+  }
+
+  /**
+   * Retrieves an item from the included pool of items.
+   *
+   * @param string $type
+   *   The resource type.
+   * @param string $id
+   *   The resource identifier.
+   * @param array $included
+   *   All the available included elements.
+   *
+   * @return array
+   *   The JSON API element.
+   */
+  protected static function retrieveIncludedItem($type, $id, array $included) {
+    foreach ($included as $item) {
+      if (
+        !empty($item['type']) &&
+        $item['type'] == $type &&
+        !empty($item['id']) &&
+        $item['id'] == $id
+      ) {
+        return $item;
+      }
+    }
+    return NULL;
   }
 
 }

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -405,7 +405,7 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
     }
     // Check if the resource needs to be included. If not then set 'full_view'
     // to false.
-    $cardinality = $resource_field->cardinality();
+    $cardinality = $resource_field->getCardinality();
     $output = array();
     $public_field_name = $resource_field->getPublicName();
     if (!$ids = $resource_field->compoundDocumentId($interpreter)) {

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -597,14 +597,16 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
     }
     $data = $decoded_json['data'];
     $includes = empty($decoded_json['included']) ? array() : $decoded_json['included'];
+    // It's always weird to deal with lists of items vs a single item.
+    $single_item = !ResourceFieldBase::isArrayNumeric($data);
     // Make sure we're always dealing with a list of items.
-    $data = ResourceFieldBase::isArrayNumeric($data) ? $data : array($data);
+    $data = $single_item ? array($data) : $data;
     $output = array();
     foreach ($data as $item) {
       $output[] = $this::restructureItem($item, $includes);
     }
 
-    return $output;
+    return $single_item ? reset($output) : $output;
   }
 
   /**

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -307,7 +307,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     // The access calls use the request method. Fake the view to be a GET.
     $old_request = $this->getRequest();
     $this->getRequest()->setMethod(RequestInterface::METHOD_GET);
-    $output = array($this->view($wrapper->getIdentifier()));
+    $output = array($this->view($identifier));
     // Put the original request back to a PUT/PATCH.
     $this->request = $old_request;
 

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -823,9 +823,6 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       throw new BadRequestException('Bad input data provided. Please, check your input and your Content-Type header.');
     }
     $save = FALSE;
-    // We cannot set the 'id' property of the $object, it's only needed to know
-    // which entity to update. Remove it from the properties to set.
-    unset($object['id']);
     $original_object = $object;
     $interpreter = new DataInterpreterEMW($this->getAccount(), $wrapper);
     // Keeps a list of the fields that have been set.

--- a/src/Plugin/resource/DataProvider/DataProviderTaxonomyTerm.php
+++ b/src/Plugin/resource/DataProvider/DataProviderTaxonomyTerm.php
@@ -19,12 +19,10 @@ class DataProviderTaxonomyTerm extends DataProviderEntity implements DataProvide
    */
   protected function setPropertyValues(\EntityDrupalWrapper $wrapper, $object, $replace = FALSE) {
     $term = $wrapper->value();
-    if (!empty($term->vid)) {
-      return;
+    if (empty($term->vid)) {
+      $vocabulary = taxonomy_vocabulary_machine_name_load($term->vocabulary_machine_name);
+      $term->vid = $vocabulary->vid;
     }
-
-    $vocabulary = taxonomy_vocabulary_machine_name_load($term->vocabulary_machine_name);
-    $term->vid = $vocabulary->vid;
 
     parent::setPropertyValues($wrapper, $object, $replace);
   }

--- a/src/Plugin/resource/Field/ResourceField.php
+++ b/src/Plugin/resource/Field/ResourceField.php
@@ -193,9 +193,16 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
   /**
    * {@inheritdoc}
    */
-  public function cardinality() {
+  public function getCardinality() {
     // Default to cardinality of 1.
     return 1;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCardinality($cardinality) {
+    $this->cardinality = $cardinality;
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldBase.php
+++ b/src/Plugin/resource/Field/ResourceFieldBase.php
@@ -150,6 +150,13 @@ abstract class ResourceFieldBase implements ResourceFieldInterface {
   protected $publicFieldInfo;
 
   /**
+   * Holds the field cardinality.
+   *
+   * @var int
+   */
+  protected $cardinality;
+
+  /**
    * Get the request in the data provider.
    *
    * @return RequestInterface

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -1050,13 +1050,23 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
   /**
    * {@inheritdoc}
    */
-  public function cardinality() {
-    // Default to single cardinality.
-    $default = 1;
-    if (!$field_info = field_info_field($this->getProperty())) {
-      return $default;
+  public function getCardinality() {
+    if (isset($this->cardinality)) {
+      return $this->cardinality;
     }
-    return empty($field_info['cardinality']) ? $default : $field_info['cardinality'];
+    // Default to single cardinality.
+    $this->cardinality = 1;
+    if ($field_info = field_info_field($this->getProperty())) {
+      $this->cardinality = empty($field_info['cardinality']) ? $this->cardinality : $field_info['cardinality'];
+    }
+    return $this->cardinality;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCardinality($cardinality) {
+    $this->cardinality = $cardinality;
   }
 
   /**

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -53,14 +53,18 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
       return NULL;
     }
 
-    $field_info = field_info_field($this->getProperty());
-    if ($field_info['cardinality'] != 1 && !is_array($value)) {
+    $cardinality = $this->cardinality();
+    if ($cardinality != 1 && !is_array($value)) {
       // If the field is entity reference type and its cardinality larger than
       // 1 set value to an array.
-      $value = explode(',', $value);
+      $ids = explode(',', $value);
+      $unpluck_id = function ($item) {
+        return array('id' => $item);
+      };
+      $value = array_map($unpluck_id, $ids);
     }
 
-    if ($field_info['cardinality'] != 1 && ResourceFieldBase::isArrayNumeric($value)) {
+    if ($cardinality != 1 && ResourceFieldBase::isArrayNumeric($value)) {
       // For multiple value items, pre-process them separately.
       $values = array();
       foreach ($value as $item) {

--- a/src/Plugin/resource/Field/ResourceFieldEntityReference.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityReference.php
@@ -53,23 +53,22 @@ class ResourceFieldEntityReference extends ResourceFieldEntity implements Resour
       return NULL;
     }
 
-    $cardinality = $this->cardinality();
+    $cardinality = $this->getCardinality();
     if ($cardinality != 1 && !is_array($value)) {
       // If the field is entity reference type and its cardinality larger than
       // 1 set value to an array.
-      $ids = explode(',', $value);
-      $unpluck_id = function ($item) {
-        return array('id' => $item);
-      };
-      $value = array_map($unpluck_id, $ids);
+      $value = explode(',', $value);
     }
 
     if ($cardinality != 1 && ResourceFieldBase::isArrayNumeric($value)) {
+      // Set the cardinality to 1 to process each value as a single value item.
+      $this->setCardinality(1);
       // For multiple value items, pre-process them separately.
       $values = array();
       foreach ($value as $item) {
         $values[] = $this->preprocess($item);
       }
+      $this->setCardinality($cardinality);
       return $values;
     }
     // If the provided value is the ID to the referenced entity, then do not do

--- a/src/Plugin/resource/Field/ResourceFieldInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldInterface.php
@@ -248,7 +248,15 @@ interface ResourceFieldInterface {
    *   The number of potentially returned fields. Reuses field cardinality
    *   constants.
    */
-  public function cardinality();
+  public function getCardinality();
+
+  /**
+   * Set the cardinality.
+   *
+   * @param int $cardinality
+   *   The new cardinality.
+   */
+  public function setCardinality($cardinality);
 
   /**
    * Get the request in the data provider.

--- a/src/Plugin/resource/Field/ResourceFieldResource.php
+++ b/src/Plugin/resource/Field/ResourceFieldResource.php
@@ -99,12 +99,19 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
    *   The number of potentially returned fields. Reuses field cardinality
    *   constants.
    */
-  public function cardinality() {
+  public function getCardinality() {
     if ($this->decorated instanceof ResourceFieldEntityInterface) {
-      return $this->decorated->cardinality();
+      return $this->decorated->getCardinality();
     }
     // Default to single cardinality.
     return 1;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCardinality($cardinality) {
+    $this->decorated->setCardinality($cardinality);
   }
 
   /**

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -43,8 +43,8 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
    */
   public static function getInfo() {
     return array(
-      'name' => 'JSON API GET',
-      'description' => 'Test the JSON API formatter for read operations.',
+      'name' => 'JSON API',
+      'description' => 'Test the JSON API formatter.',
       'group' => 'RESTful',
     );
   }
@@ -60,7 +60,9 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $this->account = $this->drupalCreateUser();
     $this->entities = $this->createEntities();
     $this->handler = restful()->getResourceManager()->getPlugin('main:1.1');
-    $this->formatter = restful()->getFormatterManager()->negotiateFormatter(NULL, 'json_api');
+    $this->formatter = restful()
+      ->getFormatterManager()
+      ->negotiateFormatter(NULL, 'json_api');
     $configuration = array(
       'resource' => $this->handler,
     );
@@ -123,7 +125,10 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
 
     // Make sure that using fields + includes lists all the fields in the
     // embedded entity if there is no subfield added.
-    $this->handler->setRequest(Request::create('api/v1.1/main/' . $wrapper->getIdentifier(), array('include' => 'entity_reference_multiple_resource,entity_reference_single_resource', 'fields' => 'entity_reference_multiple_resource,entity_reference_single_resource')));
+    $this->handler->setRequest(Request::create('api/v1.1/main/' . $wrapper->getIdentifier(), array(
+      'include' => 'entity_reference_multiple_resource,entity_reference_single_resource',
+      'fields' => 'entity_reference_multiple_resource,entity_reference_single_resource'
+    )));
     $this->handler->setPath($wrapper->getIdentifier());
     $this->formatter->setResource($this->handler);
     $resource_field_collections = $this->handler->process();
@@ -131,7 +136,10 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $this->assertEqual(count($result['included'][0]['attributes']), 16);
 
     // Now make sure that including fields only lists those fields.
-    $this->handler->setRequest(Request::create('api/v1.1/main/' . $wrapper->getIdentifier(), array('include' => 'entity_reference_single_resource', 'fields' => 'entity_reference_single_resource.label')));
+    $this->handler->setRequest(Request::create('api/v1.1/main/' . $wrapper->getIdentifier(), array(
+      'include' => 'entity_reference_single_resource',
+      'fields' => 'entity_reference_single_resource.label'
+    )));
     $this->handler->setPath($wrapper->getIdentifier());
     $this->formatter->setResource($this->handler);
     $resource_field_collections = $this->handler->process();
@@ -407,41 +415,92 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $expected_links = array(
       'self' => $this->handler->versionedUrl('', array('query' => array('range' => $range))),
       'first' => $this->handler->versionedUrl('', array('query' => array('range' => $range))),
-      'last' => $this->handler->versionedUrl('', array('query' => array('range' => $range, 'page' => 5))),
-      'next' => $this->handler->versionedUrl('', array('query' => array('range' => $range, 'page' => 2))),
+      'last' => $this->handler->versionedUrl('', array(
+        'query' => array(
+          'range' => $range,
+          'page' => 5
+        )
+      )),
+      'next' => $this->handler->versionedUrl('', array(
+        'query' => array(
+          'range' => $range,
+          'page' => 2
+        )
+      )),
     );
     $this->assertEqual($links, $expected_links);
 
     // 2. Test pagination links in the middle page.
     $range = 2;
-    $this->handler->setRequest(Request::create('', array('range' => $range, 'page' => 2)));
+    $this->handler->setRequest(Request::create('', array(
+      'range' => $range,
+      'page' => 2
+    )));
     $this->handler->setPath('');
     $this->formatter->setResource($this->handler);
     $resource_field_collections = $this->handler->process();
     $result = drupal_json_decode($this->formatter->format($resource_field_collections));
     $links = $result['links'];
     $expected_links = array(
-      'self' => $this->handler->versionedUrl('', array('query' => array('range' => $range, 'page' => 2))),
+      'self' => $this->handler->versionedUrl('', array(
+        'query' => array(
+          'range' => $range,
+          'page' => 2
+        )
+      )),
       'first' => $this->handler->versionedUrl('', array('query' => array('range' => $range))),
-      'previous' => $this->handler->versionedUrl('', array('query' => array('range' => $range, 'page' => 1))),
-      'last' => $this->handler->versionedUrl('', array('query' => array('range' => $range, 'page' => 5))),
-      'next' => $this->handler->versionedUrl('', array('query' => array('range' => $range, 'page' => 3))),
+      'previous' => $this->handler->versionedUrl('', array(
+        'query' => array(
+          'range' => $range,
+          'page' => 1
+        )
+      )),
+      'last' => $this->handler->versionedUrl('', array(
+        'query' => array(
+          'range' => $range,
+          'page' => 5
+        )
+      )),
+      'next' => $this->handler->versionedUrl('', array(
+        'query' => array(
+          'range' => $range,
+          'page' => 3
+        )
+      )),
     );
     $this->assertEqual($links, $expected_links);
 
     // 3. Test pagination links in the last page.
     $range = 2;
-    $this->handler->setRequest(Request::create('', array('range' => $range, 'page' => 5)));
+    $this->handler->setRequest(Request::create('', array(
+      'range' => $range,
+      'page' => 5
+    )));
     $this->handler->setPath('');
     $this->formatter->setResource($this->handler);
     $resource_field_collections = $this->handler->process();
     $result = drupal_json_decode($this->formatter->format($resource_field_collections));
     $links = $result['links'];
     $expected_links = array(
-      'self' => $this->handler->versionedUrl('', array('query' => array('range' => $range, 'page' => 5))),
+      'self' => $this->handler->versionedUrl('', array(
+        'query' => array(
+          'range' => $range,
+          'page' => 5
+        )
+      )),
       'first' => $this->handler->versionedUrl('', array('query' => array('range' => $range))),
-      'previous' => $this->handler->versionedUrl('', array('query' => array('range' => $range, 'page' => 4))),
-      'last' => $this->handler->versionedUrl('', array('query' => array('range' => $range, 'page' => 5))),
+      'previous' => $this->handler->versionedUrl('', array(
+        'query' => array(
+          'range' => $range,
+          'page' => 4
+        )
+      )),
+      'last' => $this->handler->versionedUrl('', array(
+        'query' => array(
+          'range' => $range,
+          'page' => 5
+        )
+      )),
     );
     $this->assertEqual($links, $expected_links);
   }
@@ -474,9 +533,18 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $entities[2]->term_single[LANGUAGE_NONE][] = array('tid' => $tids[0]);
     $entities[2]->term_multiple[LANGUAGE_NONE][] = array('tid' => $tids[1]);
     $entities[2]->term_multiple[LANGUAGE_NONE][] = array('tid' => $tids[2]);
-    $entities[2]->file_single[LANGUAGE_NONE][] = array('fid' => $images[0], 'display' => TRUE);
-    $entities[2]->file_multiple[LANGUAGE_NONE][] = array('fid' => $images[1], 'display' => TRUE);
-    $entities[2]->file_multiple[LANGUAGE_NONE][] = array('fid' => $images[2], 'display' => TRUE);
+    $entities[2]->file_single[LANGUAGE_NONE][] = array(
+      'fid' => $images[0],
+      'display' => TRUE
+    );
+    $entities[2]->file_multiple[LANGUAGE_NONE][] = array(
+      'fid' => $images[1],
+      'display' => TRUE
+    );
+    $entities[2]->file_multiple[LANGUAGE_NONE][] = array(
+      'fid' => $images[2],
+      'display' => TRUE
+    );
     entity_save('entity_test', $entities[2]);
 
 
@@ -546,6 +614,138 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     $response = $formatter->prepare($handler->process());
     // Assert that $entities[2] points to $entities[0]
     $this->assertEqual($response['data'][0]['id'], $entities[2]->uuid);
+  }
+
+  /**
+   * Sub-request parsing.
+   */
+  public function testSubRequestParsing() {
+    $relationships = array(
+      'rel1' => array('data' => array('type' => 'tags', 'id' => 7)),
+      'rel2' => array(
+        'data' => array(
+          array(
+            'type' => 'articles',
+            'id' => 1,
+          ),
+          array(
+            'type' => 'articles',
+            'id' => 2,
+            'meta' => array('subrequest' => array('method' => 'PUT')),
+          ),
+          array(
+            'type' => 'articles',
+            'id' => 3,
+            'meta' => array('subrequest' => array('method' => 'PATCH')),
+          ),
+          array(
+            'type' => 'articles',
+            'id' => 'newRel2--1',
+            'meta' => array(
+              'subrequest' => array(
+                'method' => 'POST',
+                'headers' => array('X-CSRF-Token' => 'my-token'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Generate 3 random strings.
+    $rnd_text = array_map(array($this, 'randomName'), range(0, 4));
+    $included = array(
+      array(
+        'type' => 'articles',
+        'id' => 1,
+        'attributes' => array('label' => $rnd_text[0]),
+        'relationships' => array(
+          'articles' => array(
+            'data' => array(
+              'type' => 'articles',
+              'id' => 2,
+            ),
+          ),
+        ),
+      ),
+      array(
+        'type' => 'articles',
+        'id' => 2,
+        'attributes' => array('label' => $rnd_text[1]),
+      ),
+      array(
+        'type' => 'articles',
+        'id' => 3,
+        'attributes' => array('label' => $rnd_text[2]),
+      ),
+      array(
+        'type' => 'articles',
+        'id' => 'newRel2--1',
+        'attributes' => array('label' => $rnd_text[3]),
+        'relationships' => array(
+          'articles' => array(
+            'data' => array(
+              'type' => 'articles',
+              'id' => 1,
+            ),
+          ),
+        ),
+      ),
+    );
+    $data = array(
+      array(
+        'type' => 'articles',
+        'id' => 5,
+        'attributes' => array(
+          'title' => $rnd_text[4],
+        ),
+        'relationships' => $relationships,
+      ),
+    );
+    $json_api = array(
+      'data' => $data,
+      'included' => $included,
+    );
+    $parsed_body = restful()
+      ->getFormatterManager()
+      ->getPlugin('json_api')
+      ->parseBody(drupal_json_encode($json_api));
+
+    $expected = array(
+      array(
+        'title' => $rnd_text[4],
+        'rel1' => array('id' => 7),
+        'rel2' => array(
+          array('id' => 1),
+          array(
+            'id' => 2,
+            'body' => array(
+              'label' => $rnd_text[1],
+            ),
+            'request' => array('method' => 'PUT'),
+          ),
+          array(
+            'id' => 3,
+            'body' => array(
+              'label' => $rnd_text[2],
+            ),
+            'request' => array('method' => 'PATCH'),
+          ),
+          array(
+            'body' => array(
+              'label' => $rnd_text[3],
+              'articles' => array('id' => 1),
+            ),
+            'request' => array(
+              'method' => 'POST',
+              'headers' => array('X-CSRF-Token' => 'my-token'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    $this->assertEqual($expected, $parsed_body);
   }
 
   /**

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -18,6 +18,9 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
    */
   protected $handler = NULL;
 
+  /**
+   * {@inheritdoc}
+   */
   public static function getInfo() {
     return array(
       'name' => 'Sub requests',
@@ -26,7 +29,10 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
     );
   }
 
-  function setUp() {
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
     parent::setUp('restful_test', 'entity_validator_example');
 
     // Entity reference - single.
@@ -86,15 +92,17 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
   /**
    * Test creating and updating an entity with sub-resources.
    */
-  function testCreateAndUpdateEntity() {
+  public function testCreateAndUpdateEntity() {
     $base_request = $request = array(
       'label' => 'parent',
       'body' => 'Drupal',
       'entity_reference_single' => array(
-        'values' => array(array(
-          'label' => 'child1',
-          'body' => 'Drupal1',
-        )),
+        'values' => array(
+          array(
+            'label' => 'child1',
+            'body' => 'Drupal1',
+          ),
+        ),
       ),
       'entity_reference_multiple' => array(
         'values' => array(
@@ -177,7 +185,8 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
 
     // Test the version of the sub-resource.
     $public_fields = $this->handler->getFieldDefinitions();
-    $erm_resource = $public_fields->get('entity_reference_multiple')->getResource();
+    $erm_resource = $public_fields->get('entity_reference_multiple')
+      ->getResource();
     $this->assertEqual($erm_resource['majorVersion'], 1, 'Sub resource major version is correct.');
     $this->assertEqual($erm_resource['minorVersion'], 2, 'Sub resource minor version is correct.');
   }
@@ -269,4 +278,5 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
       $this->fail('Wrong exception thrown on validation fail on the parent.');
     }
   }
+
 }

--- a/tests/RestfulSubResourcesCreateEntityTestCase.test
+++ b/tests/RestfulSubResourcesCreateEntityTestCase.test
@@ -97,22 +97,31 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
       'label' => 'parent',
       'body' => 'Drupal',
       'entity_reference_single' => array(
-        'values' => array(
-          array(
-            'label' => 'child1',
-            'body' => 'Drupal1',
-          ),
+        'body' => array(
+          'label' => 'child1',
+          'body' => 'Drupal1',
+        ),
+        'request' => array(
+          'method' => 'POST',
         ),
       ),
       'entity_reference_multiple' => array(
-        'values' => array(
-          array(
+        array(
+          'body' => array(
             'label' => 'child2',
             'body' => 'Drupal2',
           ),
-          array(
+          'request' => array(
+            'method' => 'POST',
+          ),
+        ),
+        array(
+          'body' => array(
             'label' => 'child3',
             'body' => 'Drupal3',
+          ),
+          'request' => array(
+            'method' => 'POST',
           ),
         ),
       ),
@@ -156,28 +165,36 @@ class RestfulSubResourcesCreateEntityTestCase extends DrupalWebTestCase {
     $request['entity_reference_multiple']['request'] = array(
       'method' => RequestInterface::METHOD_PATCH,
     );
-    $request['entity_reference_multiple']['values'] = array(
+    $request['entity_reference_multiple'] = array(
       array(
         // Set the $node3.
         'id' => $node3->nid,
       ),
       array(
-        // Create a new node. Even if the request method is set to PATCH, since
-        // there is no id to rely upon, this is a POST.
-        'label' => 'POST new one',
-        'body' => 'Drupal',
+        'body' => array(
+          // Create a new node.
+          'label' => 'POST new one',
+          'body' => 'Drupal',
+        ),
+        'request' => array('method' => 'POST'),
       ),
       array(
         // Set $node4 and update some of the fields.
         'id' => $node4->nid,
-        'label' => 'PATCH existing one',
-        'body' => 'Drupal',
+        'body' => array(
+          'label' => 'PATCH existing one',
+          'body' => 'Drupal',
+        ),
+        'request' => array('method' => 'PATCH'),
       ),
       array(
         // Set $node5 and update some of the fields.
         'id' => $node5->nid,
-        'label' => 'PATCH existing one',
-        'body' => 'Drupal',
+        'body' => array(
+          'label' => 'PATCH existing one',
+          'body' => 'Drupal',
+        ),
+        'request' => array('method' => 'POST'),
       ),
     );
 


### PR DESCRIPTION
This PR introduces the formatter bodyParser for JSON API with a test.

To implement a bodyParser you have to take whatever input the formatter takes, and return the same structure that _Simple JSON_ expects.

There is also some refactoring in the `preprocess` method for the `ResourceFieldEntityReference` field to simplify it.

Finally, the documentation was updated with the new format of the input for Simple JSON.
