### PR TITLE
Token Auth PHP notice

### DIFF
--- a/modules/restful_token_auth/restful_token_auth.module
+++ b/modules/restful_token_auth/restful_token_auth.module
@@ -136,7 +136,7 @@ function restful_token_auth_cron() {
  * Implements hook_user_update().
  */
 function restful_token_auth_user_update(&$edit, $account, $category) {
-  if ($edit['status']) {
+  if (isset($edit['status']) && $edit['status']) {
     return;
   }
 


### PR DESCRIPTION
1.x equivalent of https://github.com/RESTful-Drupal/restful/pull/988 , fixing PHP notice that appears while using `user_multiple_role_edit([$uid], 'add_role', $rid);`