### PR TITLE
Remove warning when sending empty array to multiple values properties.

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -938,6 +938,10 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
       );
     }
 
+    // In case the value is empty.
+    if (empty($value)) {
+      $return = [];
+    }
     // Multiple values.
     foreach ($value as $delta => $single_value) {
       if (!$instance['settings']['text_processing']) {


### PR DESCRIPTION
Notice: Undefined variable: return in RestfulEntityBase->propertyValuesPreprocessText() (line 1142 of /modules/contrib/restful/plugins/restful/RestfulEntityBase.php).