### PR TITLE
Update DataProviderDbQuery.php

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
+++ b/src/Plugin/resource/DataProvider/DataProviderDbQuery.php
@@ -331,7 +331,7 @@ class DataProviderDbQuery extends DataProvider implements DataProviderDbQueryInt
     if (!drupal_write_record($this->getTableName(), $record, $id_columns)) {
       throw new ServiceUnavailableException('Record could not be updated to the database.');
     }
-    return $this->view($identifier);
+    return array($this->view($identifier));
   }
 
   /**


### PR DESCRIPTION
Data providers' `update()` method must return an array. The returned value from this method is ultimately passed via `$page_callback_result` to `drupal_deliver_page()` which expects it the value to be:

``` php
 * @param $page_callback_result
 *   The result of a page callback. Can be one of:
 *   - NULL: to indicate no content.
 *   - An integer menu status constant: to indicate an error condition.
 *   - A string of HTML content.
 *   - A renderable array of content.
```

Without this pull request, the value returned will be an object.
