### PR TITLE
Multiple auth types ignored if unsuccessful cookie sent

### DIFF
--- a/src/Plugin/authentication/CookieAuthentication.php
+++ b/src/Plugin/authentication/CookieAuthentication.php
@@ -33,6 +33,10 @@ class CookieAuthentication extends Authentication {
 
     global $user;
     $account = user_load($user->uid);
+    
+    if ($account->uid === 0) {
+      return FALSE;
+    }
 
     if (!$request::isWriteMethod($request->getMethod()) || $request->getApplicationData('rest_call')) {
       // Request is done via API not CURL, or not a write operation, so we don't


### PR DESCRIPTION
If a resource specifies `authenticationTypes = TRUE` you would expect it to try each possible authentication provider until one of them successfully authenticates. However, if you supply an invalid cookie with the request (accidentally, in my case), as well as an `access_token`, the latter is never used.

The auth managers are attempted at https://github.com/RESTful-Drupal/restful/blob/7.x-2.x/src/Authentication/AuthenticationManager.php#L97-L103 in the following order: 
- basic auth
- cookie
- token

The cookie auth manager _always_ returns a `$account` even if it's for user 0. Therefore the token auth is never attempted.

You could argue that it's failing auth because I sent a cookie that fails auth, and you'd be right :D Personally, I would have thought it would keep trying, and the docs as they stand certainly imply this. If your stance is the current behaviour is correct, I should update the docs to make it clear that if you provide more than one means of authentication with the request, the auth providers will be checked in an arbitrary (albeit probably consistent) order, and the first auth data checked will end the authentication process whether successful or not.
