### PR TITLE
[BUGFIX] Use the decorator to get metadata

### DIFF
--- a/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
@@ -36,14 +36,6 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface 
   protected $cacheController;
 
   /**
-   * Array of metadata. Use this as a mean to pass info to the render layer.
-   *
-   * @var ArrayCollection
-   *   Key value store.
-   */
-  protected $metadata;
-
-  /**
    * Constructs a CacheDecoratedDataProvider object.
    *
    * @param DataProviderInterface $subject
@@ -54,7 +46,6 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface 
   public function __construct(DataProviderInterface $subject, \DrupalCacheInterface $cache_controller) {
     $this->subject = $subject;
     $this->cacheController = $cache_controller;
-    $this->metadata = new ArrayCollection();
   }
 
   /**
@@ -274,7 +265,7 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface 
    * {@inheritdoc}
    */
   public function getMetadata() {
-    return $this->metadata;
+    return $this->subject->getMetadata();
   }
 
   /**

--- a/src/Plugin/resource/DataProvider/DataProviderNode.php
+++ b/src/Plugin/resource/DataProvider/DataProviderNode.php
@@ -7,9 +7,11 @@
 
 namespace Drupal\restful\Plugin\resource\DataProvider;
 
-
-use Drupal\restful\Exception\BadRequestException;
-
+/**
+ * Class DataProviderNode.
+ *
+ * @package Drupal\restful\Plugin\resource\DataProvider
+ */
 class DataProviderNode extends DataProviderEntity implements DataProviderInterface {
 
   /**


### PR DESCRIPTION
In the decorated resource, use the subject to get the underlying
metadata information.
