### PR TITLE
7.x-2.x - restful_cache_fragment grows at an enormous rate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ install:
   # Make sure we don't fail when checking out projects
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
   - sudo cat /etc/apt/sources.list
-  - echo "deb http://us-central1.gce.archive.ubuntu.com/ubuntu/ precise multiverse" | sudo tee -a /etc/apt/sources.list
-  - echo "deb-src http://us-central1.gce.archive.ubuntu.com/ubuntu/ precise multiverse" | sudo tee -a /etc/apt/sources.list
-  - echo "deb http://us-central1.gce.archive.ubuntu.com/ubuntu/ precise-updates multiverse" | sudo tee -a /etc/apt/sources.list
-  - echo "deb-src http://us-central1.gce.archive.ubuntu.com/ubuntu/ precise-updates multiverse" | sudo tee -a /etc/apt/sources.list
+  - echo "deb http://archive.ubuntu.com/ubuntu/ precise multiverse" | sudo tee -a /etc/apt/sources.list
+  - echo "deb-src http://archive.ubuntu.com/ubuntu/ precise multiverse" | sudo tee -a /etc/apt/sources.list
+  - echo "deb http://archive.ubuntu.com/ubuntu/ precise-updates multiverse" | sudo tee -a /etc/apt/sources.list
+  - echo "deb-src http://archive.ubuntu.com/ubuntu/ precise-updates multiverse" | sudo tee -a /etc/apt/sources.list
   - echo "deb http://security.ubuntu.com/ubuntu precise-security multiverse" | sudo tee -a /etc/apt/sources.list
   - echo "deb-src http://security.ubuntu.com/ubuntu precise-security multiverse" | sudo tee -a /etc/apt/sources.list
 

--- a/restful.admin.inc
+++ b/restful.admin.inc
@@ -101,7 +101,7 @@ function restful_admin_settings($form_state) {
   $form['restful_cache']['restful_fast_cache_clear'] = array(
     '#type' => 'checkbox',
     '#title' => t('Fast cache clear'),
-    '#description' => t('A lot of cache fragment entries may be created by default, and depending of your setup. This may cause your cache clears to be slow. By checking this checkbox the cache fragments are deleted from the database in a fast manner. As a trade-in, no hook_entity_delete will be fired for the cache fragment entities. This is OK in the vast majority of the cases.'),
+    '#description' => t('A lot of cache fragment entries may be created by default. This may cause your cache clears to be slow. By checking this checkbox the cache fragments are deleted from the database in a fast manner. As a trade-in, no hook_entity_delete will be fired for the cache fragment entities. This is OK in the vast majority of the cases. You can mitigate the number of generated fragments by overriding the "getCacheContext" method in your data provider.'),
     '#default_value' => variable_get('restful_fast_cache_clear', TRUE),
   );
 

--- a/restful.admin.inc
+++ b/restful.admin.inc
@@ -98,6 +98,13 @@ function restful_admin_settings($form_state) {
     '#default_value' => variable_get('restful_render_cache', FALSE),
   );
 
+  $form['restful_cache']['restful_fast_cache_clear'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Fast cache clear'),
+    '#description' => t('A lot of cache fragment entries may be created by default, and depending of your setup. This may cause your cache clears to be slow. By checking this checkbox the cache fragments are deleted from the database in a fast manner. As a trade-in, no hook_entity_delete will be fired for the cache fragment entities. This is OK in the vast majority of the cases.'),
+    '#default_value' => variable_get('restful_fast_cache_clear', TRUE),
+  );
+
   $form['advanced'] = array(
     '#type' => 'fieldset',
     '#title' => t('Advanced'),

--- a/restful.entity.inc
+++ b/restful.entity.inc
@@ -165,7 +165,7 @@ function _restful_entity_clear_all_resources($cid) {
 }
 
 /**
- * Shutdown function that deletes the scheduled fragments and caches on shutdown.
+ * Delete the scheduled fragments and caches on shutdown.
  */
 function restful_entity_clear_render_cache() {
   if ($hashes = drupal_static('restful_entity_clear_hashes', array())) {
@@ -185,8 +185,8 @@ function restful_entity_clear_render_cache() {
       }
       // You can get away without the fragments for a clear.
       $cache_object = new RenderCache(new ArrayCollection(), $hash, $handler->getCacheController());
-      // Do a clear with the RenderCache object to also remove the cache fragment
-      // entities.
+      // Do a clear with the RenderCache object to also remove the cache
+      // fragment entities.
       $cache_object->clear();
     }
   }

--- a/restful.module
+++ b/restful.module
@@ -201,7 +201,7 @@ function restful_menu_access_callback($resource_name, $version_string = NULL) {
  * @param string $version
  *   The version, prefixed with v (e.g. v1, v2.2).
  *
- * @throws ServiceUnavailableException
+ * @throws \Drupal\restful\Exception\ServiceUnavailableException
  *
  * @return string
  *   JSON output with the result of the API call.

--- a/src/RenderCache/Entity/CacheFragmentController.php
+++ b/src/RenderCache/Entity/CacheFragmentController.php
@@ -248,7 +248,7 @@ class CacheFragmentController extends \EntityAPIController {
     }
     // Get the hashes from the base table.
     $info = entity_get_info(static::ENTITY_TYPE);
-    static::$tableIdKey = $info['base table'];
+    static::$tableIdKey = $info['entity keys']['id'];
     return static::$tableIdKey;
   }
 

--- a/src/RenderCache/Entity/CacheFragmentController.php
+++ b/src/RenderCache/Entity/CacheFragmentController.php
@@ -135,7 +135,7 @@ class CacheFragmentController extends \EntityAPIController {
       return;
     }
     if ($this->isFastDeleteEnabled()) {
-      db_truncate($this::getTableName());
+      db_truncate($this::getTableName())->execute();
       return;
     }
     $this->delete(array_keys($results[static::ENTITY_TYPE]));


### PR DESCRIPTION
I've created a custom resource for a custom entity. This entity has a relationship to a node that represents editable content. When exposing this entity and it's node relationship via a custom resource, the restful_cache_fragment table is populated with a little over 10,000 entries (with a range of 100). While this provides great performance on subsequent requests; it makes flushing the cache or rebuilding the registry (drush rr) quite difficult without manually truncating the table. Is creating this many entries expected behavior?
