### PR TITLE
Use arrays to define OAuth2 information in the plugin definition

### DIFF
--- a/src/Plugin/authentication/OAuth2ServerAuthentication.php
+++ b/src/Plugin/authentication/OAuth2ServerAuthentication.php
@@ -78,13 +78,11 @@ class OAuth2ServerAuthentication extends Authentication {
 
     $plugin_definition = ResourcePluginManager::create('cache', $request)->getDefinition($plugin_id);
 
-    if (empty($plugin_definition['oauth2Server'])) {
+    if (empty($plugin_definition['oauth2Info']) || empty($plugin_definition['oauth2Info']['server'])) {
       return NULL;
     }
 
-    $server = $plugin_definition['oauth2Server'];
-    $scope = !empty($plugin_definition['oauth2Scope']) ? $plugin_definition['oauth2Scope'] : '';
-    return ['server' => $server, 'scope' => $scope];
+    return $plugin_definition['oauth2Info'] + ['scope' => ''];
   }
 
   /**

--- a/src/Plugin/authentication/OAuth2ServerAuthentication.php
+++ b/src/Plugin/authentication/OAuth2ServerAuthentication.php
@@ -78,11 +78,19 @@ class OAuth2ServerAuthentication extends Authentication {
 
     $plugin_definition = ResourcePluginManager::create('cache', $request)->getDefinition($plugin_id);
 
-    if (empty($plugin_definition['oauth2Info']) || empty($plugin_definition['oauth2Info']['server'])) {
-      return NULL;
+    // First check if we have an array with OAuth2 info and use if available.
+    if (!empty($plugin_definition['oauth2Info']) && !empty($plugin_definition['oauth2Info']['server'])) {
+      return $plugin_definition['oauth2Info'] + ['scope' => ''];
     }
 
-    return $plugin_definition['oauth2Info'] + ['scope' => ''];
+    // Check for OAuth2 properties at top level for legacy support.
+    if (!empty($plugin_definition['oauth2Server'])) {
+      $server = $plugin_definition['oauth2Server'];
+      $scope = !empty($plugin_definition['oauth2Scope']) ? $plugin_definition['oauth2Scope'] : '';
+      return ['server' => $server, 'scope' => $scope];
+    }
+
+    return NULL;
   }
 
   /**


### PR DESCRIPTION
Currently, we use two pieces of information for OAuth2 authentication - server and scope. We define them as separate items in the plugin definition. There might be more items required in the future (one of which could be support for client credentials in #944). It might be cleaner to change all the definitions to an array.
