### PR TITLE
Allow bundles FALSE

### DIFF
--- a/modules/restful_example/src/Plugin/resource/DataProvider/DataProviderComment.php
+++ b/modules/restful_example/src/Plugin/resource/DataProvider/DataProviderComment.php
@@ -13,6 +13,27 @@ use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
 class DataProviderComment  extends DataProviderEntity implements DataProviderInterface {
 
   /**
+   * Overrides DataProviderEntity::setPropertyValues().
+   *
+   * Set nid and node type to a comment.
+   */
+  protected function setPropertyValues(\EntityDrupalWrapper $wrapper, $object, $replace = FALSE) {
+    $comment = $wrapper->value();
+    if (empty($comment->nid) && !empty($object['nid'])) {
+      // Comment nid must be set manually, as the nid property setter requires
+      // 'administer comments' permission.
+      $comment->nid = $object['nid'];
+      unset($object['nid']);
+
+      // Make sure we have a bundle name.
+      $node = node_load($comment->nid);
+      $comment->node_type = 'comment_node_' . $node->type;
+    }
+
+    parent::setPropertyValues($wrapper, $object, $replace);
+  }
+
+  /**
    * Overrides DataProviderEntity::getQueryForList().
    *
    * Expose only published comments.

--- a/modules/restful_example/src/Plugin/resource/DataProvider/DataProviderComment.php
+++ b/modules/restful_example/src/Plugin/resource/DataProvider/DataProviderComment.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful_example\Plugin\resource\DataProvider\DataProviderComment.
+ */
+
+namespace Drupal\restful_example\Plugin\resource\DataProvider;
+
+use Drupal\restful\Plugin\resource\DataProvider\DataProviderEntity;
+use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
+
+class DataProviderComment  extends DataProviderEntity implements DataProviderInterface {
+
+  /**
+   * Overrides DataProviderEntity::getQueryForList().
+   *
+   * Expose only published comments.
+   */
+  public function getQueryForList() {
+    $query = parent::getQueryForList();
+    $query->propertyCondition('status', COMMENT_PUBLISHED);
+    return $query;
+  }
+
+  /**
+   * Overrides DataProviderEntity::getQueryCount().
+   *
+   * Only count published comments.
+   */
+  public function getQueryCount() {
+    $query = parent::getQueryCount();
+    $query->propertyCondition('status', COMMENT_PUBLISHED);
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityPreSave(\EntityDrupalWrapper $wrapper) {
+    $comment = $wrapper->value();
+    if (!empty($comment->cid)) {
+      // Comment is already saved.
+      return;
+    }
+
+    $comment->uid = $this->getAccount()->uid;
+  }
+
+}

--- a/modules/restful_example/src/Plugin/resource/comment/Comments__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/comment/Comments__1_0.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful_example\Plugin\resource\comment\Comments__1_0.
+ */
+
+namespace Drupal\restful_example\Plugin\resource\comment;
+
+use Drupal\restful\Plugin\resource\ResourceEntity;
+use Drupal\restful\Plugin\resource\ResourceInterface;
+
+/**
+ * Class Comments__1_0
+ * @package Drupal\restful_example\Plugin\resource\comment
+ *
+ * @Resource(
+ *   name = "comments:1.0",
+ *   resource = "comments",
+ *   label = "Comments",
+ *   description = "Export the comments with all authentication providers.",
+ *   authenticationTypes = TRUE,
+ *   authenticationOptional = TRUE,
+ *   dataProvider = {
+ *     "entityType": "comment",
+ *     "bundles": FALSE,
+ *   },
+ *   majorVersion = 1,
+ *   minorVersion = 0
+ * )
+ */
+class Comments__1_0 extends ResourceEntity implements ResourceInterface {}

--- a/modules/restful_example/src/Plugin/resource/comment/Comments__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/comment/Comments__1_0.php
@@ -57,7 +57,7 @@ class Comments__1_0 extends ResourceEntity implements ResourceInterface {
    * {@inheritdoc}
    */
   protected function dataProviderClassName() {
-    return '\Drupal\restful_example\Plugin\resource\DataProvider\DataProviderComment';
+    return '\Drupal\restful_example\Plugin\resource\comment\DataProviderComment';
   }
 
 }

--- a/modules/restful_example/src/Plugin/resource/comment/Comments__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/comment/Comments__1_0.php
@@ -29,4 +29,39 @@ use Drupal\restful\Plugin\resource\ResourceInterface;
  *   minorVersion = 0
  * )
  */
-class Comments__1_0 extends ResourceEntity implements ResourceInterface {}
+class Comments__1_0 extends ResourceEntity implements ResourceInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function publicFields() {
+    $public_fields = parent::publicFields();
+
+    $public_fields['node'] = array(
+      'property' => 'node',
+      'resource' => array(
+        'name' => 'articles',
+        'majorVersion' => 1,
+        'minorVersion' => 0,
+      ),
+    );
+
+    // Add a custom field for test only.
+    if (field_info_field('comment_text')) {
+      $public_fields['comment_text'] = array(
+        'property' => 'comment_text',
+        'sub_property' => 'value',
+      );
+    }
+
+    return $public_fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function dataProviderClassName() {
+    return '\Drupal\restful_example\Plugin\resource\DataProvider\DataProviderComment';
+  }
+
+}

--- a/modules/restful_example/src/Plugin/resource/comment/Comments__1_0.php
+++ b/modules/restful_example/src/Plugin/resource/comment/Comments__1_0.php
@@ -37,13 +37,9 @@ class Comments__1_0 extends ResourceEntity implements ResourceInterface {
   protected function publicFields() {
     $public_fields = parent::publicFields();
 
-    $public_fields['node'] = array(
+    $public_fields['nid'] = array(
       'property' => 'node',
-      'resource' => array(
-        'name' => 'articles',
-        'majorVersion' => 1,
-        'minorVersion' => 0,
-      ),
+      'sub_property' => 'nid',
     );
 
     // Add a custom field for test only.

--- a/modules/restful_example/src/Plugin/resource/comment/DataProviderComment.php
+++ b/modules/restful_example/src/Plugin/resource/comment/DataProviderComment.php
@@ -2,10 +2,10 @@
 
 /**
  * @file
- * Contains \Drupal\restful_example\Plugin\resource\DataProvider\DataProviderComment.
+ * Contains \Drupal\restful_example\Plugin\resource\comment\DataProviderComment.
  */
 
-namespace Drupal\restful_example\Plugin\resource\DataProvider;
+namespace Drupal\restful_example\Plugin\resource\comment;
 
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderEntity;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
@@ -16,6 +16,9 @@ class DataProviderComment  extends DataProviderEntity implements DataProviderInt
    * Overrides DataProviderEntity::setPropertyValues().
    *
    * Set nid and node type to a comment.
+   *
+   * Note that to create a comment with 'post comments' permission, apply a
+   * patch on https://www.drupal.org/node/2236229
    */
   protected function setPropertyValues(\EntityDrupalWrapper $wrapper, $object, $replace = FALSE) {
     $comment = $wrapper->value();

--- a/restful.info
+++ b/restful.info
@@ -11,6 +11,7 @@ registry_autoload[] = PSR-4
 
 ; Tests
 files[] = tests/RestfulAuthenticationTestCase.test
+files[] = tests/RestfulCommentTestCase.test
 files[] = tests/RestfulCreateEntityTestCase.test
 files[] = tests/RestfulCreateNodeTestCase.test
 files[] = tests/RestfulCreatePrivateNodeTestCase.test

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -85,15 +85,18 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       throw new InternalServerErrorException('The entity type was not provided.');
     }
     $this->entityType = $options['entityType'];
-    if (!empty($options['bundles'])) {
+
+    $options += array('bundles' => array());
+    if ($options['bundles']) {
       $this->bundles = $options['bundles'];
     }
-    else {
+    elseif ($options['bundles'] !== FALSE) {
       // If no bundles are passed, then assume all the bundles of the entity
       // type.
       $entity_info = entity_get_info($this->entityType);
       $this->bundles = !empty($entity_info['bundles']) ? array_keys($entity_info['bundles']) : $entity_info['type'];
     }
+
     if (isset($options['EFQClass'])) {
       $this->EFQClass = $options['EFQClass'];
     }

--- a/tests/RestfulCommentTestCase.test
+++ b/tests/RestfulCommentTestCase.test
@@ -71,7 +71,7 @@ class RestfulCommentTestCase extends DrupalWebTestCase {
     $label = $this->randomName();
     $request = array(
       'label' => $label,
-      'node' => $this->node->nid,
+      'nid' => $this->node->nid,
     );
     $result = drupal_json_decode(restful()
       ->getFormatterManager()
@@ -80,6 +80,7 @@ class RestfulCommentTestCase extends DrupalWebTestCase {
 
     $comment = comment_load($result[0]['id']);
     $this->assertEqual($comment->uid, $user->uid, 'Correct user was set to be the author of the comment.');
+    $this->assertEqual($comment->nid, $this->node->nid, 'Correct nid set.');
     $this->assertEqual($comment->subject, $label, 'Correct subject set.');
   }
 
@@ -106,7 +107,7 @@ class RestfulCommentTestCase extends DrupalWebTestCase {
     $result = $result['data'];
 
     $comment = $result[0];
-    $this->assertEqual($comment['node']['id'], $this->node->nid, 'Correct nid get.');
+    $this->assertEqual($comment['nid'], $this->node->nid, 'Correct nid get.');
     $this->assertEqual($comment['label'], $label, 'Correct subject get.');
   }
 
@@ -144,11 +145,11 @@ class RestfulCommentTestCase extends DrupalWebTestCase {
         'id' => $id,
         'label' => $new_label,
         'self' => $handler->versionedUrl($id),
+        'nid' => $this->node->nid,
         'comment_text' => NULL,
       ),
     );
 
-    unset($result[0]['node']);
     $result[0]['comment_text'] = trim(strip_tags($result[0]['comment_text']));
     $this->assertEqual($result, $expected_result);
   }
@@ -187,11 +188,11 @@ class RestfulCommentTestCase extends DrupalWebTestCase {
         'id' => $id,
         'label' => $new_label,
         'self' => $handler->versionedUrl($id),
+        'nid' => $this->node->nid,
         'comment_text' => $text,
       ),
     );
 
-    unset($result[0]['node']);
     $result[0]['comment_text'] = trim(strip_tags($result[0]['comment_text']));
     $this->assertEqual($result, $expected_result);
   }

--- a/tests/RestfulCommentTestCase.test
+++ b/tests/RestfulCommentTestCase.test
@@ -111,7 +111,7 @@ class RestfulCommentTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Test creating a comment (PUT method).
+   * Test updating a comment (PUT method).
    */
   public function testUpdateCommentAsPut() {
     $resource_manager = restful()->getResourceManager();
@@ -154,7 +154,7 @@ class RestfulCommentTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Test creating a comment (PATCH method).
+   * Test updating a comment (PATCH method).
    */
   public function testUpdateCommentAsPatch() {
     $resource_manager = restful()->getResourceManager();
@@ -197,7 +197,7 @@ class RestfulCommentTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Test creating a comment (DELETE method).
+   * Test deleting a comment (DELETE method).
    */
   public function testDeleteComment() {
     $resource_manager = restful()->getResourceManager();

--- a/tests/RestfulCommentTestCase.test
+++ b/tests/RestfulCommentTestCase.test
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * @file
+ * Contains RestfulCommentTestCase
+ */
+
+class RestfulCommentTestCase extends DrupalWebTestCase {
+
+  /**
+   * Holds the user account that owns the content.
+   *
+   * @var object
+   */
+  protected $account;
+
+  /**
+   * Article content.
+   *
+   * @var object
+   */
+  protected $node;
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Comment integration',
+      'description' => 'Test the CRUD of a comment.',
+      'group' => 'RESTful',
+    );
+  }
+
+  public function setUp() {
+    parent::setUp('restful_example', 'comment');
+    $this->account = $this->drupalCreateUser(array(
+      'create article content',
+      'edit own comments',
+    ));
+
+    $settings = array(
+      'type' => 'article',
+      'title' => $this->randomName(),
+      'uid' => $this->account->uid,
+    );
+    $this->node = $this->drupalCreateNode($settings);
+
+    // Add a comment_text field instead of comment_body field as the
+    // comment_body property is required, see entity_metadata_comment_entity_property_info()
+    // for more information.
+    $this->addTextField('comment', 'comment_node_article', 'comment_text');
+  }
+
+  /**
+   * Test creating a comment (POST method).
+   */
+  public function testCreateComment() {
+    $resource_manager = restful()->getResourceManager();
+    $this->drupalLogin($this->account);
+
+    $handler = $resource_manager->getPlugin('comments:1.0');
+
+    // @todo Remove "administer comments" when https://www.drupal.org/node/2236229 is fixed.
+    $permissions = array(
+      'post comments',
+      'administer comments',
+    );
+    // Set a different user from the logged in user, to assert the comment's
+    // author is set correctly.
+    $user = $this->drupalCreateUser($permissions);
+    $handler->setAccount($user);
+
+    $label = $this->randomName();
+    $request = array(
+      'label' => $label,
+      'node' => $this->node->nid,
+    );
+    $result = drupal_json_decode(restful()
+      ->getFormatterManager()
+      ->format($handler->doPost($request), 'json'));
+    $result = $result['data'];
+
+    $comment = comment_load($result[0]['id']);
+    $this->assertEqual($comment->uid, $user->uid, 'Correct user was set to be the author of the comment.');
+    $this->assertEqual($comment->subject, $label, 'Correct subject set.');
+  }
+
+  /**
+   * Test creating a comment (GET method).
+   */
+  public function testRetrieve() {
+    $resource_manager = restful()->getResourceManager();
+
+    $label = $this->randomName();
+    $settings = array(
+      'node_type' => 'comment_node_article',
+      'nid' => $this->node->nid,
+      'uid' => $this->account->uid,
+      'subject' => $label,
+    );
+    $comment = $this->createComment($settings);
+    $id = $comment->cid;
+
+    $handler = $resource_manager->getPlugin('comments:1.0');
+    $result = drupal_json_decode(restful()
+      ->getFormatterManager()
+      ->format($handler->doGet($id), 'json'));
+    $result = $result['data'];
+
+    $comment = $result[0];
+    $this->assertEqual($comment['node']['id'], $this->node->nid, 'Correct nid get.');
+    $this->assertEqual($comment['label'], $label, 'Correct subject get.');
+  }
+
+  /**
+   * Test creating a comment (PUT method).
+   */
+  public function testUpdateCommentAsPut() {
+    $resource_manager = restful()->getResourceManager();
+
+    $label = $this->randomName();
+    $new_label = $this->randomName();
+    $text = $this->randomName();
+
+    $settings = array(
+      'node_type' => 'comment_node_article',
+      'nid' => $this->node->nid,
+      'uid' => $this->account->uid,
+      'subject' => $label,
+    );
+    $settings['comment_text'][LANGUAGE_NONE][0]['value'] = $text;
+
+    $comment = $this->createComment($settings);
+    $id = $comment->cid;
+
+    $handler = $resource_manager->getPlugin('comments:1.0');
+    $handler->setAccount($this->account);
+    $request = array('label' => $new_label);
+
+    $result = drupal_json_decode(restful()
+      ->getFormatterManager()
+      ->format($handler->doPut($id, $request), 'json'));
+    $result = $result['data'];
+    $expected_result = array(
+      array(
+        'id' => $id,
+        'label' => $new_label,
+        'self' => $handler->versionedUrl($id),
+        'comment_text' => NULL,
+      ),
+    );
+
+    unset($result[0]['node']);
+    $result[0]['comment_text'] = trim(strip_tags($result[0]['comment_text']));
+    $this->assertEqual($result, $expected_result);
+  }
+
+  /**
+   * Test creating a comment (PATCH method).
+   */
+  public function testUpdateCommentAsPatch() {
+    $resource_manager = restful()->getResourceManager();
+
+    $label = $this->randomName();
+    $new_label = $this->randomName();
+    $text = $this->randomName();
+
+    $settings = array(
+      'node_type' => 'comment_node_article',
+      'nid' => $this->node->nid,
+      'uid' => $this->account->uid,
+      'subject' => $label,
+    );
+    $settings['comment_text'][LANGUAGE_NONE][0]['value'] = $text;
+
+    $comment = $this->createComment($settings);
+    $id = $comment->cid;
+
+    $handler = $resource_manager->getPlugin('comments:1.0');
+    $handler->setAccount($this->account);
+    $request = array('label' => $new_label);
+
+    $result = drupal_json_decode(restful()
+      ->getFormatterManager()
+      ->format($handler->doPatch($id, $request), 'json'));
+    $result = $result['data'];
+    $expected_result = array(
+      array(
+        'id' => $id,
+        'label' => $new_label,
+        'self' => $handler->versionedUrl($id),
+        'comment_text' => $text,
+      ),
+    );
+
+    unset($result[0]['node']);
+    $result[0]['comment_text'] = trim(strip_tags($result[0]['comment_text']));
+    $this->assertEqual($result, $expected_result);
+  }
+
+  /**
+   * Test creating a comment (DELETE method).
+   */
+  public function testDeleteComment() {
+    $resource_manager = restful()->getResourceManager();
+
+    $label = $this->randomName();
+    $text = $this->randomName();
+
+    $settings = array(
+      'node_type' => 'comment_node_article',
+      'nid' => $this->node->nid,
+      'uid' => $this->account->uid,
+      'subject' => $label,
+    );
+    $settings['comment_text'][LANGUAGE_NONE][0]['value'] = $text;
+
+    $comment = $this->createComment($settings);
+    $id = $comment->cid;
+
+    $handler = $resource_manager->getPlugin('comments:1.0');
+    // Set a different user from the comment user, as only the administer
+    // can delete comments.
+    $user = $this->drupalCreateUser(array('administer comments'));
+    $handler->setAccount($user);
+    $handler->doDelete($id);
+
+    $result = !comment_load($id);
+    $this->assertTrue($result, 'Comment deleted.');
+  }
+
+  /**
+   * Adds a text field.
+   *
+   * @param string $entity_type
+   *   The entity type.
+   * @param string $bundle.
+   *   The bundle name.
+   * @param string $field_name.
+   *   The field name.
+   */
+  protected function addTextField($entity_type, $bundle, $field_name) {
+    // Text - single, with text processing.
+    $field = array(
+      'field_name' => $field_name,
+      'type' => 'text_long',
+      'entity_types' => array($entity_type),
+      'cardinality' => 1,
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'field_name' => $field_name,
+      'bundle' => $bundle,
+      'entity_type' => $entity_type,
+      'label' => t('Text single with text processing'),
+      'settings' => array(
+        'text_processing' => 1,
+      ),
+    );
+    field_create_instance($instance);
+  }
+
+  /**
+   * Creates a comment based on default settings.
+   *
+   * @param array $settings
+   *   An associative array of settings to change from the defaults, keys are
+   *   comment properties, for example 'subject' => 'Hello, world!'.
+   * @return object
+   *   Created comment object.
+   */
+  protected function createComment($settings = array()) {
+    // Populate defaults array.
+    $settings += array(
+      'cid'          => FALSE,
+      'pid'          => 0,
+      'subject'      => $this->randomName(8),
+      'status'       => COMMENT_PUBLISHED,
+      'node_type'    => 'comment_node_article',
+      'language'     => LANGUAGE_NONE,
+      'comment_text' => array(LANGUAGE_NONE => array(array())),
+    );
+
+    // If the comment's user uid is not specified manually, use the currently
+    // logged in user if available, or else the user running the test.
+    if (!isset($settings['uid'])) {
+      if ($this->loggedInUser) {
+        $settings['uid'] = $this->loggedInUser->uid;
+      }
+      else {
+        global $user;
+        $settings['uid'] = $user->uid;
+      }
+    }
+
+    // Merge comment text field value and format separately.
+    $body = array(
+      'value' => $this->randomName(32),
+      'format' => filter_default_format(),
+    );
+    $settings['comment_text'][$settings['language']][0] += $body;
+
+    $comment = (object) $settings;
+    comment_save($comment);
+
+    return $comment;
+  }
+}


### PR DESCRIPTION
`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'comment.node_type' in 'where clause'` occurs on below `comments` resource:

``` php
/**
 * Class Comments__1_0
 * @package Drupal\restful_example\Plugin\resource\comment
 *
 * @Resource(
 *   name = "comments:1.0",
 *   resource = "comments",
 *   label = "Comments",
 *   description = "Export the comments with all authentication providers.",
 *   authenticationTypes = TRUE,
 *   authenticationOptional = TRUE,
 *   dataProvider = {
 *     "entityType": "comment",
 *     "bundles": {
 *       "comment_node_article"
 *     },
 *   },
 *   majorVersion = 1,
 *   minorVersion = 0
 * )
 */
class Comments__1_0 extends ResourceEntity implements ResourceInterface {}
```

Unlike other entities, the comment table doesn't have a column for bundle, If we allow no bundles using `bundles = FALSE`:

``` php
/**
* ...
 *   dataProvider = {
 *     "entityType": "comment",
 *     "bundles": FALSE,
 *   },
 * ...
 */
```

and bypass entity bundle condition for EntityFieldQuery, the comments resource would work.
