### PR TITLE
[CLEANUP] Friendly error for incompatible BETWEEN ops

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProvider.php
+++ b/src/Plugin/resource/DataProvider/DataProvider.php
@@ -109,7 +109,8 @@ abstract class DataProvider implements DataProviderInterface {
     }
 
     // Make sure that we have the same amount of operators than values.
-    if (!in_array(strtoupper($filter['operator'][0]), array(
+    $first_operator = strtoupper($filter['operator'][0]);
+    if (!in_array($first_operator, array(
         'IN',
         'NOT IN',
         'BETWEEN',
@@ -117,11 +118,16 @@ abstract class DataProvider implements DataProviderInterface {
     ) {
       throw new BadRequestException('The number of operators and values has to be the same.');
     }
+    // Make sure that the BETWEEN operator gets only 2 values.
+    if ($first_operator == 'BETWEEN' && count($filter['value']) != 2) {
+      throw new BadRequestException('The BETWEEN operator takes exactly 2 values.');
+    }
 
     $filter += array('conjunction' => 'AND');
 
     // Clean the operator in case it came from the URL.
-    // e.g. filter[minor_version][operator]=">="
+    // e.g. filter[minor_version][operator][0]=">="
+    // str_replace will process all the elements in the array.
     $filter['operator'] = str_replace(array('"', "'"), '', $filter['operator']);
 
     static::isValidOperatorsForFilter($filter['operator']);

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -640,7 +640,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       }
 
       if (field_info_field($property_name)) {
-        if (in_array(strtoupper($filter['operator'][0]), array('IN', 'NOT IN', 'BETWEEN'))) {
+        if ($this::isMultipleValuOperator($filter['operator'][0])) {
           $query->fieldCondition($property_name, $resource_field->getColumn(), $this->getReferencedIds($filter['value'], $resource_field), $filter['operator'][0]);
           continue;
         }
@@ -652,7 +652,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
       }
       else {
         $column = $this->getColumnFromProperty($property_name);
-        if (in_array(strtoupper($filter['operator'][0]), array('IN', 'NOT IN', 'BETWEEN'))) {
+        if ($this::isMultipleValuOperator($filter['operator'][0])) {
           $query->propertyCondition($column, $this->getReferencedIds($filter['value'], $resource_field), $filter['operator'][0]);
           continue;
         }
@@ -661,6 +661,19 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
         }
       }
     }
+  }
+
+  /**
+   * Checks if the operator accepts multiple values.
+   *
+   * @param $operator_name
+   *   The name of the operator.
+   *
+   * @return bool
+   *   TRUE if the operator can interpret multiple values. FALSE otherwise.
+   */
+  protected static function isMultipleValuOperator($operator_name) {
+    return in_array(strtoupper($operator_name), array('IN', 'NOT IN', 'BETWEEN'));
   }
 
   /**


### PR DESCRIPTION
When the BETWEEN operator is used, then 2 values should be provided
otherwise when piping the options along to the data provider there
will be an incomprehensible error. For MySql that means a syntax
error.
