### PR TITLE
Return NULL if the embedded entity does not exist

### DIFF
--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -336,6 +336,10 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
         // access to the property.
         return NULL;
       }
+      catch (UnprocessableEntityException $e) {
+        // If you access a nonexistent embedded entity.
+        return NULL;
+      }
       // Test if the $embedded_entity meets the filter or not.
       if (empty($parsed_input['filter'])) {
         return $embedded_entity;

--- a/tests/RestfulJsonApiTestCase.test
+++ b/tests/RestfulJsonApiTestCase.test
@@ -584,15 +584,13 @@ class RestfulJsonApiTestCase extends RestfulCurlBaseTestCase {
     )));
     $handler->setPath($entities[2]->uuid);
     $format_manager->setResource($handler);
-    try {
-      $format_manager
-        ->negotiateFormatter(NULL, 'json_api')
-        ->prepare($handler->process());
-      $this->fail('Entity can be loaded with uuid when there is no idField.');
-    }
-    catch (UnprocessableEntityException $e) {
-      $this->pass('Entity cannot be loaded with uuid when there is no idField.');
-    }
+    $response = $format_manager
+      ->negotiateFormatter(NULL, 'json_api')
+      ->prepare($handler->process());
+
+    $result = $response['data']['attributes'];
+    // Make sure the entity_reference_resource_error is NULL.
+    $this->assertNull($result['entity_reference_resource_error'], 'Entity cannot be loaded with uuid when there is no idField.');
     variable_del('restful_test_alternative_id_error');
 
     // Clear caches to remove error field.


### PR DESCRIPTION
The embedded entity may be deleted, if in that case return NULL for the embedded entity, otherwise the present request won't work just due to a nonexistent embedded entity.
