### PR TITLE
Add parsing of Content Type and Length HTTP headers for PHP CGI/FPM.

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -369,11 +369,12 @@ class Request implements RequestInterface {
       $headers = apache_request_headers();
     }
     else {
+      $content_header_keys = array('CONTENT_TYPE', 'CONTENT_LENGTH');
       foreach ($_SERVER as $key => $value) {
-        if (strpos($key, 'HTTP_') === 0) {
+        if (strpos($key, 'HTTP_') === 0 || in_array($key, $content_header_keys)) {
           // Generate the plausible header name based on the $name.
           // Converts 'HTTP_X_FORWARDED_FOR' to 'X-Forwarded-For'
-          $name = substr($key, 5);
+          $name = preg_replace('/^HTTP_/', '', $key);
           $parts = explode('_', $name);
           $parts = array_map('strtolower', $parts);
           $parts = array_map('ucfirst', $parts);


### PR DESCRIPTION
When PHP is running as CGI/FPM as opposed to apache mod_php, apache_request_headers() does not exist and HTTP headers have to be parsed from the $_SERVER superglobal.

Content-Type and Content-Length do not appear in $_SERVER with the HTTP_ prefix though, so a specific check is required for them.

This was addressed by symfony in https://github.com/symfony/symfony/issues/1234
