### PR TITLE
[BUGFIX] Remove Content-Length header

### DIFF
--- a/src/Formatter/FormatterManager.php
+++ b/src/Formatter/FormatterManager.php
@@ -14,6 +14,11 @@ use Drupal\restful\Plugin\resource\ResourceInterface;
 use Drupal\restful\Plugin\FormatterPluginManager;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 
+/**
+ * Class FormatterManager.
+ *
+ * @package Drupal\restful\Formatter
+ */
 class FormatterManager implements FormatterManagerInterface {
 
   /**

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -259,7 +259,6 @@ class Response implements ResponseInterface {
       throw new InternalServerErrorException(sprintf('The Response content must be a string or object implementing __toString(), "%s" given.', gettype($content)));
     }
     $this->content = (string) $content;
-    $this->headers->add(HttpHeader::create('Content-Length', strlen($this->content)));
   }
 
   /**


### PR DESCRIPTION
Under some data conditions reporting an invalid content lenght can
result in invalid JSON for some Content-Type. Remove the
Content-Length header.
