### PR TITLE
Add sorts to the count query.

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -527,13 +527,13 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     try {
       $this->queryForListSort($query);
     }
-    catch (ServerConfigurationException $e) {
+    catch (BadRequestException $e) {
       watchdog_exception('restful', $e);
     }
     try {
       $this->queryForListFilter($query);
     }
-    catch (ServerConfigurationException $e) {
+    catch (BadRequestException $e) {
       watchdog_exception('restful', $e);
     }
 
@@ -552,8 +552,14 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
   protected function getQueryCount() {
     $query = $this->getEntityFieldQuery();
 
-    // If we are trying to filter on a computed field, just ignore it and log an
-    // exception.
+    // If we are trying to filter or sort on a computed field, just ignore it
+    // and log an exception.
+    try {
+      $this->queryForListSort($query);
+    }
+    catch (BadRequestException $e) {
+      watchdog_exception('restful', $e);
+    }
     try {
       $this->queryForListFilter($query);
     }


### PR DESCRIPTION
When sorting on a field, a join on the field data table is added to the query.
So entities that don't have any values for that field will be filtered out.
However, the count query doesn't add sorts to the query causing a mismatch between the count() and the query for listing.

Additionally, the getQueryForList() catches exceptions that are not thrown, we should catch "BadRequestException" exceptions instead of "ServerConfigurationException".