### PR TITLE
[BUGFIX] Avoid warning for invalid filters

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProvider.php
+++ b/src/Plugin/resource/DataProvider/DataProvider.php
@@ -97,10 +97,10 @@ abstract class DataProvider implements DataProviderInterface {
       // filter[foo]=bar would be converted to filter[foo][value] = bar.
       $filter = array('value' => $filter);
     }
+    if (!isset($filter['value'])) {
+      throw new BadRequestException(sprintf('Value not present for the "%s" filter. Please check the URL format.', $public_field));
+    }
     if (!is_array($filter['value'])) {
-      if (!isset($filter['value'])) {
-        throw new BadRequestException(sprintf('Value not present for the "%s" filter. Please check the URL format.', $public_field));
-      }
       $filter['value'] = array($filter['value']);
     }
     // Add the property.


### PR DESCRIPTION
When an invalid filter is provided, throw the appropriate error and
avoid additional warnings.
