### PR TITLE
Allow filtering by sub_properties of addressfield

### DIFF
--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -739,7 +739,7 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
         // Do not default to format.
         $this->setColumn('value');
       }
-      elseif ($field['type'] == 'addressfield' && array_key_exists($this->subProperty, $field['columns']) ) {
+      else if ($field['type'] == 'addressfield' && isset($field['columns'][$this->subProperty])){
         $this->setColumn($this->subProperty);
       }
       else {

--- a/src/Plugin/resource/Field/ResourceFieldEntity.php
+++ b/src/Plugin/resource/Field/ResourceFieldEntity.php
@@ -739,6 +739,9 @@ class ResourceFieldEntity implements ResourceFieldEntityInterface {
         // Do not default to format.
         $this->setColumn('value');
       }
+      elseif ($field['type'] == 'addressfield' && array_key_exists($this->subProperty, $field['columns']) ) {
+        $this->setColumn($this->subProperty);
+      }
       else {
         // Set the column name.
         $this->setColumn(key($field['columns']));


### PR DESCRIPTION
A simple resource with addressfield fields:
```php
protected function publicFields()
    {
        $fields = parent::publicFields();

        $fields['country'] = array(
            'property' => 'field_address',
            'sub_property' => 'country'
        );

        $fields['locality'] = array(
            'property' => 'field_address',
            'sub_property' => 'locality'
        );

        return $fields;
    }
```
Cannot be filtered by the sub_properties of the addressfield. Every sub_properties will be default to the first column. [See line 744 in the code.](https://github.com/RESTful-Drupal/restful/blob/7.x-2.x/src/Plugin/resource/Field/ResourceFieldEntity.php#L737-L744)
Here is an exemple of the query:
`?filter[locality][value]=query&filter[locality][operator]=CONTAINS`

This PR adds a specific test for the addressfield sub_properties.
A more general solution could be achieved with testing the $field['type'] to an array of names of fields modules that have similar problems instead of just a simple string.