### PR TITLE
Use proper 'sub_property' instead when getting public field value fro…

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -392,7 +392,8 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     $resource = $info['resource'] ?: NULL;
 
     if ($info['sub_property'] && $sub_wrapper->value()) {
-      $sub_wrapper = $sub_wrapper->{$info['sub_property']};
+      $property = $info['sub_property'];
+      $sub_wrapper = $sub_wrapper->{$property};
     }
 
     if ($resource) {


### PR DESCRIPTION
For example: commerce_order of [Commerce Marketplace](https://www.drupal.org/sandbox/maciej.zgadzaj/1950386):

``` php
class RestfulCommerceOrder extends RestfulBaseEntity {
  public function publicFieldsInfo() {
    $public_fields = parent::publicFieldsInfo();

    $public_fields['seller'] = array(
      'property' => 'commerce_store',
      'sub_property' => 'creator',
      'resource' => array(
        'user' => 'users',
      ),
    );
```

should  use `creator` property rather than `commerce_store` property to get value from users resource.
