### PR TITLE
[BUGFIX] Remove cache fragments during shutdown

### DIFF
--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -77,7 +77,9 @@ function _restful_entity_cache_hashes($entity, $type) {
  */
 function restful_entity_update($entity, $type) {
   $hashes = &drupal_static('restful_entity_clear_hashes', array());
-  $hashes += _restful_entity_cache_hashes($entity, $type);
+  $new_hashes = _restful_entity_cache_hashes($entity, $type);
+  array_walk($new_hashes, '_restful_entity_clear_all_resources');
+  $hashes += $new_hashes;
   restful_register_shutdown_function_once('restful_entity_clear_render_cache');
 }
 
@@ -86,7 +88,9 @@ function restful_entity_update($entity, $type) {
  */
 function restful_entity_delete($entity, $type) {
   $hashes = &drupal_static('restful_entity_clear_hashes', array());
-  $hashes += _restful_entity_cache_hashes($entity, $type);
+  $new_hashes = _restful_entity_cache_hashes($entity, $type);
+  array_walk($new_hashes, '_restful_entity_clear_all_resources');
+  $hashes += $new_hashes;
   restful_register_shutdown_function_once('restful_entity_clear_render_cache');
 }
 
@@ -101,7 +105,9 @@ function restful_user_update(&$edit, $account, $category) {
     ->propertyCondition('type', 'user_id')
     ->propertyCondition('value', $account->uid);
   $hashes = &drupal_static('restful_entity_clear_hashes', array());
-  $hashes += CacheFragmentController::lookUpHashes($query);
+  $new_hashes = CacheFragmentController::lookUpHashes($query);
+  array_walk($new_hashes, '_restful_entity_clear_all_resources');
+  $hashes += $new_hashes;
   restful_register_shutdown_function_once('restful_entity_clear_render_cache');
 }
 
@@ -116,7 +122,9 @@ function restful_user_delete($account) {
     ->propertyCondition('type', 'user_id')
     ->propertyCondition('value', $account->uid);
   $hashes = &drupal_static('restful_entity_clear_hashes', array());
-  $hashes += CacheFragmentController::lookUpHashes($query);
+  $new_hashes = CacheFragmentController::lookUpHashes($query);
+  array_walk($new_hashes, '_restful_entity_clear_all_resources');
+  $hashes += $new_hashes;
   restful_register_shutdown_function_once('restful_entity_clear_render_cache');
 }
 
@@ -134,6 +142,26 @@ function restful_register_shutdown_function_once($callback) {
   if (!$added) {
     drupal_register_shutdown_function($callback);
   }
+}
+
+/**
+ * Clear the cache back ends for the given hash.
+ *
+ * @param string $cid
+ *   The cache ID to clear.
+ */
+function _restful_entity_clear_all_resources($cid) {
+  if (!$instance_id = CacheFragmentController::resourceIdFromHash($cid)) {
+    return;
+  }
+  $handler = restful()
+    ->getResourceManager()
+    ->getPlugin($instance_id);
+  if (!$handler instanceof CacheDecoratedResourceInterface) {
+    return;
+  }
+  // Clear the cache bin.
+  $handler->getCacheController()->clear($cid);
 }
 
 /**

--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -9,7 +9,6 @@ use Drupal\restful\Plugin\resource\Decorators\CacheDecoratedResource;
 use Drupal\restful\Plugin\resource\Decorators\CacheDecoratedResourceInterface;
 use Drupal\restful\RenderCache\Entity\CacheFragmentController;
 use Drupal\restful\RenderCache\RenderCache;
-use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
@@ -77,48 +76,18 @@ function _restful_entity_cache_hashes($entity, $type) {
  * Implements hook_entity_update().
  */
 function restful_entity_update($entity, $type) {
-  $resource_manager = restful()->getResourceManager();
-  foreach (_restful_entity_cache_hashes($entity, $type) as $hash) {
-    if (!$instance_id = CacheFragmentController::resourceIdFromHash($hash)) {
-      continue;
-    }
-    $handler = $resource_manager->getPlugin($instance_id);
-    if (!$handler instanceof CacheDecoratedResourceInterface) {
-      continue;
-    }
-    if (!$handler->hasSimpleInvalidation()) {
-      continue;
-    }
-    // You can get away without the fragments for a clear.
-    $cache_object = new RenderCache(new ArrayCollection(), $hash, $handler->getCacheController());
-    // Do a clear with the RenderCache object to also remove the cache fragment
-    // entities.
-    $cache_object->clear();
-  }
+  $hashes = &drupal_static('restful_entity_clear_hashes', array());
+  $hashes += _restful_entity_cache_hashes($entity, $type);
+  restful_register_shutdown_function_once('restful_entity_clear_render_cache');
 }
 
 /**
  * Implements hook_entity_delete().
  */
 function restful_entity_delete($entity, $type) {
-  $resource_manager = restful()->getResourceManager();
-  foreach (_restful_entity_cache_hashes($entity, $type) as $hash) {
-    if (!$instance_id = CacheFragmentController::resourceIdFromHash($hash)) {
-      continue;
-    }
-    $handler = $resource_manager->getPlugin($instance_id);
-    if (!$handler instanceof CacheDecoratedResourceInterface) {
-      continue;
-    }
-    if (!$handler->hasSimpleInvalidation()) {
-      continue;
-    }
-    // You can get away without the fragments for a clear.
-    $cache_object = new RenderCache(new ArrayCollection(), $hash, $handler->getCacheController());
-    // Do a clear with the RenderCache object to also remove the cache fragment
-    // entities.
-    $cache_object->clear();
-  }
+  $hashes = &drupal_static('restful_entity_clear_hashes', array());
+  $hashes += _restful_entity_cache_hashes($entity, $type);
+  restful_register_shutdown_function_once('restful_entity_clear_render_cache');
 }
 
 /**
@@ -131,29 +100,9 @@ function restful_user_update(&$edit, $account, $category) {
     ->entityCondition('entity_type', 'cache_fragment')
     ->propertyCondition('type', 'user_id')
     ->propertyCondition('value', $account->uid);
-  $resource_manager = restful()->getResourceManager();
-  foreach (CacheFragmentController::lookUpHashes($query) as $hash) {
-    if (!$plugin_id = CacheFragmentController::resourceIdFromHash($hash)) {
-      continue;
-    }
-    try {
-      $handler = $resource_manager->getPlugin($plugin_id);
-    }
-    catch (PluginNotFoundException $e) {
-      continue;
-    }
-    if (!$handler instanceof CacheDecoratedResourceInterface) {
-      return;
-    }
-    if (!$handler->hasSimpleInvalidation()) {
-      return;
-    }
-    // You can get away without the fragments for a clear.
-    $cache_object = new RenderCache(new ArrayCollection(), $hash, $handler->getCacheController());
-    // Do a clear with the RenderCache object to also remove the cache fragment
-    // entities.
-    $cache_object->clear();
-  }
+  $hashes = &drupal_static('restful_entity_clear_hashes', array());
+  $hashes += CacheFragmentController::lookUpHashes($query);
+  restful_register_shutdown_function_once('restful_entity_clear_render_cache');
 }
 
 /**
@@ -166,19 +115,51 @@ function restful_user_delete($account) {
     ->entityCondition('entity_type', 'cache_fragment')
     ->propertyCondition('type', 'user_id')
     ->propertyCondition('value', $account->uid);
-  $resource_manager = restful()->getResourceManager();
-  foreach (CacheFragmentController::lookUpHashes($query) as $hash) {
-    $handler = $resource_manager->getPlugin(CacheFragmentController::resourceIdFromHash($hash));
-    if (!$handler instanceof CacheDecoratedResourceInterface) {
-      return;
+  $hashes = &drupal_static('restful_entity_clear_hashes', array());
+  $hashes += CacheFragmentController::lookUpHashes($query);
+  restful_register_shutdown_function_once('restful_entity_clear_render_cache');
+}
+
+/**
+ * Helper function to schedule a shutdown once.
+ *
+ * @param callable $callback
+ *   The callback.
+ */
+function restful_register_shutdown_function_once($callback) {
+  $existing_callbacks = drupal_register_shutdown_function();
+  $added = (bool) array_filter($existing_callbacks, function ($item) use ($callback) {
+    return $item['callback'] == $callback;
+  });
+  if (!$added) {
+    drupal_register_shutdown_function($callback);
+  }
+}
+
+/**
+ * Shutdown function that deletes the scheduled fragments and caches on shutdown.
+ */
+function restful_entity_clear_render_cache() {
+  if ($hashes = drupal_static('restful_entity_clear_hashes', array())) {
+    $hashes = array_unique($hashes);
+    drupal_static_reset('restful_entity_clear_hashes');
+    $resource_manager = restful()->getResourceManager();
+    foreach ($hashes as $hash) {
+      if (!$instance_id = CacheFragmentController::resourceIdFromHash($hash)) {
+        continue;
+      }
+      $handler = $resource_manager->getPlugin($instance_id);
+      if (!$handler instanceof CacheDecoratedResourceInterface) {
+        continue;
+      }
+      if (!$handler->hasSimpleInvalidation()) {
+        continue;
+      }
+      // You can get away without the fragments for a clear.
+      $cache_object = new RenderCache(new ArrayCollection(), $hash, $handler->getCacheController());
+      // Do a clear with the RenderCache object to also remove the cache fragment
+      // entities.
+      $cache_object->clear();
     }
-    if (!$handler->hasSimpleInvalidation()) {
-      return;
-    }
-    // You can get away without the fragments for a clear.
-    $cache_object = new RenderCache(NULL, $hash, $handler->getCacheController());
-    // Do a clear with the RenderCache object to also remove the cache fragment
-    // entities.
-    $cache_object->clear();
   }
 }

--- a/src/RenderCache/RenderCache.php
+++ b/src/RenderCache/RenderCache.php
@@ -69,7 +69,21 @@ class RenderCache implements RenderCacheInterface {
    * {@inheritdoc}
    */
   public function get() {
-    return $this->cacheObject->get($this->generateCacheId());
+    $cid = $this->generateCacheId();
+    $query = new \EntityFieldQuery();
+    $count = $query
+      ->entityCondition('entity_type', 'cache_fragment')
+      ->propertyCondition('hash', $cid)
+      ->count()
+      ->execute();
+
+    if ($count) {
+      return $this->cacheObject->get($cid);
+    }
+    // If there are no cache fragments for the given hash then clear the cache
+    // and return NULL.
+    $this->cacheObject->clear($cid);
+    return NULL;
   }
 
   /**

--- a/tests/RestfulRenderCacheTestCase.test
+++ b/tests/RestfulRenderCacheTestCase.test
@@ -13,6 +13,9 @@ use Drupal\restful\RenderCache\Entity\CacheFragmentController;
 
 class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
 
+  /**
+   * {@inheritdoc}
+   */
   public static function getInfo() {
     return array(
       'name' => 'Render Cache',
@@ -21,6 +24,9 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     parent::setUp('restful_test');
   }
@@ -111,6 +117,9 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
     $account->name .= ' updated';
     user_save($account);
     $this->assertFalse($cache_object->get(), 'Cache object has been cleared after updating a user.');
+    // The cache fragment garbage collection happens on shutdown. For testing
+    // purposes we'll call the function directly here.
+    restful_entity_clear_render_cache();
     // Make sure that the cache fragment entities have been deleted.
     $query = new \EntityFieldQuery();
     /* @var CacheFragmentController $controller */


### PR DESCRIPTION
When an entity is updated or deleted we need to clear caches and
remove the cache fragments. The problem is that depending on the
site configuration, that operation may be affected for a rolling
back transaction. Defer the clearing to the shutdown instead.
