### PR TITLE
Make sure the render cache is set on create/update.

### DIFF
--- a/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
@@ -175,7 +175,16 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface,
    * {@inheritdoc}
    */
   public function create($object) {
-    return $this->subject->create($object);
+    $return = $this->subject->create($object);
+    $resource_field_collection = reset($return);
+
+    if (!$resource_field_collection instanceof ResourceFieldCollectionInterface) {
+      return NULL;
+    }
+
+    $interpreter = $resource_field_collection->getInterpreter();
+    $resource_field_collection->setContext('cache_fragments', $this->getCacheFragments($resource_field_collection->getIdField()->value($interpreter)));
+    return $return;
   }
 
   /**
@@ -216,7 +225,15 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface,
    */
   public function update($identifier, $object, $replace = TRUE) {
     $this->clearRenderedCache($this->getCacheFragments($identifier));
-    return $this->subject->update($identifier, $object, $replace);
+    $return = $this->subject->update($identifier, $object, $replace);
+    $resource_field_collection = reset($return);
+
+    if (!$resource_field_collection instanceof ResourceFieldCollectionInterface) {
+      return NULL;
+    }
+
+    $resource_field_collection->setContext('cache_fragments', $this->getCacheFragments($identifier));
+    return $return;
   }
 
   /**

--- a/src/Plugin/resource/Decorators/CacheDecoratedResource.php
+++ b/src/Plugin/resource/Decorators/CacheDecoratedResource.php
@@ -205,10 +205,19 @@ class CacheDecoratedResource extends ResourceDecoratorBase implements CacheDecor
   /**
    * {@inheritdoc}
    */
+  public function create($path) {
+    $object = $this->getRequest()->getParsedBody();
+    return $this->getDataProvider()->create($object);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function update($path) {
     $this->invalidateResourceCache($path);
     // Update according to the decorated.
-    return $this->subject->update($path);
+    $object = $this->getRequest()->getParsedBody();
+    return $this->getDataProvider()->update($path, $object, FALSE);
   }
 
   /**


### PR DESCRIPTION
I realized the render cache was set only on view() (after doing a doGet on the Resource for instance).

I noticed that when creating/updating an entity (by calling doPost() & doPatch()) on the resource, no cache entry is created.

I spent quiet some time debugging the issue, and realized the check performed in isCacheEnabled() in the Formatter was returning FALSE, because of the $data->getContext().

On view(), CacheDecoratedResource is calling the view method on the CacheDecoratedDataProvider object.

While on create/update, we're not calling the methods on the CacheDecoratedDataProvider.

Additionally, we aren't calling setCacheFragments on the ResourceFieldCollection.

After the patch cache entry is created when I create an entity via the API, On update for some reasons, the cache entry seems to be created from time to time, unsure why...