### PR TITLE
Data provider: move to function apart isListRequest function

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProvider.php
+++ b/src/Plugin/resource/DataProvider/DataProvider.php
@@ -364,6 +364,16 @@ abstract class DataProvider implements DataProviderInterface {
   }
 
   /**
+   * Check this is a request to get list of entities.
+   *
+   * @return bool
+   *   TRUE if this a request to get list of entities.
+   */
+  public function isListRequest() {
+    return $this->request->isListRequest($this->getResourcePath());
+  }
+
+  /**
    * Filter the query for list.
    *
    * @returns array
@@ -375,7 +385,7 @@ abstract class DataProvider implements DataProviderInterface {
    * @see \RestfulEntityBase::getQueryForList
    */
   protected function parseRequestForListFilter() {
-    if (!$this->request->isListRequest($this->getResourcePath())) {
+    if (!$this->isListRequest()) {
       // Not a list request, so we don't need to filter.
       // We explicitly check this, as this function might be called from a
       // formatter plugin, after RESTful's error handling has finished, and an


### PR DESCRIPTION
Hi.

The changes from this PR are make a method in _Drupal\restful\Plugin\resource\DataProvider_ class to check is a list request. In this way other class can extend and determine if this is a list request by themselves.

Use case: a resource wich is using path like this 'resource/%' with only one value, no commas, that returns a list of entities using a custom data provider. This is useful because the custom data provider can use the filters   in his query for list.

Please review, thanks!