### PR TITLE
[BUGFIX] Avoid INNER JOIN for LEFT JOIN filters

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProvider.php
+++ b/src/Plugin/resource/DataProvider/DataProvider.php
@@ -97,6 +97,9 @@ abstract class DataProvider implements DataProviderInterface {
       $filter = array('value' => $filter);
     }
     if (!is_array($filter['value'])) {
+      if (!isset($filter['value'])) {
+        throw new BadRequestException(sprintf('Value not present for the "%s" filter. Please check the URL format.', $public_field));
+      }
       $filter['value'] = array($filter['value']);
     }
     // Add the property.

--- a/src/Util/EntityFieldQuery.php
+++ b/src/Util/EntityFieldQuery.php
@@ -459,9 +459,10 @@ class EntityFieldQuery extends \EntityFieldQuery implements EntityFieldQueryRela
       return;
     }
     $method = $having ? 'havingCondition' : 'condition';
-    $db_or = db_or()
-      ->condition($sql_field, $condition['value'], $condition['operator'])
-      ->condition($sql_field, NULL, 'IS NULL');
+    $db_or = db_or()->condition($sql_field, $condition['value'], $condition['operator']);
+    if (strtoupper($condition['operator']) != 'IS NULL' && strtoupper($condition['operator']) != 'IS NOT NULL') {
+      $db_or->condition($sql_field, NULL, 'IS NULL');
+    }
     $select_query->$method($db_or);
   }
 


### PR DESCRIPTION
If the first field condition (alphabetically) is a LEFT JOIN filter,
make sure that subsequent fields do not join to it with an INNER
JOIN.
