### PR TITLE
Fix: get correct range to output the next link

### DIFF
--- a/src/Plugin/formatter/FormatterHalJson.php
+++ b/src/Plugin/formatter/FormatterHalJson.php
@@ -123,8 +123,9 @@ class FormatterHalJson extends Formatter implements FormatterInterface {
     $input = $request->getParsedInput();
     $page = !empty($input['page']) ? $input['page'] : 1;
 
+    $query = $input;
     if ($page > 1) {
-      $query = array('page' => $page - 1) + $input;
+      $query['page'] = $page - 1;
       $data['_links']['previous'] = array(
         'title' => 'Previous',
         'href' => $resource->versionedUrl('', array('query' => $query), TRUE),
@@ -142,7 +143,7 @@ class FormatterHalJson extends Formatter implements FormatterInterface {
     $range = $range > $max_range ? $max_range : $range;
     $previous_items = ($page - 1) * $range;
     if (isset($data['count']) && $data['count'] > $listed_items + $previous_items) {
-      $query = array('page' => $page + 1) + $input;
+      $query['page'] = $page + 1;
       $data['_links']['next'] = array(
         'title' => 'Next',
         'href' => $resource->versionedUrl('', array('query' => $query), TRUE),

--- a/src/Plugin/formatter/FormatterHalJson.php
+++ b/src/Plugin/formatter/FormatterHalJson.php
@@ -121,14 +121,13 @@ class FormatterHalJson extends Formatter implements FormatterInterface {
     );
 
     $input = $request->getParsedInput();
-    $data_provider = $resource->getDataProvider();
     $page = !empty($input['page']) ? $input['page'] : 1;
 
     if ($page > 1) {
-      $input['page'] = $page - 1;
+      $query = array('page' => $page - 1) + $input;
       $data['_links']['previous'] = array(
         'title' => 'Previous',
-        'href' => $resource->getUrl(),
+        'href' => $resource->versionedUrl('', array('query' => $query), TRUE),
       );
     }
 
@@ -138,13 +137,15 @@ class FormatterHalJson extends Formatter implements FormatterInterface {
     // We know that there are more pages if the total count is bigger than the
     // number of items of the current request plus the number of items in
     // previous pages.
-    $items_per_page = $data_provider->getRange();
-    $previous_items = ($page - 1) * $items_per_page;
+    $max_range = $resource->getDataProvider()->getRange();
+    $range = isset($input['range']) ? (int) $input['range'] : $max_range;
+    $range = $range > $max_range ? $max_range : $range;
+    $previous_items = ($page - 1) * $range;
     if (isset($data['count']) && $data['count'] > $listed_items + $previous_items) {
-      $input['page'] = $page + 1;
+      $query = array('page' => $page + 1) + $input;
       $data['_links']['next'] = array(
         'title' => 'Next',
-        'href' => $resource->getUrl(),
+        'href' => $resource->versionedUrl('', array('query' => $query), TRUE),
       );
     }
 

--- a/src/Plugin/formatter/FormatterJson.php
+++ b/src/Plugin/formatter/FormatterJson.php
@@ -161,8 +161,9 @@ class FormatterJson extends Formatter implements FormatterInterface {
     $input = $request->getParsedInput();
     $page = !empty($input['page']) ? $input['page'] : 1;
 
+    $query = $input;
     if ($page > 1) {
-      $query = array('page' => $page - 1) + $input;
+      $query['page'] = $page - 1;
       $data['previous'] = array(
         'title' => 'Previous',
         'href' => $resource->versionedUrl('', array('query' => $query), TRUE),
@@ -177,7 +178,7 @@ class FormatterJson extends Formatter implements FormatterInterface {
     $range = $range > $max_range ? $max_range : $range;
     $previous_items = ($page - 1) * $range;
     if (isset($data['count']) && $data['count'] > count($data['data']) + $previous_items) {
-      $query = array('page' => $page + 1) + $input;
+      $query['page'] = $page + 1;
       $data['next'] = array(
         'title' => 'Next',
         'href' => $resource->versionedUrl('', array('query' => $query), TRUE),

--- a/src/Plugin/formatter/FormatterJson.php
+++ b/src/Plugin/formatter/FormatterJson.php
@@ -172,8 +172,10 @@ class FormatterJson extends Formatter implements FormatterInterface {
     // We know that there are more pages if the total count is bigger than the
     // number of items of the current request plus the number of items in
     // previous pages.
-    $items_per_page = $resource->getDataProvider()->getRange();
-    $previous_items = ($page - 1) * $items_per_page;
+    $max_range = $resource->getDataProvider()->getRange();
+    $range = isset($input['range']) ? (int) $input['range'] : $max_range;
+    $range = $range > $max_range ? $max_range : $range;
+    $previous_items = ($page - 1) * $range;
     if (isset($data['count']) && $data['count'] > count($data['data']) + $previous_items) {
       $query = array('page' => $page + 1) + $input;
       $data['next'] = array(

--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -208,19 +208,20 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
     if (isset($data['meta']['count']) && $data['meta']['count'] > $range) {
       $num_pages = ceil($data['meta']['count'] / $range);
 
-      $query = array('page' => 1) + $input;
+      $query = $input;
+      unset($query['page']);
       $data['links']['first'] = $resource->getUrl(array('query' => $query), FALSE);
 
-      $query = array('page' => $num_pages) + $input;
-      $data['links']['last'] = $resource->getUrl(array('query' => $query), FALSE);
-
       if ($page > 1) {
-        $query = array('page' => $page - 1) + $input;
+        $query['page'] = $page - 1;
         $data['links']['previous'] = $resource->getUrl(array('query' => $query), FALSE);
       }
 
+      $query['page'] = $num_pages;
+      $data['links']['last'] = $resource->getUrl(array('query' => $query), FALSE);
+
       if ($page < $num_pages) {
-        $query = array('page' =>$page + 1) + $input;
+        $query['page'] = $page + 1;
         $data['links']['next'] = $resource->getUrl(array('query' => $query), FALSE);
       }
     }


### PR DESCRIPTION
When generating`next` link in [FormatterJson](https://github.com/RESTful-Drupal/restful/blob/7.x-2.x/src/Plugin/formatter/FormatterJson.php#L175), the `$item_per_page` is always 50, it should change by request input, like what [DataProvider#parseRequestForListPagination()](https://github.com/RESTful-Drupal/restful/blob/7.x-2.x/src/Plugin/resource/DataProvider/DataProvider.php#L425-L426) does.
