### PR TITLE
[BUGFIX] Make sure the description property is always available in the base RestfulException object.

### DIFF
--- a/exceptions/RestfulBadRequestException.php
+++ b/exceptions/RestfulBadRequestException.php
@@ -15,9 +15,7 @@ class RestfulBadRequestException extends RestfulException {
   protected $code = 400;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Bad Request.';
 

--- a/exceptions/RestfulException.php
+++ b/exceptions/RestfulException.php
@@ -29,6 +29,13 @@ class RestfulException extends Exception {
   protected $headers = array();
 
   /**
+   * Defines the description.
+   *
+   * @var string
+   */
+  protected $description;
+
+  /**
    * Gets the description of the exception.
    *
    * @return string


### PR DESCRIPTION
From the original PR:
The `RestfulException` class contains a method `getDescription` that accesses a property called `description`. This property is not always available and in certain cases, logs errors like these:

```
Notice: Undefined property: RestfulException::$description in RestfulException->getDescription() (line 38 of /.../restful/exceptions/RestfulException.php)
```

On investigating, I found this method was introduced in 484a1744 with the description property added in child classes of `RestfulException`. If an application is extending that class and not defining the property, it results in the error above. While you may want to make it explicit that the description should be set in the child classes, it is not enforced which results in these notices. I think it is a good idea to at least keep it in the base class so that if a child class chooses not to use this, it doesn't have to.

On that note, why not just use the `message` property? I am just curious.
