### PR TITLE
[BUGFIX] Refresh token cleanup

### DIFF
--- a/modules/restful_token_auth/src/Plugin/resource/RefreshToken__1_0.php
+++ b/modules/restful_token_auth/src/Plugin/resource/RefreshToken__1_0.php
@@ -11,6 +11,7 @@ namespace Drupal\restful_token_auth\Plugin\resource;
 use Drupal\restful\Exception\BadRequestException;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\ResourceInterface;
+use Drupal\restful\Util\EntityFieldQuery;
 use Drupal\restful_token_auth\Entity\RestfulTokenAuth;
 
 /**
@@ -79,6 +80,21 @@ class RefreshToken__1_0 extends TokenAuthenticationBase implements ResourceInter
     // Remove the refresh token once used.
     $refresh_token = entity_load_single('restful_token_auth', key($results['restful_token_auth']));
     $uid = $refresh_token->uid;
+
+    // Get the access token linked to this refresh token then do some cleanup.
+    $access_token_query = new EntityFieldQuery();
+    $access_token_reference = $access_token_query
+      ->entityCondition('entity_type', 'restful_token_auth')
+      ->entityCondition('bundle', 'access_token')
+      ->fieldCondition('refresh_token_reference', 'target_id', $refresh_token->id)
+      ->range(0, 1)
+      ->execute();
+
+    if (!empty($access_token_reference['restful_token_auth'])) {
+      $access_token = key($access_token_reference['restful_token_auth']);
+      entity_delete('restful_token_auth', $access_token);
+    }
+
     $refresh_token->delete();
 
     // Create the new access token and return it.


### PR DESCRIPTION
Delete the access token associated with a refresh token when a new
refresh token is created. Also clean up the reference table.
