### PR TITLE
Replace drupal_static(__FUNCTION__) with drupal_static(__METHOD__)

### DIFF
--- a/src/Formatter/FormatterManager.php
+++ b/src/Formatter/FormatterManager.php
@@ -173,7 +173,7 @@ class FormatterManager implements FormatterManagerInterface {
    * @see drupal_match_path().
    */
   protected static function matchContentType($content_type, $pattern) {
-    $regexps = &drupal_static(__FUNCTION__);
+    $regexps = &drupal_static(__METHOD__);
 
     if (!isset($regexps[$pattern])) {
       // Convert path settings to a regular expression.


### PR DESCRIPTION
Using `__FUNCTION__` can result in possible collisions in caches when method names overlap.
