### PR TITLE
Wrong help link

### DIFF
--- a/restful.module
+++ b/restful.module
@@ -113,10 +113,10 @@ function restful_permission() {
  */
 function restful_help($path, $arg) {
   switch ($path) {
-    case 'admin/structure/block':
+    case 'admin/config/services/restful':
     case 'admin/help#restful':
-      $message = t('This module is managed in GitHub. Please make sure to read the docs in the !link page for more help.', array(
-        '!link' => l(t('README.md'), 'https://github.com/Gizra/restful/blob/7.x-1.x/README.md'),
+      $message = t('This module is managed in GitHub. Please make sure to read the files in the !link folder for more help.', array(
+        '!link' => l(t('Docs'), 'https://github.com/RESTful-Drupal/restful/tree/7.x-2.x/docs'),
       ));
       return '<p>' . $message . '</p>';
   }


### PR DESCRIPTION
The link for help goes to the 1.x version and it is displayed on wrong paths.
