### PR TITLE
[FEATURE] More semantic error codes on access check

### DIFF
--- a/restful.module
+++ b/restful.module
@@ -172,6 +172,7 @@ function restful_menu_access_callback($resource_name, $version_string = NULL) {
   catch (RestfulException $e) {
     // We can get here if the request method is not valid or if no resource can
     // be negotiated.
+    watchdog('restful', $e->getMessage(), array(), WATCHDOG_WARNING);
   }
   catch (\Drupal\Component\Plugin\Exception\PluginNotFoundException $e) {
     restful_delivery(MENU_NOT_FOUND);

--- a/restful.module
+++ b/restful.module
@@ -172,13 +172,17 @@ function restful_menu_access_callback($resource_name, $version_string = NULL) {
   catch (RestfulException $e) {
     // We can get here if the request method is not valid or if no resource can
     // be negotiated.
-    watchdog('restful', $e->getMessage(), array(), WATCHDOG_WARNING);
+    $response = restful()->getResponse();
+    $output = _restful_build_http_api_error($e, $response);
+    $response->setStatusCode($e->getCode());
+    $response->setContent(drupal_json_encode($output));
+    $response->send();
+    exit();
   }
   catch (\Drupal\Component\Plugin\Exception\PluginNotFoundException $e) {
     restful_delivery(MENU_NOT_FOUND);
     exit();
   }
-  return FALSE;
 }
 
 /**

--- a/tests/RestfulCsrfTokenTestCase.test
+++ b/tests/RestfulCsrfTokenTestCase.test
@@ -109,7 +109,7 @@ class RestfulCsrfTokenTestCase extends RestfulCurlBaseTestCase {
         'Content-Type' => 'application/x-www-form-urlencoded',
       ), FALSE);
       if ($csrf_required) {
-        $params['@code'] = 403;
+        $params['@code'] = 400;
         $this->assertEqual($result['code'], $params['@code'], format_string('@code on @method without CSRF token for @role user.', $params));
       }
       else {

--- a/tests/RestfulRenderCacheTestCase.test
+++ b/tests/RestfulRenderCacheTestCase.test
@@ -9,8 +9,10 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Drupal\restful\Http\Request;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\RenderCache\RenderCache;
-use Drupal\restful\RenderCache\Entity\CacheFragmentController;
 
+/**
+ * Class RestfulRenderCacheTestCase.
+ */
 class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
 
   /**
@@ -122,7 +124,7 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
     restful_entity_clear_render_cache();
     // Make sure that the cache fragment entities have been deleted.
     $query = new \EntityFieldQuery();
-    /* @var CacheFragmentController $controller */
+    /* @var \Drupal\restful\RenderCache\Entity\CacheFragmentController $controller */
     $controller = entity_get_controller('cache_fragment');
     $results = $query
       ->entityCondition('entity_type', 'cache_fragment')
@@ -226,7 +228,7 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
     // Try to access the cached resource.
     $response = $this->httpRequest($path);
     // The user should get a 403.
-    $this->assertEqual($response['code'], 403, 'Access denied for anonymous user.');
+    $this->assertEqual($response['code'], 401, 'Access denied for anonymous user.');
     // Clear the cache, since anonymous requests get cached. Requests with basic
     // authentication will pick that cached version. This is a know issue and we
     // accept it as a lesser evil.
@@ -245,7 +247,7 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
     // Try to access the cached resource.
     $response = $this->httpRequest($path);
     // The user should get a 403.
-    $this->assertEqual($response['code'], 403, 'Access denied for anonymous user.');
+    $this->assertEqual($response['code'], 401, 'Access denied for anonymous user.');
     if (!drupal_is_cli()) {
       // Make sure that there is not a page cache entry.
       $this->assertFalse($cache->get($url), 'A page cache entry was created for an anonymous user.');

--- a/tests/RestfulRenderCacheTestCase.test
+++ b/tests/RestfulRenderCacheTestCase.test
@@ -227,7 +227,7 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
     $this->drupalLogout();
     // Try to access the cached resource.
     $response = $this->httpRequest($path);
-    // The user should get a 403.
+    // The user should get a 401.
     $this->assertEqual($response['code'], 401, 'Access denied for anonymous user.');
     // Clear the cache, since anonymous requests get cached. Requests with basic
     // authentication will pick that cached version. This is a know issue and we
@@ -246,7 +246,7 @@ class RestfulRenderCacheTestCase extends \RestfulCurlBaseTestCase {
 
     // Try to access the cached resource.
     $response = $this->httpRequest($path);
-    // The user should get a 403.
+    // The user should get a 401.
     $this->assertEqual($response['code'], 401, 'Access denied for anonymous user.');
     if (!drupal_is_cli()) {
       // Make sure that there is not a page cache entry.


### PR DESCRIPTION
If a request is denied access via a RESTful exception do not discard the error code. Instead return a well formatted error response.
