### PR TITLE
Port getQueryCount() method to 2.x

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -178,20 +178,8 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
    * {@inheritdoc}
    */
   public function count() {
-    $query = $this->getEntityFieldQuery();
-
-    // If we are trying to filter on a computed field, just ignore it and log an
-    // exception.
-    try {
-      $this->queryForListFilter($query);
-    }
-    catch (BadRequestException $e) {
-      watchdog_exception('restful', $e);
-    }
-
-    $this->addExtraInfoToQuery($query);
-
-    return intval($query->count()->execute());
+    $query = $this->getQueryCount();
+    return intval($query->execute());
   }
 
   /**
@@ -537,6 +525,29 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     $this->addExtraInfoToQuery($query);
 
     return $query;
+  }
+
+  /**
+   * Prepare a query for RestfulEntityBase::count().
+   *
+   * @return \EntityFieldQuery
+   *   The EntityFieldQuery object.
+   */
+  protected function getQueryCount() {
+    $query = $this->getEntityFieldQuery();
+
+    // If we are trying to filter on a computed field, just ignore it and log an
+    // exception.
+    try {
+      $this->queryForListFilter($query);
+    }
+    catch (BadRequestException $e) {
+      watchdog_exception('restful', $e);
+    }
+
+    $this->addExtraInfoToQuery($query);
+
+    return $query->count();
   }
 
   /**

--- a/src/Plugin/resource/DataProvider/DataProviderNode.php
+++ b/src/Plugin/resource/DataProvider/DataProviderNode.php
@@ -24,26 +24,14 @@ class DataProviderNode extends DataProviderEntity implements DataProviderInterfa
   }
 
   /**
-   * Overrides DataProviderEntity::count().
+   * Overrides DataProviderEntity::getQueryCount().
    *
    * Only count published nodes.
    */
-  public function count() {
-    $query = $this->getEntityFieldQuery();
-
-    // If we are trying to filter on a computed field, just ignore it and log an
-    // exception.
-    try {
-      $this->queryForListFilter($query);
-    }
-    catch (BadRequestException $e) {
-      watchdog_exception('restful', $e);
-    }
+  public function getQueryCount() {
+    $query = parent::getQueryCount();
     $query->propertyCondition('status', NODE_PUBLISHED);
-
-    $this->addExtraInfoToQuery($query);
-
-    return intval($query->count()->execute());
+    return $query;
   }
 
   /**


### PR DESCRIPTION
I have some DataProviders and need to override count() method, but feel it complicated, the `getQueryCount()` method on 1.x is very convenient, so port it to 2.x.
