### PR TITLE
Do not change field class of a callback field

### DIFF
--- a/src/Plugin/resource/ResourceEntity.php
+++ b/src/Plugin/resource/ResourceEntity.php
@@ -189,6 +189,8 @@ abstract class ResourceEntity extends Resource {
     // ResourceFieldEntity. Otherwise they will be considered regular
     // ResourceField.
     return array_map(function ($field_definition) {
+      if (isset($field_definition['callback'])) return $field_definition;
+
       $field_entity_class = '\Drupal\restful\Plugin\resource\Field\ResourceFieldEntity';
       $class_name = ResourceFieldEntity::fieldClassName($field_definition);
       if (!$class_name || is_subclass_of($class_name, $field_entity_class)) {


### PR DESCRIPTION
If a `callback` is set to a field, it's all the callback's responsibility to return a value, even NULL. But the`ResourceFieldEntity` tries to return parent entity for that field.

For instance:

``` php
class Users__1_1 extends ResourceEntity {

  protected function publicFields() {
    $fields = parent::publicFields();
    $fields['avatar'] = array(
      'callback' => array($this, 'getAvatar'),
    );
  }

  public function getAvatar(DataInterpreterInterface $interpreter) {
    $user = $interpreter->getWrapper()->value();
    return $user->picture ?: NULL;
  }
}
```

The user 28 does not have a picture.
Returns:

``` json
{
    "id": "28",
    "label": "test",
    "self": "http://api.example.com/v1.1/users/28",
    "avatar": {
        "uid": "28",
        "name": "test@example.com",
        "pass": "$S$DHe5ZSXY5FMj4DqdhM9hG1DABiTip6o2hE5tZYox.i8QOeQGcK/7",
        "mail": "test@example.com"
    }
}
```

Should be:

``` json
{
    "id": "28",
    "label": "test",
    "self": "http://api.example.com/v1.1/users/28",
    "avatar": null
}
```
