### PR TITLE
Fixes a typo in checking permissions before deleting an entity.

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -594,7 +594,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    * {@inheritdoc}
    */
   public function deleteEntity($entity_id) {
-    $this->isValidEntity('update', $entity_id);
+    $this->isValidEntity('delete', $entity_id);
 
     $wrapper = entity_metadata_wrapper($this->entityType, $entity_id);
     $wrapper->delete();


### PR DESCRIPTION
The `deleteEntity` method right now validates that the user has "update" permission, not "delete" permission. I have a use case where a user is allowed to update but not delete a node, thus this is returning a false-positive.
