### PR TITLE
404 instead of 422 if entity not found

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1162,7 +1162,7 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
     );
 
     if (!$entity = entity_load_single($entity_type, $entity_id)) {
-      throw new RestfulUnprocessableEntityException(format_string('The entity ID @id for @resource does not exist.', $params));
+      throw new RestfulNotFoundException(format_string('The entity ID @id for @resource does not exist.', $params));
     }
 
     list(,, $bundle) = entity_extract_ids($entity_type, $entity);

--- a/tests/RestfulExceptionHandleTestCase.test
+++ b/tests/RestfulExceptionHandleTestCase.test
@@ -45,7 +45,7 @@ class RestfulExceptionHandleTestCase extends RestfulCurlBaseTestCase {
     $url = 'api/v1.0/articles/1';
     $result = $this->httpRequest($url);
     $body = drupal_json_decode($result['body']);
-    $this->assertEqual($result['code'], '422', format_string('422 status code sent for @url url.', array('@url' => $url)));
+    $this->assertEqual($result['code'], '404', format_string('404 status code sent for @url url.', array('@url' => $url)));
     $this->assertTrue(strpos($result['headers'], 'application/problem+json;'), '"application/problem+json" found in invalid request.');
     $this->assertEqual($body['title'], 'The entity ID 1 for Articles does not exist.', 'Correct error message.');
   }


### PR DESCRIPTION
Error 422 implies semantically incorrect requests according to https://tools.ietf.org/html/rfc4918#section-11.2

Throwing `RestfulNotFoundException` and a resulting HTTP error 404 seems much more appropriate if the requested entity does not exist.