### PR TITLE
[FEATURE] Allow custom resouce field classes to alter queries

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProvider.php
+++ b/src/Plugin/resource/DataProvider/DataProvider.php
@@ -399,7 +399,8 @@ abstract class DataProvider implements DataProviderInterface {
       if (!static::isNestedField($public_field) && !$this->fieldDefinitions->get($public_field)) {
         throw new BadRequestException(format_string('The filter @filter is not allowed for this path.', array('@filter' => $public_field)));
       }
-      $filters[] = static::processFilterInput($value, $public_field);
+      $filter = static::processFilterInput($value, $public_field);
+      $filters[] = $filter + array('resource_id' => $this->pluginId);
     }
 
     return $filters;

--- a/src/Plugin/resource/DataProvider/DataProviderDecorator.php
+++ b/src/Plugin/resource/DataProvider/DataProviderDecorator.php
@@ -183,4 +183,46 @@ abstract class DataProviderDecorator implements DataProviderInterface {
     $this->decorated->remove($identifier);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function discover($path = NULL) {
+    return $this->decorated->discover($path);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function isNestedField($field_name) {
+    return DataProvider::isNestedField($field_name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function processFilterInput($filter, $public_field) {
+    return DataProvider::processFilterInput($filter, $public_field);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setResourcePath($resource_path) {
+    $this->decorated->setResourcePath($resource_path);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResourcePath() {
+    return $this->decorated->getResourcePath();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMetadata() {
+    return $this->decorated->getMetadata();
+  }
+
 }

--- a/src/Plugin/resource/Field/ResourceFieldEntityAlterableInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityAlterableInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Plugin\resource\Field\ResourceFieldFilterableInterface.
+ */
+
+namespace Drupal\restful\Plugin\resource\Field;
+
+/**
+ * Class ResourceFieldFilterableInterface.
+ *
+ * @package Drupal\restful\Plugin\resource\Field
+ */
+interface ResourceFieldEntityAlterableInterface {
+
+  /**
+   * Alter the list query to add the filtering for this field.
+   *
+   * @param array $filter
+   *   The filter array definition.
+   * @param \EntityFieldQuery $query
+   *   The entity field query to modify.
+   */
+  public function alterFilterEntityFieldQuery(array &$filter, \EntityFieldQuery $query);
+
+  /**
+   * Alter the list query to add the sorting for this field.
+   *
+   * @param array $sort
+   *   The sort array definition.
+   * @param \EntityFieldQuery $query
+   *   The entity field query to modify.
+   */
+  public function alterSortEntityFieldQuery(array &$sort, \EntityFieldQuery $query);
+
+}

--- a/src/Resource/ResourceManager.php
+++ b/src/Resource/ResourceManager.php
@@ -329,7 +329,7 @@ class ResourceManager implements ResourceManagerInterface {
    * @return ResourceInterface
    *   The transformed resource.
    */
-  protected function massagePlugin(ResourceInterface $plugin, RequestInterface $request = NULL) {
+  protected function massagePlugin(ResourceInterface $plugin = NULL, RequestInterface $request = NULL) {
     if (!$plugin) {
       return NULL;
     }

--- a/src/Resource/ResourceManager.php
+++ b/src/Resource/ResourceManager.php
@@ -84,31 +84,14 @@ class ResourceManager implements ResourceManagerInterface {
    * {@inheritdoc}
    */
   public function getPlugin($instance_id, RequestInterface $request = NULL) {
-    /* @var ResourceInterface $plugin */
-    if (!$plugin = $this->plugins->get($instance_id)) {
-      return NULL;
-    }
-    if ($request) {
-      $plugin->setRequest($request);
-    }
-    return $plugin;
+    return $this->massagePlugin($this->plugins->get($instance_id), $request);
   }
 
   /**
    * {@inheritdoc}
    */
   public function getPluginCopy($instance_id, RequestInterface $request = NULL) {
-    if (!$plugin = $this->pluginManager->createInstance($instance_id)) {
-      return NULL;
-    }
-    if ($request) {
-      $plugin->setRequest($request);
-    }
-    // Allow altering the resource, this way we can read the resource's
-    // definition to return a different class that is using composition.
-    drupal_alter('restful_resource', $plugin);
-    $plugin = $plugin->isEnabled() ? $plugin : NULL;
-    return $plugin;
+    return $this->massagePlugin($this->pluginManager->createInstance($instance_id), $request);
   }
 
   /**
@@ -333,6 +316,32 @@ class ResourceManager implements ResourceManagerInterface {
     // Get the latest resource for the minor version.
     $resource = end($resources);
     return array($resource['majorVersion'], $resource['minorVersion']);
+  }
+
+  /**
+   * Helper method that sets the request and alters the resource.
+   *
+   * @param ResourceInterface $plugin
+   *   The resource to return.
+   * @param RequestInterface $request
+   *   The request.
+   *
+   * @return ResourceInterface
+   *   The transformed resource.
+   */
+  protected function massagePlugin(ResourceInterface $plugin, RequestInterface $request = NULL) {
+    if (!$plugin) {
+      return NULL;
+    }
+    if ($request) {
+      $plugin->setRequest($request);
+    }
+    // Allow altering the resource, this way we can read the resource's
+    // definition to return a different class that is using composition.
+    drupal_alter('restful_resource', $plugin);
+    $plugin = $plugin->isEnabled() ? $plugin : NULL;
+
+    return $plugin;
   }
 
 }


### PR DESCRIPTION
To add special handling for filters and sorts. This is very
useful when used with filters that are not regular fields or
properties, like the URL alias. This is required for restful_alias
to work properly.
