### PR TITLE
ISSUE 966 allow restful to work correctly with drush commands 

### DIFF
--- a/plugins/formatter/hal_json/hal_json.inc
+++ b/plugins/formatter/hal_json/hal_json.inc
@@ -7,6 +7,10 @@ $plugin = array(
   'class' => 'RestfulFormatterHalJson',
   'curie' => array(
     'name' => 'hal',
-    'href' => url('docs/rels', array('absolute' => TRUE)) . '/{rel}',
   ),
 );
+
+
+if (!drupal_is_cli()) {
+  $plugin['curie']['href'] = url('docs/rels', array('absolute' => TRUE)) . '/{rel}';
+}


### PR DESCRIPTION
When executing a drush command, many times the URL() function is not available. It' needs to be revoked if drupal_is_cli() returns true.