### PR TITLE
[BUGFIX] Move the resource to a new test module

### DIFF
--- a/modules/restful_token_auth/modules/restful_token_auth_test/restful_token_auth_test.info
+++ b/modules/restful_token_auth/modules/restful_token_auth_test/restful_token_auth_test.info
@@ -1,0 +1,8 @@
+name = RESTful Token Authentication tests
+description = Test module that provides some example resources.
+core = 7.x
+
+dependencies[] = restful_token_auth
+
+registry_autoload[] = PSR-0
+registry_autoload[] = PSR-4

--- a/modules/restful_token_auth/modules/restful_token_auth_test/restful_token_auth_test.module
+++ b/modules/restful_token_auth/modules/restful_token_auth_test/restful_token_auth_test.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Module implementation file.
+ */

--- a/modules/restful_token_auth/modules/restful_token_auth_test/src/Plugin/resource/Articles__1_3.php
+++ b/modules/restful_token_auth/modules/restful_token_auth_test/src/Plugin/resource/Articles__1_3.php
@@ -2,10 +2,10 @@
 
 /**
  * @file
- * Contains \Drupal\restful_token_auth\Plugin\resource\Articles__1_3.
+ * Contains \Drupal\restful_token_auth_test\Plugin\resource\Articles__1_3.
  */
 
-namespace Drupal\restful_token_auth\Plugin\resource;
+namespace Drupal\restful_token_auth_test\Plugin\resource;
 
 use Drupal\restful\Plugin\resource\ResourceInterface;
 use Drupal\restful\Plugin\resource\ResourceNode;

--- a/modules/restful_token_auth/tests/RestfulTokenAuthenticationTestCase.test
+++ b/modules/restful_token_auth/tests/RestfulTokenAuthenticationTestCase.test
@@ -26,7 +26,7 @@ class RestfulTokenAuthenticationTestCase extends DrupalWebTestCase {
    * {@inheritdoc}
    */
   public function setUp() {
-    parent::setUp('restful_example', 'restful_token_auth');
+    parent::setUp('restful_example', 'restful_token_auth', 'restful_token_auth_test');
   }
 
   /**


### PR DESCRIPTION
Allow implementors to use the 'articles' namespace when Token Auth
is enabled.
