### PR TITLE
In-memory caching of authentication plugins.

### DIFF
--- a/src/Plugin/AuthenticationPluginManager.php
+++ b/src/Plugin/AuthenticationPluginManager.php
@@ -62,7 +62,7 @@ class AuthenticationPluginManager extends DefaultPluginManager {
    * {@inheritdoc}
    */
   public function getDefinitions() {
-    $definitions = &drupal_static(__FUNCTION__);
+    $definitions = &drupal_static(__METHOD__);
     if (!isset($definitions)) {
       $definitions = parent::getDefinitions();
     }

--- a/src/Plugin/AuthenticationPluginManager.php
+++ b/src/Plugin/AuthenticationPluginManager.php
@@ -57,4 +57,24 @@ class AuthenticationPluginManager extends DefaultPluginManager {
     return new static(Module::getNamespaces(), _cache_get_object($bin));
   }
 
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinitions() {
+    $definitions = &drupal_static(__FUNCTION__);
+    if (!isset($definitions)) {
+      $definitions = parent::getDefinitions();
+    }
+    return $definitions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinition($plugin_id, $exception_on_invalid = TRUE) {
+    $definitions = $this->getDefinitions();
+    return $this->doGetDefinition($definitions, $plugin_id, $exception_on_invalid);
+  }
+
 }


### PR DESCRIPTION
When there are a lot of sub-entities returned from a rest call
the getDefinitions method gets called often and each time
it hits the database to return the cached authentication plugins.
This could result in dozens or hundreds of redundant database
calls per request that look like this:

```
SELECT cid, data, created, expire, serialized FROM {cache} WHERE cid IN (:cids)

a:1:{s:5:":cids";a:1:{i:0;s:22:"authentication_plugins";}}
```

Adding a memory cache of the definitions ensures there are no
redundant database calls. This cut the TTFB of an in-the-wild
service by more than half.
