### PR TITLE
Add support for multiple access tokens per user (#977)

### DIFF
--- a/modules/restful_token_auth/src/Entity/RestfulTokenAuthController.php
+++ b/modules/restful_token_auth/src/Entity/RestfulTokenAuthController.php
@@ -56,19 +56,6 @@ class RestfulTokenAuthController extends \EntityAPIController {
    *   The token entity.
    */
   private function generateRefreshToken($uid) {
-    // Check if there are other refresh tokens for the user.
-    // $query = new \EntityFieldQuery();
-    // $results = $query
-    //   ->entityCondition('entity_type', 'restful_token_auth')
-    //   ->entityCondition('bundle', 'refresh_token')
-    //   ->propertyCondition('uid', $uid)
-    //   ->execute();
-    //
-    // if (!empty($results['restful_token_auth'])) {
-    //   // Delete the tokens.
-    //   entity_delete_multiple('restful_token_auth', array_keys($results['restful_token_auth']));
-    // }
-
     // Create a new refresh token.
     $values = array(
       'uid' => $uid,

--- a/modules/restful_token_auth/src/Entity/RestfulTokenAuthController.php
+++ b/modules/restful_token_auth/src/Entity/RestfulTokenAuthController.php
@@ -57,17 +57,17 @@ class RestfulTokenAuthController extends \EntityAPIController {
    */
   private function generateRefreshToken($uid) {
     // Check if there are other refresh tokens for the user.
-    $query = new \EntityFieldQuery();
-    $results = $query
-      ->entityCondition('entity_type', 'restful_token_auth')
-      ->entityCondition('bundle', 'refresh_token')
-      ->propertyCondition('uid', $uid)
-      ->execute();
-
-    if (!empty($results['restful_token_auth'])) {
-      // Delete the tokens.
-      entity_delete_multiple('restful_token_auth', array_keys($results['restful_token_auth']));
-    }
+    // $query = new \EntityFieldQuery();
+    // $results = $query
+    //   ->entityCondition('entity_type', 'restful_token_auth')
+    //   ->entityCondition('bundle', 'refresh_token')
+    //   ->propertyCondition('uid', $uid)
+    //   ->execute();
+    //
+    // if (!empty($results['restful_token_auth'])) {
+    //   // Delete the tokens.
+    //   entity_delete_multiple('restful_token_auth', array_keys($results['restful_token_auth']));
+    // }
 
     // Create a new refresh token.
     $values = array(

--- a/modules/restful_token_auth/src/Plugin/resource/AccessToken__1_0.php
+++ b/modules/restful_token_auth/src/Plugin/resource/AccessToken__1_0.php
@@ -59,8 +59,6 @@ class AccessToken__1_0 extends TokenAuthenticationBase implements ResourceInterf
     $entity_type = $this->getEntityType();
     $account = $this->getAccount();
 
-    // TODO: Reimplement token cleanup (but needs to support multiple tokens).
-
     // Check if there is a token that did not expire yet.
     /* @var DataProviderEntityInterface $data_provider */
     $data_provider = $this->getDataProvider();

--- a/modules/restful_token_auth/src/Plugin/resource/AccessToken__1_0.php
+++ b/modules/restful_token_auth/src/Plugin/resource/AccessToken__1_0.php
@@ -63,31 +63,25 @@ class AccessToken__1_0 extends TokenAuthenticationBase implements ResourceInterf
 
     // Check if there is a token that did not expire yet.
     /* @var DataProviderEntityInterface $data_provider */
-    // $data_provider = $this->getDataProvider();
-    // $query = $data_provider->EFQObject();
-    // $result = $query
-    //   ->entityCondition('entity_type', $entity_type)
-    //   ->entityCondition('bundle', 'access_token')
-    //   ->propertyCondition('uid', $account->uid)
-    //   ->range(0, 1)
-    //   ->execute();
-    //
-    // $token_exists = FALSE;
-    //
-    // if (!empty($result[$entity_type])) {
-    //   $id = key($result[$entity_type]);
-    //   $access_token = entity_load_single($entity_type, $id);
-    //
-    //   $token_exists = TRUE;
-    //   if (!empty($access_token->expire) && $access_token->expire < REQUEST_TIME) {
-    //     if (variable_get('restful_token_auth_delete_expired_tokens', TRUE)) {
-    //       // Token has expired, so we can delete this token.
-    //       $access_token->delete();
-    //     }
-    //
-    //     $token_exists = FALSE;
-    //   }
-    // }
+    $data_provider = $this->getDataProvider();
+    $query = $data_provider->EFQObject();
+    $result = $query
+      ->entityCondition('entity_type', $entity_type)
+      ->entityCondition('bundle', 'access_token')
+      ->propertyCondition('uid', $account->uid)
+      ->execute();
+
+    if (!empty($result[$entity_type])) {
+      foreach ($result[$entity_type] as $id => $value) {
+        $access_token = entity_load_single($entity_type, $id);
+        if (!empty($access_token->expire) && $access_token->expire < REQUEST_TIME) {
+          if (variable_get('restful_token_auth_delete_expired_tokens', TRUE)) {
+            // Token has expired, so we can delete this token.
+            $access_token->delete();
+          }
+        }
+      }
+    }
 
     /* @var \Drupal\restful_token_auth\Entity\RestfulTokenAuthController $controller */
     $controller = entity_get_controller($this->getEntityType());


### PR DESCRIPTION
Cleaned up and fixed the diff posted in #977.

This adds support for multiple access tokens per-user, a common use-case where a user might want to authenticate with Drupal from multiple devices (phone, tablet, 3rd party service, etc).

This modifies previous functionality of reusing existing access token / removing extra refresh tokens (which broke if you had two+ devices attempting to refresh with the same refresh token). An alternative would be to support both strategies and add configuration option to toggle between them.