### PR TITLE
[FEATURE] Allow RESTful module to support \EntityStructureWrapper types in the buildResourceMetadataItem function.

### DIFF
--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -1118,6 +1118,9 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
     if ($wrapper instanceof \EntityValueWrapper) {
       $wrapper = entity_metadata_wrapper($this->getEntityType(), $wrapper->value());
     }
+    elseif ($wrapper instanceof \EntityStructureWrapper) {
+      $wrapper = entity_metadata_wrapper($this->getEntityType(), $wrapper->{$this->getSubProperty()}->value());
+    }
     $id = $wrapper->getIdentifier();
     $bundle = $wrapper->getBundle();
     $resource = $this->getResource();


### PR DESCRIPTION
Resolves #919.

I'm wondering if this needs to be careful about calling `$this->getSubProperty()`?  For me it works b/c the field types that end up using this are always defined with a `sub_property`, eg.

``` php
$public_fields['show'] = array(
  'property' => 'field_tv_shows',
  'sub_property' => 'show',
  'resource' => array(
    'name' => 'shows',
    'majorVersion' => '1',
    'minorVersion' => '0',
  ),
);
```
