### PR TITLE
For to-many relationships resource identifier objects must be unique.

### DIFF
--- a/src/Plugin/formatter/FormatterJsonApi.php
+++ b/src/Plugin/formatter/FormatterJsonApi.php
@@ -346,11 +346,11 @@ class FormatterJsonApi extends Formatter implements FormatterInterface {
           $new_includes_parents[] = $field_name;
           $included[$field_path][$include_key] = $this->renormalize($field_item, $included, $nested_allowed_fields, $new_includes_parents);
           $included[$field_path][$include_key] += $include_links ? array('links' => $include_links) : array();
-          $rel[] = $element;
+          $rel[$include_key] = $element;
         }
         // Only place the relationship info.
         $result['relationships'][$field_name] = array(
-          'data' => $single_item ? reset($rel) : $rel,
+          'data' => $single_item ? reset($rel) : array_values($rel),
         );
         if (!empty($relationship_links)) {
           $result['relationships'][$field_name]['links'] = $relationship_links;


### PR DESCRIPTION
For to-many relationships, It should filter out the duplicates `resource identifier object` in relationships.
Ref - https://github.com/json-api/json-api/blob/gh-pages/schema#L244-L251
