### PR TITLE
ignore filter if a value is not set

### DIFF
--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -1006,6 +1006,11 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
         // filter[foo]=bar would be converted to filter[foo][value] = bar.
         $value = array('value' => $value);
       }
+      // It's possible someone is setting `operator` (or some other key) without a `value`.
+      // In these cases we should ignore the filter.
+      if (!isset($value['value'])) {
+        continue;
+      }
       if (!is_array($value['value'])) {
         $value['value'] = array($value['value']);
       }


### PR DESCRIPTION
We have a somewhat strange situation where a bot is trying to pull from our system with a request including 

```
?filter[id][operator]=IN
```

but fails to include any value for `id`. This causes Drupal to throw an exception: `Undefined index: value`

This PR changes that handling to ignore the filter if there's no value provided.