### PR TITLE
Add access-token header in example

### DIFF
--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -261,7 +261,7 @@ curl -u "username:password" https://example.com/api/login
 
 # Call a "protected" with token resource (Articles resource version 1.3 in "RESTful example")
 # Use access-token instead of access_token for ensuring header is not going to be
-#   dropped out from $_SERVER so it remains compatible with other webservers different than apache.
+# dropped out from $_SERVER so it remains compatible with other webservers different than apache.
 curl -H "access-token: YOUR_TOKEN" https://example.com/api/v1.3/articles/1
 ```
 

--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -260,7 +260,9 @@ curl -u "username:password" https://example.com/api/login
 {"access_token":"YOUR_TOKEN"}
 
 # Call a "protected" with token resource (Articles resource version 1.3 in "RESTful example")
-curl https://example.com/api/v1.3/articles/1?access_token=YOUR_TOKEN
+# Use access-token instead of access_token for ensuring header is not going to be
+#   dropped out from $_SERVER so it remains compatible with other webservers different than apache.
+curl -H "access-token: YOUR_TOKEN" https://example.com/api/v1.3/articles/1
 ```
 
 ## Error handling


### PR DESCRIPTION
Use dash instead of underscore so that it remains compatible with other webservers when apache_request_headers function is not reliable.

I was trying to make this work using HTTP header in pantheon (nginx web server) and access_token disappeared from $_SERVER and since apache_request_headers doesn't exists; I didn't get the authentication working. Using access-token instead fixed the issue.
