### PR TITLE
Fix Return of Multiple bundles resource when there are no items

### DIFF
--- a/plugins/restful/RestfulEntityBaseMultipleBundles.php
+++ b/plugins/restful/RestfulEntityBaseMultipleBundles.php
@@ -58,7 +58,7 @@ class RestfulEntityBaseMultipleBundles extends RestfulEntityBase {
 
 
     if (empty($result[$entity_type])) {
-      return;
+      return array();
     }
 
     $account = $this->getAccount();


### PR DESCRIPTION
Current PR makes sure we get the current return value, instead of an empty response.

![localhost_unio_server_www_api_embeds_slide_31741_filter_label___foo_](https://cloud.githubusercontent.com/assets/125707/24585545/cff538e4-1795-11e7-9b50-b052f2098493.jpg)


