### PR TITLE
DataProviderNode: use the language code

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProviderNode.php
+++ b/src/Plugin/resource/DataProvider/DataProviderNode.php
@@ -17,22 +17,24 @@ class DataProviderNode extends DataProviderEntity implements DataProviderInterfa
   /**
    * Overrides DataProviderEntity::getQueryForList().
    *
-   * Expose only published nodes.
+   * Expose only published nodes, and of the current language.
    */
   public function getQueryForList() {
     $query = parent::getQueryForList();
     $query->propertyCondition('status', NODE_PUBLISHED);
+    $query->propertyCondition('language', $this->getLangCode());
     return $query;
   }
 
   /**
    * Overrides DataProviderEntity::getQueryCount().
    *
-   * Only count published nodes.
+   * Only count published nodes, and of the current language.
    */
   public function getQueryCount() {
     $query = parent::getQueryCount();
     $query->propertyCondition('status', NODE_PUBLISHED);
+    $query->propertyCondition('language', $this->getLangCode());
     return $query;
   }
 


### PR DESCRIPTION
Without this, endpoints exposing nodes will return nodes of all languages, even if the endpoint is called with a language prefix for example.

This small change allows to filter the nodes by the language prefix, which is what we need in our use case, and also it seems some other people in the issue queue: https://github.com/RESTful-Drupal/restful/issues/980 for example.

Should we merge this then?