### PR TITLE
Token Auth PHP notice

### DIFF
--- a/modules/restful_token_auth/restful_token_auth.module
+++ b/modules/restful_token_auth/restful_token_auth.module
@@ -131,7 +131,7 @@ function restful_token_auth_restful_resource_alter(ResourceInterface &$resource)
  * Implements hook_user_update().
  */
 function restful_token_auth_user_update(&$edit, $account, $category) {
-  if ($edit['status']) {
+  if (isset($edit['status']) && $edit['status']) {
     return;
   }
 


### PR DESCRIPTION
`user_multiple_role_edit([$uid], 'add_role', $rid);` results in a PHP notice and also it drops the token, it seems. We should not rely on all the magic that PHP does here, but check if we have that key in the array first.