### PR TITLE
Fixes #685: Adds UID to an entity upon creation.

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -634,7 +634,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
     // Set the uid as early as possible to avoid false-negatives on permission
     // checks.
-    if (!empty($this->getAccount()->uid) && $this->getAccount()->uid !== 0) {
+    if ('node' == $this->entityType && !empty($this->getAccount()->uid)) {
       $values['uid'] += $this->getAccount()->uid;
     }
 

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -594,7 +594,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    * {@inheritdoc}
    */
   public function deleteEntity($entity_id) {
-    $this->isValidEntity('update', $entity_id);
+    $this->isValidEntity('delete', $entity_id);
 
     $wrapper = entity_metadata_wrapper($this->entityType, $entity_id);
     $wrapper->delete();
@@ -631,6 +631,12 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     $entity_info = $this->getEntityInfo();
     $bundle_key = $entity_info['entity keys']['bundle'];
     $values = $bundle_key ? array($bundle_key => $this->bundle) : array();
+
+    // Set the uid as early as possible to avoid false-negatives on permission
+    // checks.
+    if (!empty($this->getAccount()->uid) && $this->getAccount()->uid !== 0) {
+      $values['uid'] += $this->getAccount()->uid;
+    }
 
     $entity = entity_create($this->entityType, $values);
 

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -632,12 +632,6 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     $bundle_key = $entity_info['entity keys']['bundle'];
     $values = $bundle_key ? array($bundle_key => $this->bundle) : array();
 
-    // Set the uid as early as possible to avoid false-negatives on permission
-    // checks.
-    if ('node' == $this->entityType && !empty($this->getAccount()->uid)) {
-      $values['uid'] += $this->getAccount()->uid;
-    }
-
     $entity = entity_create($this->entityType, $values);
 
     if ($this->checkEntityAccess('create', $this->entityType, $entity) === FALSE) {
@@ -648,7 +642,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
     $wrapper = entity_metadata_wrapper($this->entityType, $entity);
 
-    $this->setPropertyValues($wrapper);
+    $this->setPropertyValues($wrapper, FALSE, 'create');
     return array($this->viewEntity($wrapper->getIdentifier()));
   }
 
@@ -661,10 +655,13 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    *   Determine if properties that are missing from the request array should
    *   be treated as NULL, or should be skipped. Defaults to FALSE, which will
    *   skip, instead of setting the fields to NULL.
+   * @param string $op
+   *   The operation that is happening to the entity (create or edit). Defaults
+   *   to 'edit'.
    *
    * @throws RestfulBadRequestException
    */
-  protected function setPropertyValues(EntityMetadataWrapper $wrapper, $null_missing_fields = FALSE) {
+  protected function setPropertyValues(EntityMetadataWrapper $wrapper, $null_missing_fields = FALSE, $op = 'edit') {
     $request = $this->getRequest();
 
     static::cleanRequest($request);
@@ -689,7 +686,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
       if (!array_key_exists($public_field_name, $request)) {
         // No property to set in the request.
-        if ($null_missing_fields && $this->checkPropertyAccess('edit', $public_field_name, $wrapper->{$property_name}, $wrapper)) {
+        if ($null_missing_fields && $this->checkPropertyAccess($op, $public_field_name, $wrapper->{$property_name}, $wrapper)) {
           // We need to set the value to NULL.
           $field_value = NULL;
         }
@@ -708,7 +705,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
 
       // We check the property access only after setting the values, as the
       // access callback's response might change according to the field value.
-      if (!$this->checkPropertyAccess('edit', $public_field_name, $wrapper->{$property_name}, $wrapper)) {
+      if (!$this->checkPropertyAccess($op, $public_field_name, $wrapper->{$property_name}, $wrapper)) {
         throw new \RestfulBadRequestException(format_string('Property @name cannot be set.', array('@name' => $public_field_name)));
       }
 

--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -632,6 +632,12 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     $bundle_key = $entity_info['entity keys']['bundle'];
     $values = $bundle_key ? array($bundle_key => $this->bundle) : array();
 
+    // Set the uid as early as possible to avoid false-negatives on permission
+    // checks.
+    if (!empty($this->getAccount()->uid) && $this->getAccount()->uid !== 0) {
+      $values['uid'] += $this->getAccount()->uid;
+    }
+
     $entity = entity_create($this->entityType, $values);
 
     if ($this->checkEntityAccess('create', $this->entityType, $entity) === FALSE) {


### PR DESCRIPTION
When an entity is being created, it's possible to get a false-negative on the entity access check if the UID isn't on the entity and the user making the request isn't an admin user.

For example, a user role "Content Contributor" is allowed to create "Blog" nodes and is only allowed to edit their own (not _any_).

When a "Content Contributor" makes the following request:

```
POST api/v1.0/blog
{
    "title": "Test title",
    "body": "<p>An example body\r\n</p>",
}
```

They would receive the following back:

```
{
  "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
  "title": "Property title cannot be set.",
  "status": 400,
  "detail": "Bad Request."
}
```

If you remove title, then you get the same message for body (or any other public field on the node). The reason for this is because the way that "create" happens in RESTful right now is that the entity is created without the UID (author) on the entity. So the entity is created but isn't attributed to the user making the request, so when the user making the request then tries to _edit_ the entity to set the a value, the permission system denies them access.

I consider this to be a critical bug.
