### PR TITLE
Add OAuth2 authentication provider

### DIFF
--- a/src/Plugin/authentication/OAuth2ServerAuthentication.php
+++ b/src/Plugin/authentication/OAuth2ServerAuthentication.php
@@ -78,13 +78,13 @@ class OAuth2ServerAuthentication extends Authentication {
 
     $plugin_definition = ResourcePluginManager::create('cache', $request)->getDefinition($plugin_id);
 
-    $server = !empty($plugin_definition['oauth2Server']) ? $plugin_definition['oauth2Server'] : variable_get('oauth2_server_restful_server');
-    if (!$server) {
+    if (empty($plugin_definition['oauth2Server'])) {
       return NULL;
     }
 
-    $scope = !empty($plugin_definition['oauth2Scope']) ? $plugin_definition['oauth2Scope'] : variable_get('oauth2_server_restful_scope');
-    return ['server' => $server, 'scope' =>$scope];
+    $server = $plugin_definition['oauth2Server'];
+    $scope = !empty($plugin_definition['oauth2Scope']) ? $plugin_definition['oauth2Scope'] : '';
+    return ['server' => $server, 'scope' => $scope];
   }
 
   /**

--- a/src/Plugin/authentication/OAuth2ServerAuthentication.php
+++ b/src/Plugin/authentication/OAuth2ServerAuthentication.php
@@ -3,6 +3,7 @@
 namespace Drupal\restful\Plugin\authentication;
 
 use Drupal\Component\Plugin\PluginBase;
+use Drupal\restful\Exception\ServerConfigurationException;
 use Drupal\restful\Exception\UnauthorizedException;
 use Drupal\restful\Http\RequestInterface;
 use Drupal\restful\Plugin\ResourcePluginManager;
@@ -11,7 +12,7 @@ use Drupal\restful\Plugin\ResourcePluginManager;
  * Authentication support for oauth2_server.
  *
  * @Authentication(
- *   id = "oauth2_auth",
+ *   id = "oauth2",
  *   label = "OAuth2 authentication",
  *   description = "Authenticate requests based on oauth2_server auth.",
  * )
@@ -19,10 +20,22 @@ use Drupal\restful\Plugin\ResourcePluginManager;
 class OAuth2ServerAuthentication extends Authentication {
 
   /**
+   * The resource manager.
+   *
+   * @var \Drupal\restful\Resource\ResourceManagerInterface
+   */
+  protected $resourceManager;
+
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->resourceManager = restful()->getResourceManager();
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function applies(RequestInterface $request) {
-    return module_exists('oauth2_server') && $this->getResourcePluginIdFromRequest();
+    return module_exists('oauth2_server') && $this->getOAuth2Info($request);
   }
 
   /**
@@ -31,38 +44,52 @@ class OAuth2ServerAuthentication extends Authentication {
   public function authenticate(RequestInterface $request) {
     $oauth2_info = $this->getOAuth2Info($request);
     if (!$oauth2_info) {
-      return NULL;
+      throw new ServerConfigurationException('The resource uses OAuth2 authentication but does not specify the OAuth2 server.');
     }
 
     $result = oauth2_server_check_access($oauth2_info['server'], $oauth2_info['scope']);
     if ($result instanceof \OAuth2\Response) {
       throw new UnauthorizedException($result->getResponseBody(), $result->getStatusCode());
     }
-    elseif (is_array($result) && !empty($result['user_id'])) {
-      return user_load($result['user_id']);
+    elseif (empty($result['user_id'])) {
+      return NULL;
     }
+    return user_load($result['user_id']);
   }
 
-//  protected function getOAuth2Info() {
-//    return [variable_get('oauth2_server_restful_server'), variable_get('oauth2_server_restful_scope')];
-//  }
-
-  protected function getOAuth2Info($request) {
+  /**
+   * Get OAuth2 information from the request.
+   *
+   * @param \Drupal\restful\Http\RequestInterface $request
+   *   The request.
+   *
+   * @return array|null
+   *   Simple associative array with the following keys:
+   *   - server: The OAuth2 server to authenticate against.
+   *   - scope: The scope required for the resource.
+   */
+  protected function getOAuth2Info(RequestInterface $request) {
     $plugin_id = $this->getResourcePluginIdFromRequest();
-    $plugin = ResourcePluginManager::create('cache', $request)->getDefinition($plugin_id);
+    $plugin_definition = ResourcePluginManager::create('cache', $request)->getDefinition($plugin_id);
 
-    $server = !empty($plugin['oauth2Server']) ? $plugin['oauth2Server'] : variable_get('oauth2_server_restful_server');
+    $server = !empty($plugin_definition['oauth2Server']) ? $plugin_definition['oauth2Server'] : variable_get('oauth2_server_restful_server');
     if (!$server) {
       return NULL;
     }
 
-    $scope = !empty($plugin['oauth2Scope']) ? $plugin['oauth2Scope'] : variable_get('oauth2_server_restful_scope');
+    $scope = !empty($plugin_definition['oauth2Scope']) ? $plugin_definition['oauth2Scope'] : variable_get('oauth2_server_restful_scope');
     return ['server' => $server, 'scope' =>$scope];
   }
 
+  /**
+   * Get the resource plugin id requested.
+   *
+   * @return null|string
+   *   The plugin id of the resource that was requested.
+   */
   protected function getResourcePluginIdFromRequest() {
-    $resource_name = restful()->getResourceManager()->getResourceIdFromRequest();
-    $version = restful()->getResourceManager()->getVersionFromRequest();
+    $resource_name = $this->resourceManager->getResourceIdFromRequest();
+    $version = $this->resourceManager->getVersionFromRequest();
 
     if (!$resource_name || !$version) {
       return NULL;

--- a/src/Plugin/authentication/OAuth2ServerAuthentication.php
+++ b/src/Plugin/authentication/OAuth2ServerAuthentication.php
@@ -70,6 +70,12 @@ class OAuth2ServerAuthentication extends Authentication {
    */
   protected function getOAuth2Info(RequestInterface $request) {
     $plugin_id = $this->getResourcePluginIdFromRequest();
+    if (!$plugin_id) {
+      // If the plugin can't be determined, it is probably not a request to the
+      // resource but something else that is just loading all the plugins.
+      return NULL;
+    }
+
     $plugin_definition = ResourcePluginManager::create('cache', $request)->getDefinition($plugin_id);
 
     $server = !empty($plugin_definition['oauth2Server']) ? $plugin_definition['oauth2Server'] : variable_get('oauth2_server_restful_server');

--- a/src/Plugin/authentication/OAuth2ServerAuthentication.php
+++ b/src/Plugin/authentication/OAuth2ServerAuthentication.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\restful\Plugin\authentication;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\restful\Exception\UnauthorizedException;
+use Drupal\restful\Http\RequestInterface;
+use Drupal\restful\Plugin\ResourcePluginManager;
+
+/**
+ * Authentication support for oauth2_server.
+ *
+ * @Authentication(
+ *   id = "oauth2_auth",
+ *   label = "OAuth2 authentication",
+ *   description = "Authenticate requests based on oauth2_server auth.",
+ * )
+ */
+class OAuth2ServerAuthentication extends Authentication {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RequestInterface $request) {
+    return module_exists('oauth2_server') && $this->getResourcePluginIdFromRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function authenticate(RequestInterface $request) {
+    $oauth2_info = $this->getOAuth2Info($request);
+    if (!$oauth2_info) {
+      return NULL;
+    }
+
+    $result = oauth2_server_check_access($oauth2_info['server'], $oauth2_info['scope']);
+    if ($result instanceof \OAuth2\Response) {
+      throw new UnauthorizedException($result->getResponseBody(), $result->getStatusCode());
+    }
+    elseif (is_array($result) && !empty($result['user_id'])) {
+      return user_load($result['user_id']);
+    }
+  }
+
+//  protected function getOAuth2Info() {
+//    return [variable_get('oauth2_server_restful_server'), variable_get('oauth2_server_restful_scope')];
+//  }
+
+  protected function getOAuth2Info($request) {
+    $plugin_id = $this->getResourcePluginIdFromRequest();
+    $plugin = ResourcePluginManager::create('cache', $request)->getDefinition($plugin_id);
+
+    $server = !empty($plugin['oauth2Server']) ? $plugin['oauth2Server'] : variable_get('oauth2_server_restful_server');
+    if (!$server) {
+      return NULL;
+    }
+
+    $scope = !empty($plugin['oauth2Scope']) ? $plugin['oauth2Scope'] : variable_get('oauth2_server_restful_scope');
+    return ['server' => $server, 'scope' =>$scope];
+  }
+
+  protected function getResourcePluginIdFromRequest() {
+    $resource_name = restful()->getResourceManager()->getResourceIdFromRequest();
+    $version = restful()->getResourceManager()->getVersionFromRequest();
+
+    if (!$resource_name || !$version) {
+      return NULL;
+    }
+
+    return $resource_name . PluginBase::DERIVATIVE_SEPARATOR . $version[0] . '.' . $version[1];
+  }
+
+}


### PR DESCRIPTION
This change depends on the changes in PR #940. It uses the new method introduced in that PR
to identify the resource being requested and get the plugin definition to read the oauth2
server and scope to use for authorizing the request.

This would probably need to be changed once #940 is merged or a better method to access the
request being processed is identifed (as mentioned in #939). I am creating this PR in hope
of clarifying the changes in PR #940.
