### PR TITLE
Allow OPTIONS calls to access_token.

### DIFF
--- a/modules/restful_token_auth/src/Plugin/resource/AccessToken__1_0.php
+++ b/modules/restful_token_auth/src/Plugin/resource/AccessToken__1_0.php
@@ -47,6 +47,7 @@ class AccessToken__1_0 extends TokenAuthenticationBase implements ResourceInterf
       '' => array(
         // Get or create a new token.
         RequestInterface::METHOD_GET => 'getOrCreateToken',
+        RequestInterface::METHOD_OPTIONS => 'discover',
       ),
     );
   }


### PR DESCRIPTION
Without this, a preflight `OPTIONS` call will return either a 
- `401 Unauthorized` if you request without auth (like a browser will do)
- `400 Bad Request` if you do provide auth
