### PR TITLE
Add ability to retrieve resource name from the resource manager

### DIFF
--- a/src/Resource/ResourceManager.php
+++ b/src/Resource/ResourceManager.php
@@ -121,6 +121,19 @@ class ResourceManager implements ResourceManagerInterface {
   /**
    * {@inheritdoc}
    */
+  public function getResourceIdFromRequest() {
+    $resource_name = &drupal_static(__METHOD__);
+    if (isset($resource_name)) {
+      return $resource_name;
+    }
+    $path = $this->request->getPath(FALSE);
+    list($resource_name,) = static::getPageArguments($path);
+    return $resource_name;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getVersionFromRequest() {
     $version = &drupal_static(__METHOD__);
     if (isset($version)) {

--- a/src/Resource/ResourceManagerInterface.php
+++ b/src/Resource/ResourceManagerInterface.php
@@ -51,6 +51,14 @@ interface ResourceManagerInterface {
   public function clearPluginCache($instance_id);
 
   /**
+   * Get the resource name for the current request.
+   *
+   * @return string
+   *   The resource ID.
+   */
+  public function getResourceIdFromRequest();
+
+  /**
    * Gets the major and minor version for the current request.
    *
    * @return array

--- a/tests/RestfulHookMenuTestCase.test
+++ b/tests/RestfulHookMenuTestCase.test
@@ -139,26 +139,31 @@ class RestfulHookMenuTestCase extends RestfulCurlBaseTestCase {
         'path' => 'api/v1.1/articles',
         'version_header' => NULL,
         'expected_version' => array(1, 1),
+        'expected_resource' => 'articles',
       ),
       array(
         'path' => 'api/v1/articles',
         'version_header' => NULL,
         'expected_version' => array(1, 7),
+        'expected_resource' => 'articles',
       ),
       array(
         'path' => 'api/articles',
         'version_header' => 'v1',
         'expected_version' => array(1, 7),
+        'expected_resource' => 'articles',
       ),
       array(
         'path' => 'api/articles',
         'version_header' => 'v1.0',
         'expected_version' => array(1, 0),
+        'expected_resource' => 'articles',
       ),
       array(
         'path' => 'api/articles',
         'version_header' => NULL,
         'expected_version' => array(2, 1),
+        'expected_resource' => 'articles',
       ),
     );
 
@@ -173,6 +178,7 @@ class RestfulHookMenuTestCase extends RestfulCurlBaseTestCase {
       $resource_manager = new \Drupal\restful\Resource\ResourceManager($request);
       drupal_static_reset('Drupal\restful\Resource\ResourceManager::getVersionFromRequest');
       $this->assertEqual($resource_manager->getVersionFromRequest(), $test_item['expected_version'], sprintf('%s resolves correctly.', $test_item['path']));
+      $this->assertEqual($resource_manager->getResourceIdFromRequest(), $test_item['expected_resource'], sprintf('Resource name obtained correctly from %s.', $test_item['path']));
     }
 
   }


### PR DESCRIPTION
The ResourceManager class provides methods to get version information and even create a new
instance of a plugin based on the current request. However, the methods that help in getting
the resource id (such as ::getMenuItem and getPageArguments) are protected.

Since we are already able to get information on version, we should also be able to get the
resource id using the resource manager class. This commit adds a method to do that.

This blocks issue #939 where we need to get the resource plugin definition from an
authentication plugin. Calling negotiate or trying to retrieve menu item information via
menu_get_item results in an recursive call (infinite).
