### PR TITLE
Temporary workaround to allow RESTful to work on PHP7.

### DIFF
--- a/restful.info
+++ b/restful.info
@@ -9,6 +9,9 @@ configure = admin/config/services/restful
 registry_autoload[] = PSR-0
 registry_autoload[] = PSR-4
 
+; Temporary workaround to allow RESTful to work fine on PHP7.
+registry_autoload_files[] = src/Util/ExplorableDecoratorInterface.php
+
 ; Tests
 files[] = tests/RestfulAuthenticationTestCase.test
 files[] = tests/RestfulCommentTestCase.test


### PR DESCRIPTION
This PR provides a temporary workaround for issue #937. For reasons I do not fully understand at the moment, the autoloader on PHP7 (at least v. 7.0.9 I use) fails to load `ExplorableDecoratorInterface`: 

```  
PHP Fatal error:  Interface 'Drupal\restful\Util\ExplorableDecoratorInterface' not found in .... modules/contrib/restful/src/Plugin/resource/Field/ResourceFieldResource.php on line 17
```

This is while using the latest `restful` stable release (it actually fails with the HEAD dev version, too) and Drupal 7.44. This simple change allows the module to work fine, so following @e0ipso's suggestion, I am issuing this PR.
