### PR TITLE
Add the ability to define subdirectories for file uploads (2.x)

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProviderFile.php
+++ b/src/Plugin/resource/DataProvider/DataProviderFile.php
@@ -107,7 +107,8 @@ class DataProviderFile extends DataProviderEntity implements DataProviderInterfa
     $options = $provider_options['options'];
     
     $subdir = empty($options['subdir']) ? NULL : $options['subdir'] . '/';
-    $datedir = $options['datedir'] === TRUE && !empty($options['subdir']) ? date('Y-m-d') . '/' : NULL;
+    $date_format = empty($options['date_format']) ? NULL : $options['date_format'];
+    $datedir = $options['datedir'] === TRUE && !is_null($date_format) ? date($date_format) . '/' : NULL;
 
     $validators = empty($options['validators']) ? NULL : $options['validators'];
     $destination = $options['scheme'] . '://' . $subdir . $datedir;

--- a/src/Plugin/resource/DataProvider/DataProviderFile.php
+++ b/src/Plugin/resource/DataProvider/DataProviderFile.php
@@ -105,9 +105,13 @@ class DataProviderFile extends DataProviderEntity implements DataProviderInterfa
 
     $provider_options = $this->getOptions();
     $options = $provider_options['options'];
+    
+    $subdir = empty($options['subdir']) ? NULL : $options['subdir'] . '/';
+    $datedir = $options['datedir'] === TRUE && !empty($options['subdir']) ? date('Y-m-d') . '/' : NULL;
 
     $validators = empty($options['validators']) ? NULL : $options['validators'];
-    $destination = $options['scheme'] . "://";
+    $destination = $options['scheme'] . '://' . $subdir . $datedir;
+    file_prepare_directory($destination, FILE_CREATE_DIRECTORY);
     $replace = empty($options['replace']) ? NULL : $options['replace'];
 
     // Return cached objects without processing since the file will have


### PR DESCRIPTION
This change makes it possible to set an option for creating a subdirectory when saving a file, & it also adds the ability to optionally place files in a dated (Y-m-d) subdirectory within your named subdirectory.

This mimics the ability to set subdirectories & dated subdirectories when cteating a file field on a content type in Drupal core. For instance, you can add a file field & in the field settings you can put something like the following in the 'File directory' field: `avatars/[current-date:custom:Y]-[current-date:custom:m]-[current-date:custom:d]`.

If setting a dated subdirectory, the date format is configurable using any format accepted by PHP's date function: https://secure.php.net/manual/en/function.date.php .

Example annotation for file upload plug-in:

``` php
/**
 * Class FilesUpload__1_0
 * @package Drupal\restful_example\Plugin\Resource
 *
 * @Resource(
 *   name = "files_upload:1.0",
 *   resource = "files_upload",
 *   label = "File upload",
 *   description = "A file upload wrapped with RESTful.",
 *   authenticationTypes = TRUE,
 *   dataProvider = {
 *     "entityType": "file",
 *     "options": {
 *       "scheme": "public",
 *       "subdir": "avatars",
 *       "datedir": TRUE,
 *       "date_format": "Y-m-d"
 *     }
 *   },
 *   menuItem = "file-upload",
 *   majorVersion = 1,
 *   minorVersion = 0
 * )
 */
```
