### PR TITLE
[BUGFIX] Use the alias to compare existing aliases

### DIFF
--- a/src/Util/EntityFieldQuery.php
+++ b/src/Util/EntityFieldQuery.php
@@ -84,7 +84,7 @@ class EntityFieldQuery extends \EntityFieldQuery implements EntityFieldQueryRela
 
       // Add the table if the base entity table was not added because:
       // 1. There was a fieldCondition or fieldOrderBy, AND
-      // 2. There was no property condition ot order.
+      // 2. There was no property condition or order.
       if ($delta == 0) {
         $is_entity_table_present = FALSE;
         $field_base_table_alias = NULL;
@@ -191,7 +191,7 @@ class EntityFieldQuery extends \EntityFieldQuery implements EntityFieldQueryRela
    */
   protected static function aliasJoinTable($table_name, SelectQuery $query) {
     foreach ($query->getTables() as $table_info) {
-      if ($table_info['table'] == $table_name) {
+      if ($table_info['alias'] == $table_name) {
         $matches = array();
         preg_match('/.*_(\d+)$/', $table_name, $matches);
         $num = empty($matches[1]) ? -1 : $matches[1];


### PR DESCRIPTION
Fix the logic that generates new alias table names to check for
the existing aliases instead of the table names.
