### PR TITLE
Fix/incorrect response status

### DIFF
--- a/src/Plugin/resource/CrudInterface.php
+++ b/src/Plugin/resource/CrudInterface.php
@@ -80,6 +80,9 @@ interface CrudInterface {
    *
    * @param mixed $identifier
    *   The ID of thing to be removed.
+   *
+   * @return array
+   *   An array of structured data for the thing that was removed.
    */
   public function remove($identifier);
 

--- a/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
+++ b/src/Plugin/resource/DataProvider/CacheDecoratedDataProvider.php
@@ -224,7 +224,7 @@ class CacheDecoratedDataProvider implements CacheDecoratedDataProviderInterface,
    */
   public function remove($identifier) {
     $this->clearRenderedCache($this->getCacheFragments($identifier));
-    $this->subject->remove($identifier);
+    return $this->subject->remove($identifier);
   }
 
   /**

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -225,10 +225,8 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     // Put the original request back to a POST.
     $this->request = $old_request;
 
-    return array(
-        'status' => 201,
-        $output
-    );
+    $output += array('status' => 201);
+    return $output;
   }
 
   /**

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -301,9 +301,6 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
 
     $this->setPropertyValues($wrapper, $object, $replace);
 
-    // Set the HTTP headers.
-    $this->setHttpHeader('Status', 201);
-
     if (!empty($wrapper->url) && $url = $wrapper->url->value()) {
       $this->setHttpHeader('Location', $url);
     }

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -225,7 +225,10 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     // Put the original request back to a POST.
     $this->request = $old_request;
 
-    return $output;
+    return array(
+        'status' => 201,
+        $output
+    );
   }
 
   /**

--- a/src/Plugin/resource/DataProvider/DataProviderEntity.php
+++ b/src/Plugin/resource/DataProvider/DataProviderEntity.php
@@ -329,7 +329,10 @@ class DataProviderEntity extends DataProvider implements DataProviderEntityInter
     $wrapper->delete();
 
     // Set the HTTP headers.
-    $this->setHttpHeader('Status', 204);
+    return array(
+        'type' => 'https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5',
+        'status' => 204,
+    );
   }
 
   /**

--- a/src/Plugin/resource/Decorators/CacheDecoratedResource.php
+++ b/src/Plugin/resource/Decorators/CacheDecoratedResource.php
@@ -225,7 +225,7 @@ class CacheDecoratedResource extends ResourceDecoratorBase implements CacheDecor
    */
   public function remove($path) {
     $this->invalidateResourceCache($path);
-    $this->subject->remove($path);
+    return $this->subject->remove($path);
   }
 
   /**

--- a/src/Plugin/resource/Resource.php
+++ b/src/Plugin/resource/Resource.php
@@ -408,7 +408,7 @@ abstract class Resource extends PluginBase implements ResourceInterface {
    */
   public function remove($path) {
     // TODO: Compare this with 1.x logic.
-    $this->getDataProvider()->remove($path);
+    return $this->getDataProvider()->remove($path);
   }
 
   /**

--- a/src/Plugin/resource/ResourceInterface.php
+++ b/src/Plugin/resource/ResourceInterface.php
@@ -258,6 +258,9 @@ interface ResourceInterface extends PluginInspectionInterface, ConfigurablePlugi
    *
    * @param string $path
    *   The resource path.
+   *
+   * @return array
+   *   An array of structured data for the thing that was removed.
    */
   public function remove($path);
 


### PR DESCRIPTION
Responses for DELETE and POST(create) requests return a 200 OK status. These should be 204 and 201 respectively. There is currently code in the related DataProvider methods but looks like it was copied from the 1.x release and does not function correctly.

As a permanent fix, I feel a refactor of the main page_callback and page_delivery_callback would be better. But I don't know the codebase well enough to safely implement this. This pull request works with the current delivery_callback, returning the correct status key=>value pair from the DataProvider along with the main response array.