### PR TITLE
Modify comments on inherited properties to use inheritdoc

### DIFF
--- a/exceptions/RestfulBadRequestException.php
+++ b/exceptions/RestfulBadRequestException.php
@@ -20,9 +20,7 @@ class RestfulBadRequestException extends RestfulException {
   protected $description = 'Bad Request.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-bad-request';
 

--- a/exceptions/RestfulFloodException.php
+++ b/exceptions/RestfulFloodException.php
@@ -15,16 +15,12 @@ class RestfulFloodException extends RestfulException {
   protected $code = 429;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Too Many Requests.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-flood';
 

--- a/exceptions/RestfulForbiddenException.php
+++ b/exceptions/RestfulForbiddenException.php
@@ -15,16 +15,12 @@ class RestfulForbiddenException extends RestfulException {
   protected $code = 403;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Forbidden.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-forbidden';
 

--- a/exceptions/RestfulGoneException.php
+++ b/exceptions/RestfulGoneException.php
@@ -15,16 +15,12 @@ class RestfulGoneException extends Exception {
   protected $code = 410;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'The resource at this end point is no longer available.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-gone';
 

--- a/exceptions/RestfulNotFoundException.php
+++ b/exceptions/RestfulNotFoundException.php
@@ -15,16 +15,12 @@ class RestfulNotFoundException extends RestfulException {
   protected $code = 404;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Not Found.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-not-found';
 

--- a/exceptions/RestfulNotImplementedException.php
+++ b/exceptions/RestfulNotImplementedException.php
@@ -15,16 +15,12 @@ class RestfulNotImplementedException extends \RestfulException {
   protected $code = 501;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Not Implemented.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-not-implemented';
 

--- a/exceptions/RestfulServerConfigurationException.php
+++ b/exceptions/RestfulServerConfigurationException.php
@@ -15,16 +15,12 @@ class RestfulServerConfigurationException extends \RestfulException {
   protected $code = 500;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Server configuration error.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-server-configuration';
 

--- a/exceptions/RestfulServiceUnavailable.php
+++ b/exceptions/RestfulServiceUnavailable.php
@@ -15,16 +15,12 @@ class RestfulServiceUnavailable extends RestfulException {
   protected $code = 503;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Service unavailable.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-bad-request';
 

--- a/exceptions/RestfulUnauthorizedException.php
+++ b/exceptions/RestfulUnauthorizedException.php
@@ -15,16 +15,12 @@ class RestfulUnauthorizedException extends \RestfulException {
   protected $code = 401;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Unauthorized.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-unauthorized';
 

--- a/exceptions/RestfulUnprocessableEntityException.php
+++ b/exceptions/RestfulUnprocessableEntityException.php
@@ -15,17 +15,13 @@ class RestfulUnprocessableEntityException extends RestfulException {
   protected $code = 422;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Unprocessable Entity; Validation errors.';
 
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-unprocessable-entity';
 

--- a/exceptions/RestfulUnsupportedMediaTypeException.php
+++ b/exceptions/RestfulUnsupportedMediaTypeException.php
@@ -5,7 +5,7 @@
  * Contains RestfulUnsupportedMediaTypeException
  */
 
-class RestfulUnsupportedMediaTypeException extends Exception {
+class RestfulUnsupportedMediaTypeException extends RestfulException {
 
   /**
    * Defines the HTTP error code.
@@ -15,16 +15,12 @@ class RestfulUnsupportedMediaTypeException extends Exception {
   protected $code = 415;
 
   /**
-   * Defines the description.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $description = 'Unsupported Media Type.';
 
   /**
-   * Defines the problem instance.
-   *
-   * @var string
+   * {@inheritdoc}
    */
   protected $instance = 'help/restful/problem-instances-unsupported-media-type';
 


### PR DESCRIPTION
This is in follow up to #736 and #739. This commit cleans up all inherited properties to use `{@inheritdoc}` instead of writing the comments each time. There also seems to be an oversight where one of the exception classes did not inherit from `RestfulException` and that is fixed here.
