### PR TITLE
[BUGFIX] Pass in the interpreter to the ResourceField::value

### DIFF
--- a/src/Plugin/resource/Field/ResourceField.php
+++ b/src/Plugin/resource/Field/ResourceField.php
@@ -180,7 +180,7 @@ class ResourceField extends ResourceFieldBase implements ResourceFieldInterface 
    */
   public function compoundDocumentId(DataInterpreterInterface $interpreter) {
     // Since this kind of field can be anything, just return the value.
-    return $this->value();
+    return $this->value($interpreter);
   }
 
   /**


### PR DESCRIPTION
Failing to do so results in a PHP error with the type hinting.
