### PR TITLE
[FEATURE] Allow joining queries for filters on a target column

### DIFF
--- a/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
@@ -13,13 +13,14 @@ use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldCollectionInterface;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldInterface;
 use Drupal\restful\RenderCache\RenderCache;
+use Drupal\restful\Util\ExplorableDecoratorInterface;
 
 /**
  * Class CacheDecoratedDataProvider.
  *
  * @package Drupal\restful\Plugin\resource\DataProvider
  */
-class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface {
+class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface, ExplorableDecoratorInterface {
 
   /**
    * The decorated object.
@@ -277,6 +278,27 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface 
   protected function clearRenderedCache(ArrayCollection $cache_fragments) {
     $cache_object = new RenderCache($cache_fragments, NULL, $this->cacheController);
     $cache_object->clear();
+  }
+
+  /**
+   * Checks if the decorated object is an instance of something.
+   *
+   * @param string $class
+   *   Class or interface to check the instance.
+   *
+   * @return bool
+   *   TRUE if the decorated object is an instace of the $class. FALSE
+   *   otherwise.
+   */
+  public function isInstanceOf($class) {
+    if ($this instanceof $class || $this->subject instanceof $class) {
+      return TRUE;
+    }
+    // Check if the decorated resource is also a decorator.
+    if ($this->subject instanceof ExplorableDecoratorInterface) {
+      return $this->subject->isInstanceOf($class);
+    }
+    return FALSE;
   }
 
 }

--- a/src/Plugin/resource/Decorators/ResourceDecoratorBase.php
+++ b/src/Plugin/resource/Decorators/ResourceDecoratorBase.php
@@ -15,13 +15,14 @@ use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataProvider\DataProviderInterface;
 use Drupal\restful\Plugin\resource\Field\ResourceFieldCollectionInterface;
 use Drupal\restful\Plugin\resource\ResourceInterface;
+use Drupal\restful\Util\ExplorableDecoratorInterface;
 
 /**
  * Class ResourceDecoratorBase.
  *
  * @package Drupal\restful\Plugin\resource\Decorators
  */
-abstract class ResourceDecoratorBase extends PluginBase implements ResourceDecoratorInterface {
+abstract class ResourceDecoratorBase extends PluginBase implements ResourceDecoratorInterface, ExplorableDecoratorInterface {
 
   /**
    * The decorated resource.
@@ -388,6 +389,27 @@ abstract class ResourceDecoratorBase extends PluginBase implements ResourceDecor
    */
   public function getPluginId() {
     return $this->subject->getPluginId();
+  }
+
+  /**
+   * Checks if the decorated object is an instance of something.
+   *
+   * @param string $class
+   *   Class or interface to check the instance.
+   *
+   * @return bool
+   *   TRUE if the decorated object is an instace of the $class. FALSE
+   *   otherwise.
+   */
+  public function isInstanceOf($class) {
+    if ($this instanceof $class || $this->subject instanceof $class) {
+      return TRUE;
+    }
+    // Check if the decorated resource is also a decorator.
+    if ($this->subject instanceof ExplorableDecoratorInterface) {
+      return $this->subject->isInstanceOf($class);
+    }
+    return FALSE;
   }
 
   /**

--- a/src/Plugin/resource/Field/ResourceFieldEntityAlterableInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntityAlterableInterface.php
@@ -21,8 +21,11 @@ interface ResourceFieldEntityAlterableInterface {
    *   The filter array definition.
    * @param \EntityFieldQuery $query
    *   The entity field query to modify.
+   *
+   * @return array
+   *   The modified $filter array.
    */
-  public function alterFilterEntityFieldQuery(array &$filter, \EntityFieldQuery $query);
+  public function alterFilterEntityFieldQuery(array $filter, \EntityFieldQuery $query);
 
   /**
    * Alter the list query to add the sorting for this field.
@@ -31,7 +34,10 @@ interface ResourceFieldEntityAlterableInterface {
    *   The sort array definition.
    * @param \EntityFieldQuery $query
    *   The entity field query to modify.
+   *
+   * @return array
+   *   The modified $sort array.
    */
-  public function alterSortEntityFieldQuery(array &$sort, \EntityFieldQuery $query);
+  public function alterSortEntityFieldQuery(array $sort, \EntityFieldQuery $query);
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldResource.php
+++ b/src/Plugin/resource/Field/ResourceFieldResource.php
@@ -7,12 +7,14 @@
 
 namespace Drupal\restful\Plugin\resource\Field;
 
+use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\resource\DataInterpreter\DataInterpreterInterface;
 use Drupal\restful\Plugin\resource\Field\PublicFieldInfo\PublicFieldInfoInterface;
 use Drupal\restful\Plugin\resource\ResourceInterface;
+use Drupal\restful\Util\ExplorableDecoratorInterface;
 
-class ResourceFieldResource implements ResourceFieldResourceInterface {
+class ResourceFieldResource implements ResourceFieldResourceInterface, ExplorableDecoratorInterface {
 
   /**
    * Decorated resource field.
@@ -45,6 +47,13 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
   protected $resourcePlugin;
 
   /**
+   * Target Column.
+   *
+   * @var string
+   */
+  protected $targetColumn;
+
+  /**
    * Constructor.
    *
    * @param array $field
@@ -58,6 +67,10 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
       $this->setRequest($request);
     }
     $this->resourceMachineName = $field['resource']['name'];
+    // Compute the target column if empty.
+    if (!empty($field['targetColumn'])) {
+      $this->targetColumn = $field['targetColumn'];
+    }
   }
 
   /**
@@ -365,6 +378,49 @@ class ResourceFieldResource implements ResourceFieldResourceInterface {
       return $this->decorated->autoDiscovery();
     }
     return ResourceFieldBase::emptyDiscoveryInfo($this->getPublicName());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTargetColumn() {
+    if (empty($this->targetColumn)) {
+      // Check the definition of the decorated field.
+      $definition = $this->decorated->getDefinition();
+      if (!empty($definition['targetColumn'])) {
+        $this->targetColumn = $definition['targetColumn'];
+      }
+      elseif ($this->isInstanceOf(ResourceFieldEntityReferenceInterface::class)) {
+        $entity_info = entity_get_info($this->getResourcePlugin()->getEntityType());
+        // Assume that the relationship is through the entity key id.
+        $this->targetColumn = $entity_info['entity keys']['id'];
+      }
+      else {
+        throw new ServerConfigurationException(sprintf('Target column could not be found for field "%s".', $this->getPublicName()));
+      }
+    }
+    return $this->targetColumn;
+  }
+
+  /**
+   * Checks if the decorated object is an instance of something.
+   *
+   * @param string $class
+   *   Class or interface to check the instance.
+   *
+   * @return bool
+   *   TRUE if the decorated object is an instace of the $class. FALSE
+   *   otherwise.
+   */
+  public function isInstanceOf($class) {
+    if ($this instanceof $class || $this->decorated instanceof $class) {
+      return TRUE;
+    }
+    // Check if the decorated resource is also a decorator.
+    if ($this->decorated instanceof ExplorableDecoratorInterface) {
+      return $this->decorated->isInstanceOf($class);
+    }
+    return FALSE;
   }
 
 }

--- a/src/Plugin/resource/Field/ResourceFieldResourceInterface.php
+++ b/src/Plugin/resource/Field/ResourceFieldResourceInterface.php
@@ -39,4 +39,12 @@ interface ResourceFieldResourceInterface extends ResourceFieldInterface {
    */
   public function getResourcePlugin();
 
+  /**
+   * Gets the table column for joins.
+   *
+   * @return string
+   *   The column to make a join for nested filters.
+   */
+  public function getTargetColumn();
+
 }

--- a/src/Util/EntityFieldQuery.php
+++ b/src/Util/EntityFieldQuery.php
@@ -120,12 +120,12 @@ class EntityFieldQuery extends \EntityFieldQuery implements EntityFieldQueryRela
           ));
           // Get the entity type being referenced.
           $entity_info = entity_get_info($relational_filter->getEntityType());
-          $entity_table_alias = $this->aliasJoinTable($entity_info['base table'], $select_query);
+          $entity_table_alias = $this::aliasJoinTable($entity_info['base table'], $select_query);
           $select_query->addJoin('INNER', $entity_info['base table'], $entity_table_alias, sprintf('%s.%s = %s.%s',
             $field_table_name,
             _field_sql_storage_columnname($relational_filter->getName(), $relational_filter->getColumn()),
             $entity_table_alias,
-            $entity_info['entity keys']['id']
+            $relational_filter->getTargetColumn()
           ));
         }
         elseif ($relational_filter->getType() == RelationalFilterInterface::TYPE_PROPERTY) {
@@ -134,12 +134,12 @@ class EntityFieldQuery extends \EntityFieldQuery implements EntityFieldQueryRela
           // (which is not unreasonable).
           $host_entity_table = $entity_table;
           $entity_info = entity_get_info($relational_filter->getEntityType());
-          $entity_table_alias = $this->aliasJoinTable($entity_info['base table'], $select_query);
+          $entity_table_alias = $this::aliasJoinTable($entity_info['base table'], $select_query);
           $select_query->addJoin('INNER', $entity_info['base table'], $entity_table_alias, sprintf('%s.%s = %s.%s',
             $host_entity_table,
             $relational_filter->getName(),
             $entity_table_alias,
-            $entity_info['entity keys']['id']
+            $relational_filter->getTargetColumn()
           ));
         }
       }

--- a/src/Util/ExplorableDecoratorInterface.php
+++ b/src/Util/ExplorableDecoratorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\restful\Util\ExplorableDecoratorInterface.
+ */
+
+namespace Drupal\restful\Util;
+
+/**
+ * Class ExplorableDecorator.
+ *
+ * @package Drupal\restful\Util
+ */
+interface ExplorableDecoratorInterface {
+
+  /**
+   * Checks if the decorated object is an instance of something.
+   *
+   * @param string $class
+   *   Class or interface to check the instance.
+   *
+   * @return bool
+   *   TRUE if the decorated object is an instace of the $class. FALSE
+   *   otherwise.
+   */
+  public function isInstanceOf($class);
+
+}

--- a/src/Util/RelationalFilter.php
+++ b/src/Util/RelationalFilter.php
@@ -7,6 +7,11 @@
 
 namespace Drupal\restful\Util;
 
+/**
+ * Class RelationalFilter.
+ *
+ * @package Drupal\restful\Util
+ */
 class RelationalFilter implements RelationalFilterInterface {
 
   /**
@@ -45,6 +50,13 @@ class RelationalFilter implements RelationalFilterInterface {
   protected $column;
 
   /**
+   * Database column for the target table relationship.
+   *
+   * @var string
+   */
+  protected $targetColumn;
+
+  /**
    * Constructs the RelationalFilter object.
    *
    * @param string $name
@@ -52,13 +64,15 @@ class RelationalFilter implements RelationalFilterInterface {
    * @param string $column
    * @param string $entity_type
    * @param array $bundles
+   * @param string $targetColumn
    */
-  public function __construct($name, $type, $column, $entity_type, array $bundles = array()) {
+  public function __construct($name, $type, $column, $entity_type, array $bundles = array(), $target_column = NULL) {
     $this->name = $name;
     $this->type = $type;
     $this->column = $column;
     $this->entityType = $entity_type;
     $this->bundles = $bundles;
+    $this->targetColumn = $target_column;
   }
 
   /**
@@ -94,6 +108,13 @@ class RelationalFilter implements RelationalFilterInterface {
    */
   public function getColumn() {
     return $this->column;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTargetColumn() {
+    return $this->targetColumn;
   }
 
 }

--- a/src/Util/RelationalFilterInterface.php
+++ b/src/Util/RelationalFilterInterface.php
@@ -7,6 +7,11 @@
 
 namespace Drupal\restful\Util;
 
+/**
+ * Interface RelationalFilterInterface.
+ *
+ * @package Drupal\restful\Util
+ */
 interface RelationalFilterInterface {
 
   const TYPE_FIELD = 'field';
@@ -45,8 +50,19 @@ interface RelationalFilterInterface {
   public function getBundles();
 
   /**
+   * Database column for field filters.
+   *
    * @return string
+   *   The DB column.
    */
   public function getColumn();
+
+  /**
+   * Database column for the target table relationship.
+   *
+   * @return string
+   *   The DB column.
+   */
+  public function getTargetColumn();
 
 }


### PR DESCRIPTION
Instead of assuming that joins on entity tables always happen at
the entity key level.

To do so use the `targetColumn` property in the field definition.
