### PR TITLE
Add an entitySave() method to DataProviderEntity.

### DIFF
--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -349,6 +349,13 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
   /**
    * {@inheritdoc}
    */
+  public function entitySave(\EntityDrupalWrapper $wrapper) {
+    $wrapper->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function entityValidate(\EntityDrupalWrapper $wrapper) {
     if (!module_exists('entity_validator')) {
       // Entity validator doesn't exist.
@@ -1057,8 +1064,7 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     $this->entityPreSave($interpreter->getWrapper());
 
     $this->entityValidate($interpreter->getWrapper());
-
-    $wrapper->save();
+    $this->entitySave($interpreter->getWrapper());
   }
 
   /**

--- a/src/Plugin/resource/DataProvider/DataProviderEntityInterface.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntityInterface.php
@@ -20,6 +20,14 @@ interface DataProviderEntityInterface extends DataProviderInterface {
   public function entityPreSave(\EntityDrupalWrapper $wrapper);
 
   /**
+   * Save an entity.
+   *
+   * @param \EntityDrupalWrapper $wrapper
+   *   The wrapped entity.
+   */
+  public function entitySave(\EntityDrupalWrapper $wrapper);
+
+  /**
    * Validate an entity before it is saved.
    *
    * @param \EntityDrupalWrapper $wrapper


### PR DESCRIPTION
I have a custom need for the commerce_order (Order) entity type where I'd like to refresh the order (by calling an API function) before the entity gets saved, but currently there's a direct call to the ->save() method on the wrapper from setPropertyValues() which makes that impossible atm.