### PR TITLE
Fix typos, formatting, minor corrections in "Consuming your API" documentation

### DIFF
--- a/docs/api_url.md
+++ b/docs/api_url.md
@@ -8,11 +8,11 @@ You can manipulate the resources using different HTTP request types
 passed in the URL itself.
 
 ## Write operations
-Write operations can be performed via the POTS (to create items), PUT or PATCH
+Write operations can be performed via the `POST` (to create items), `PUT` or `PATCH`
 (to update items) HTTP methods.
 
 ### Basic example
-The following request will create an article using the articles resource:
+The following request will create an article using the `articles` resource:
 
 ```http
 POST /articles HTTP/1.1
@@ -30,11 +30,11 @@ Note how we are setting the properties that we want to set using JSON. The
 provided payload format needs to match the contents of the `Content-Type` header
 (in this case _application/json_).
 
-It's also worth noting that when settings reference fields with multiple values,
-you can submit an array of IDs or a string of IDs separated by comas.
+It's also worth noting that when setting reference fields with multiple values,
+you can submit an array of IDs or a string of IDs separated by commas.
 
 ### Advanced example
-You use sub-requests to manipulate (create or alter) the relationships in a single request.The following example will:
+You use sub-requests to manipulate (create or alter) the relationships in a single request. The following example will:
 
   1. Update the title of the article to be _To TDD or Not_.
   1. Update the contents of tag 6 to replace it with the provided content.
@@ -85,13 +85,13 @@ about that resource, in addition to the data itself.
 
 ``` shell
 curl https://example.com/api/
-``
+```
 This will output all the available **latest** resources (of course, if you have
 enabled the "Discovery Resource" option). For example, if there are 3 different
-api version plugins for content type Article (1.0, 1.1, 2.0) it will display the
+API version plugins for content type Article (1.0, 1.1, 2.0) it will display the
 latest only (2.0 in this case).
 
-If you want to display all the versions of all the resources declared add the
+If you want to display all the versions of all the resources declared, then add the
 query **?all=true** like this.
 
 ``` shell
@@ -127,7 +127,7 @@ the `self` and `next` objects contain information about the resource.
 ### Returning documentation about the resource
 
 Using an HTTP `OPTIONS` request, you can return documentation about the
-resource.  To do so, make an OPTIONS request to the resource's root URL.
+resource.  To do so, make an `OPTIONS` request to the resource's root URL.
 
 ```shell
 curl -X OPTIONS -i https://example.com/api/v1.0/articles
@@ -184,8 +184,8 @@ curl https://example.com/api/articles?filter[created][value]=1417591992&filter[c
 ```
 
 Additionally you can provide multiple filters for the same field. That is
-specially useful when filtering on multiple value fields. The following example
-will get all the articles with the integer multiple field that contains all 1, 3
+especially useful when filtering on multiple value fields. The following example
+will get all the articles with the `integer_multiple` field that contains all 1, 3
 and 5.
 
 ```
@@ -193,7 +193,7 @@ curl https://example.com/api/articles?filter[integer_multiple][value][0]=1&filte
 ```
 
 You can do more advanced filtering by providing values and operators. The
-following example will get all the articles with an integer value less than 5
+following example will get all the articles with an `integer_multiple` value less than 5
 and another equal to 10.
 
 ```
@@ -201,7 +201,7 @@ curl https://example.com/api/articles?filter[integer_multiple][value][0]=5&filte
 ```
 
 ## Loading by an alternate ID.
-Some times you need to load an entity by an alternate ID that is not the regular
+Sometimes you need to load an entity by an alternate ID that is not the regular
 entity ID, for example a unique ID title. All that you need to do is provide the
 alternate ID as the regular resource ID and inform that the passed in ID is not
 the regular entity ID but a different field. To do so use the `loadByFieldName`
@@ -230,8 +230,8 @@ Link: https://www.example.org/articles/12; rel="canonical"
 
 The only requirement to use this feature is that the value for your
 `loadByFieldName` field needs to be one of your exposed fields. It is also up to
-you to make sure that that field is unique. Note that in case that more tha one
-entity matches the provided ID the first record will be loaded.
+you to make sure that that field is unique. Note that in case that more than one
+entity matches the provided ID, the first record will be loaded.
 
 ## Working with authentication providers
 RESTful comes with ``cookie``, ``base_auth`` (user name and password in the HTTP
@@ -239,25 +239,25 @@ header) authentications providers, as well as a "RESTful token auth" module that
  has a `token` authentication provider.
 
 Note: if you use cookie-based authentication then you also need to set the
-HTTP ``X-CSRF-Token`` header on all writing requests (POST, PUT and DELETE).
+HTTP ``X-CSRF-Token`` header on all writing requests (`POST`, `PUT` and `DELETE`).
 You can retrieve the token from ``/api/session/token`` with a standard HTTP
-GET request.
+`GET` request.
 
 See [this](https://github.com/Gizra/angular-restful-auth) AngularJs example that
 shows a login from a fully decoupled web app to a Drupal backend.
 
-Note: If you use basic auth under .htaccess password you might hit a flood
-exception, as the server is sending the .htaccess user name and password as the
+Note: If you use basic auth under `.htaccess` password you might hit a flood
+exception, as the server is sending the `.htaccess` user name and password as the
 authentication. In such a case you may set the ``restful_skip_basic_auth`` to
 TRUE, in order to avoid using it. This will allow enabling and disabling the
 basic auth on different environments.
 
 ```bash
 # (Change username and password)
-curl -u "username:password" https://example.com/api/login
+curl -u "username:password" https://example.com/api/login-token
 
 # Response has access token.
-{"access_token":"YOUR_TOKEN"}
+{"access_token":"YOUR_TOKEN","refresh_token":"OTHER_TOKEN",...}
 
 # Call a "protected" with token resource (Articles resource version 1.3 in "RESTful example")
 curl https://example.com/api/v1.3/articles/1?access_token=YOUR_TOKEN
@@ -268,7 +268,7 @@ curl -H "access-token: YOUR_TOKEN" https://example.com/api/v1.3/articles/1
 ```
 
 ## Error handling
-If an error occurs when operating the REST endpoint via URL, A valid JSON object
+If an error occurs when operating the REST endpoint via URL, a valid JSON object
 with ``code``, ``message`` and ``description`` would be returned.
 
 The RESTful module adheres to the [Problem Details for HTTP


### PR DESCRIPTION
- Fix a few typos.
- Consistently format `GET`, `POST`, etc. in backticks.
- Correct documentation for token authentication.