### PR TITLE
[CLEANUP] Deprecate PHP 5.4 since Plug depends on 5.5.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
 

--- a/restful.info
+++ b/restful.info
@@ -1,7 +1,7 @@
 name = RESTful
 description = Turn Drupal to a RESTful server, following best practices.
 core = 7.x
-php = 5.4
+php = 5.5.9
 dependencies[] = entity
 dependencies[] = plug
 configure = admin/config/services/restful


### PR DESCRIPTION
The 5.4 version support was unrealistic since one of the
dependencies already depens on PHP 5.5.9.
